### PR TITLE
Зимние декорации

### DIFF
--- a/maps/asteroid/asteroid.dmm
+++ b/maps/asteroid/asteroid.dmm
@@ -80,6 +80,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/hallway)
 "aq" = (
@@ -159,6 +160,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/hallway)
 "aC" = (
@@ -181,6 +183,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/atmos)
 "aF" = (
@@ -335,6 +338,7 @@
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/maintstore1)
 "bb" = (
+/obj/item/decoration/snowflake,
 /turf/simulated/wall,
 /area/asteroid/research_outpost/maintstore1)
 "bc" = (
@@ -555,6 +559,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet,
 /area/asteroid/research_outpost/hallway)
 "bx" = (
@@ -639,6 +644,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet,
 /area/asteroid/research_outpost/hallway)
 "bG" = (
@@ -676,6 +682,7 @@
 /obj/structure/transit_tube{
 	icon_state = "N-S"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/atmos)
 "bK" = (
@@ -694,6 +701,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry)
 "bM" = (
@@ -1125,6 +1133,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -1282,6 +1291,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -1522,6 +1532,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -1574,6 +1585,7 @@
 /area/asteroid/research_outpost/anomaly)
 "dy" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -1582,6 +1594,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -1612,6 +1625,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/hallway)
 "dD" = (
@@ -1623,6 +1637,7 @@
 /obj/structure/transit_tube{
 	icon_state = "N-SE"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/hallway)
 "dE" = (
@@ -1683,6 +1698,7 @@
 	icon_state = "N-S"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/atmos)
 "dN" = (
@@ -1698,6 +1714,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -1709,6 +1726,7 @@
 	req_access = list(65)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -1847,6 +1865,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/atmos)
 "ea" = (
@@ -2378,6 +2397,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -2468,6 +2488,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whitepurplefull"
@@ -2672,6 +2693,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/production)
 "fy" = (
@@ -2758,6 +2780,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitebluecorner"
@@ -2769,6 +2792,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -2870,6 +2894,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/power)
 "fR" = (
@@ -3045,6 +3070,7 @@
 	req_access = list(65)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -3096,6 +3122,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/power)
 "gw" = (
@@ -3265,6 +3292,10 @@
 	icon_state = "blue"
 	},
 /area/asteroid/research_outpost/entry)
+"gW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/maintstore1)
 "gX" = (
 /obj/machinery/door/window/westleft{
 	dir = 4;
@@ -3393,6 +3424,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/med)
 "hr" = (
@@ -3441,6 +3473,7 @@
 	name = "Research Outpost Dock Airlock";
 	req_access = list(65)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry)
 "hw" = (
@@ -3452,6 +3485,7 @@
 /obj/structure/transit_tube{
 	icon_state = "N-SW"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry)
 "hz" = (
@@ -3460,6 +3494,7 @@
 	req_access = list(65)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/entry)
 "hA" = (
@@ -3488,6 +3523,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -3496,6 +3532,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -3548,6 +3585,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/power)
 "hJ" = (
@@ -3601,6 +3639,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/entry)
 "hM" = (
@@ -3774,6 +3813,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -3789,6 +3829,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/entry)
 "ih" = (
@@ -3840,6 +3881,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/west_outpost)
 "il" = (
@@ -3857,6 +3899,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -4245,6 +4288,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/atmos)
 "iV" = (
@@ -4290,6 +4334,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/outpost_misc_lab)
 "iY" = (
@@ -4678,6 +4723,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/eva)
 "jU" = (
@@ -4796,6 +4842,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/production)
 "kd" = (
@@ -4894,6 +4941,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso1)
 "km" = (
@@ -4909,6 +4957,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
 "kn" = (
@@ -4924,6 +4973,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "ko" = (
@@ -4938,6 +4988,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/maintstore2)
 "kp" = (
@@ -4957,6 +5008,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5002,6 +5054,7 @@
 	name = "Expedition Prep";
 	req_access = list(65)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/entry)
 "ku" = (
@@ -5012,6 +5065,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -5185,6 +5239,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/outpost_misc_lab)
 "kH" = (
@@ -5336,6 +5391,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/tempstorage)
 "la" = (
@@ -5399,6 +5455,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/maint)
 "lg" = (
@@ -5910,6 +5967,7 @@
 	req_access = list(65);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/gearstore)
 "mv" = (
@@ -6027,6 +6085,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/iso1)
 "mL" = (
@@ -6071,6 +6130,7 @@
 	name = "Isolation Section Airlock";
 	req_access = list(65)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso1)
 "mO" = (
@@ -6081,6 +6141,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
 "mP" = (
@@ -6400,6 +6461,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/gearstore)
 "nz" = (
@@ -7090,6 +7152,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet,
 /area/asteroid/mine/living_quarters)
 "pg" = (
@@ -7306,6 +7369,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/gearstore)
 "pF" = (
@@ -7363,6 +7427,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/tempstorage)
 "pM" = (
@@ -7498,6 +7563,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet,
 /area/asteroid/mine/living_quarters)
 "qd" = (
@@ -7506,6 +7572,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/living_quarters)
 "qe" = (
@@ -7561,6 +7628,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/explored)
 "qm" = (
@@ -7571,6 +7639,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/explored)
 "qn" = (
@@ -7605,6 +7674,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/explored)
 "qs" = (
@@ -7700,6 +7770,7 @@
 	name = "Research Outpost External Access";
 	req_access = list(10,13)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/gearstore)
 "qG" = (
@@ -7833,6 +7904,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet,
 /area/asteroid/mine/living_quarters)
 "qX" = (
@@ -8798,6 +8870,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/mine/living_quarters)
 "tD" = (
@@ -9040,6 +9113,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/west_outpost)
 "ul" = (
@@ -9077,6 +9151,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vault"
 	},
@@ -9424,6 +9499,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/mine/eva)
 "ve" = (
@@ -9562,6 +9638,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/west_outpost)
 "vt" = (
@@ -9623,6 +9700,7 @@
 /area/asteroid/mine/living_quarters)
 "vx" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -9634,6 +9712,7 @@
 	req_access = list(48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -9779,6 +9858,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/west_outpost)
 "vR" = (
@@ -10143,6 +10223,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -10305,6 +10386,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -10446,6 +10528,7 @@
 	name = "Toilet";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -10539,6 +10622,7 @@
 	req_access = list(48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/living_quarters)
 "xu" = (
@@ -10578,6 +10662,7 @@
 	locked = 1;
 	name = "Mining External Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/living_quarters)
 "xy" = (
@@ -10691,6 +10776,7 @@
 	name = "Mining External Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/living_quarters)
 "yb" = (
@@ -10758,6 +10844,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/eva)
 "yh" = (
@@ -10783,6 +10870,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/asteroid/mine/dwarf)
+"yl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/harvesting)
 "ym" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11003,6 +11094,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -11125,6 +11217,7 @@
 /obj/structure/transit_tube{
 	icon_state = "D-NE"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry)
 "zz" = (
@@ -11161,6 +11254,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/eva)
 "zC" = (
@@ -11281,6 +11375,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -11447,6 +11542,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/production)
 "Am" = (
@@ -11490,6 +11586,7 @@
 	req_access = list(48)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/mine/production)
 "Au" = (
@@ -11628,6 +11725,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/mine/production)
 "AV" = (
@@ -11706,6 +11804,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -11791,6 +11890,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/maintstore1)
 "BA" = (
@@ -11810,6 +11910,10 @@
 	icon_state = "greenfull"
 	},
 /area/asteroid/research_outpost/hallway)
+"BH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/maintstore2)
 "BZ" = (
 /turf/simulated/floor/plating/airless/asteroid,
 /area/asteroid/mine/unexplored/safe)
@@ -11876,6 +11980,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/iso2)
 "Cr" = (
@@ -11896,6 +12001,10 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
+"Da" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/sample)
 "Db" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11979,6 +12088,10 @@
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/gearstore)
+"Dv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/tempstorage)
 "DL" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -12046,6 +12159,10 @@
 	icon_state = "dark"
 	},
 /area/asteroid/research_outpost/iso1)
+"Ew" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/research_outpost/entry)
 "Fb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12103,6 +12220,10 @@
 	icon_state = "vaultfull"
 	},
 /area/asteroid/research_outpost/iso1)
+"Fv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/research_outpost/hallway)
 "FA" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -12178,6 +12299,10 @@
 /obj/structure/table,
 /turf/simulated/floor/bluegrid,
 /area/asteroid/research_outpost/iso1)
+"Gt" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/iso2)
 "Hb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Storage";
@@ -12227,6 +12352,21 @@
 "Hg" = (
 /turf/simulated/floor/engine,
 /area/asteroid/research_outpost/iso2)
+"HG" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/asteroid/mine/eva)
+"HT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/atmos)
 "HX" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -12238,6 +12378,7 @@
 /obj/structure/transit_tube{
 	icon_state = "D-SW"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry)
 "Ib" = (
@@ -12293,6 +12434,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/asteroid/research_outpost/iso2)
+"IJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/mine/maintenance)
 "IT" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -12309,6 +12454,10 @@
 	icon_state = "asteroidfloor"
 	},
 /area/asteroid/mine/explored)
+"IZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/outpost_misc_lab)
 "Jb" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -12380,6 +12529,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/asteroid/research_outpost/iso2)
+"JJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/mine/explored)
 "Kb" = (
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
@@ -12397,6 +12550,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry)
 "Kd" = (
@@ -12426,6 +12580,10 @@
 	},
 /turf/simulated/floor/plating/airless/asteroid,
 /area/asteroid/mine/explored)
+"Km" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/mine/explored)
 "Kr" = (
 /obj/machinery/light_construct/small{
 	dir = 8
@@ -12435,6 +12593,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
+"KJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/research_outpost/gearstore)
 "Lb" = (
 /obj/structure/sign/departments/botany{
 	pixel_x = 32
@@ -12512,6 +12674,7 @@
 /obj/structure/transit_tube{
 	icon_state = "NW-SE"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry)
 "Lz" = (
@@ -12672,6 +12835,10 @@
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/engine,
 /area/asteroid/research_outpost/iso2)
+"Np" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/anomaly)
 "Nr" = (
 /obj/structure/transit_tube{
 	icon_state = "N-SW"
@@ -12694,6 +12861,15 @@
 	icon_state = "brown"
 	},
 /area/asteroid/mine/living_quarters)
+"NS" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/asteroid/research_outpost/gearstore)
 "Ob" = (
 /obj/machinery/power/smes/fullcharge,
 /obj/structure/cable{
@@ -12793,6 +12969,14 @@
 	icon_state = "brown"
 	},
 /area/asteroid/mine/production)
+"Ps" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/mine/living_quarters)
+"Pt" = (
+/obj/structure/flora/tree/pine/xmas,
+/turf/simulated/floor/plating/airless/asteroid,
+/area/asteroid/mine/unexplored)
 "Pu" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -12802,6 +12986,7 @@
 	dir = 4
 	},
 /obj/structure/transit_tube,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/hallway)
 "Py" = (
@@ -12813,6 +12998,25 @@
 	icon_state = "dark"
 	},
 /area/asteroid/mine/production)
+"PE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/mine/west_outpost)
+"PY" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/asteroid/mine/living_quarters)
+"Qa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/spectro)
 "Qb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -12860,6 +13064,19 @@
 	icon_state = "brown"
 	},
 /area/asteroid/mine/production)
+"Ql" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/mine/eva)
+"Qw" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/asteroid/mine/living_quarters)
 "Qz" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
@@ -12868,6 +13085,17 @@
 	icon_state = "dark"
 	},
 /area/asteroid/mine/production)
+"QH" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/asteroid/mine/west_outpost)
 "Rb" = (
 /obj/structure/sign/departments/science,
 /turf/simulated/wall,
@@ -12927,12 +13155,17 @@
 	},
 /turf/simulated/floor,
 /area/asteroid/mine/eva)
+"Rs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/hallway)
 "Sb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/iso2)
 "Sc" = (
@@ -13032,6 +13265,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/mine/production)
+"Ti" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/longtermstorage)
 "Tj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/device/radio/intercom{
@@ -13043,6 +13280,10 @@
 	icon_state = "brown"
 	},
 /area/asteroid/mine/production)
+"TK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/research_outpost/tempstorage)
 "Ub" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor{
@@ -13086,6 +13327,22 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
+/area/asteroid/mine/production)
+"Ui" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/power)
+"Uo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/maint)
+"UD" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/mine/production)
+"UK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
 /area/asteroid/mine/production)
 "UP" = (
 /obj/structure/cable{
@@ -13243,6 +13500,10 @@
 	icon_state = "brown"
 	},
 /area/asteroid/mine/living_quarters)
+"Wv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/iso1)
 "Xb" = (
 /obj/structure/sign/departments/science{
 	icon_state = "science2";
@@ -13326,6 +13587,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/west_outpost)
 "XD" = (
@@ -13438,6 +13700,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/eva)
 "Zz" = (
@@ -27241,7 +27504,7 @@ qA
 qA
 qA
 uU
-uU
+PE
 uU
 uU
 uU
@@ -27754,13 +28017,13 @@ qA
 qA
 qA
 qA
-uU
+PE
 sB
 sB
 ve
 sB
 sB
-uU
+PE
 lA
 lA
 lA
@@ -28269,14 +28532,14 @@ lA
 lA
 lA
 uU
-kR
-kR
+QH
+QH
 wH
-kR
-kR
+QH
+QH
 uU
 uU
-uU
+PE
 uU
 lA
 lA
@@ -29048,7 +29311,7 @@ wj
 vs
 wt
 uT
-uU
+PE
 lA
 lA
 lA
@@ -29560,7 +29823,7 @@ wK
 uU
 xd
 uU
-uU
+PE
 uU
 uU
 lA
@@ -29813,8 +30076,8 @@ lA
 uU
 kR
 uk
-kR
-uU
+QH
+PE
 xe
 xO
 uS
@@ -30581,11 +30844,11 @@ lA
 lA
 uF
 uM
-uU
-kR
+PE
+QH
 vQ
 kR
-uU
+PE
 xh
 uU
 lA
@@ -44975,7 +45238,7 @@ ac
 ac
 uo
 uo
-uo
+Ps
 uo
 uo
 uo
@@ -45229,14 +45492,14 @@ ac
 ac
 ac
 uo
-uo
+Ps
 uo
 vu
 vS
 wi
 uo
 xj
-uo
+Ps
 kO
 kO
 lA
@@ -45750,7 +46013,7 @@ ut
 vn
 uo
 xl
-uo
+Ps
 uo
 uo
 kO
@@ -46513,7 +46776,7 @@ ac
 ac
 ac
 ac
-uo
+Ps
 vb
 pv
 vW
@@ -46523,7 +46786,7 @@ qd
 wn
 yv
 Pc
-uo
+Ps
 kO
 kO
 lA
@@ -46768,21 +47031,21 @@ ac
 ac
 ac
 uo
+Ps
+uo
+uo
+Ps
 uo
 uo
 uo
-uo
-uo
-uo
-uo
-uo
+Ps
 uo
 wv
 yh
 Pc
 uo
 uo
-uo
+Ps
 uo
 uo
 lA
@@ -47030,10 +47293,10 @@ pw
 uo
 us
 pw
-uo
+Ps
 us
 pw
-uo
+Ps
 ww
 yv
 bK
@@ -47277,14 +47540,14 @@ ad
 ad
 ac
 tX
-tX
+IJ
 tX
 tX
 ac
 uo
 pd
 qb
-uo
+Ps
 pr
 qb
 uo
@@ -47298,7 +47561,7 @@ yX
 Ld
 Xd
 Ax
-uo
+Ps
 lA
 lA
 rH
@@ -47538,7 +47801,7 @@ ub
 ub
 tX
 uo
-uo
+Ps
 uo
 pf
 uo
@@ -47547,7 +47810,7 @@ qW
 uo
 uo
 qc
-uo
+Ps
 wn
 vr
 xm
@@ -47793,7 +48056,7 @@ ac
 tX
 uc
 pg
-tX
+IJ
 pR
 pX
 pX
@@ -48065,7 +48328,7 @@ wY
 xa
 vt
 Pc
-uo
+Ps
 zs
 wM
 zY
@@ -48286,7 +48549,7 @@ ac
 zX
 pC
 pC
-pC
+Pt
 pC
 zX
 pC
@@ -48309,13 +48572,13 @@ oN
 oP
 tX
 uo
-XD
-XD
-XD
+PY
+PY
+PY
+Ps
 uo
-uo
-XD
-XD
+PY
+PY
 XD
 uo
 uo
@@ -48325,7 +48588,7 @@ Pc
 uo
 uo
 uo
-uo
+Ps
 uo
 ys
 lA
@@ -48561,7 +48824,7 @@ ad
 ad
 ad
 ac
-tX
+IJ
 ub
 ul
 tX
@@ -48582,7 +48845,7 @@ Pc
 ia
 wQ
 xc
-ia
+Qw
 vG
 qX
 lA
@@ -48820,13 +49083,13 @@ ad
 ac
 tX
 tX
-tX
+IJ
 tX
 kO
 kO
 lA
 lA
-ia
+Qw
 xr
 qe
 tD
@@ -49089,11 +49352,11 @@ qv
 Au
 Au
 vq
-uo
+Ps
 wn
 tp
 Pc
-ia
+Qw
 zL
 VK
 ia
@@ -49610,7 +49873,7 @@ gg
 yd
 Nd
 Zd
-uo
+Ps
 Sc
 tL
 lA
@@ -49740,7 +50003,7 @@ mo
 mo
 mo
 mo
-hp
+Ew
 HX
 Lq
 zy
@@ -49854,7 +50117,7 @@ ac
 ac
 kO
 lA
-ia
+Qw
 wJ
 xs
 uA
@@ -50124,7 +50387,7 @@ Pc
 qd
 Pd
 Ce
-uo
+Ps
 Uc
 tL
 lA
@@ -50374,7 +50637,7 @@ xr
 uC
 vZ
 wV
-uo
+Ps
 xp
 zN
 Vc
@@ -50626,15 +50889,15 @@ aa
 aa
 lA
 uo
-XD
-XD
+PY
+PY
 uo
-XD
-XD
+PY
+PY
 uo
 uo
 zT
-uo
+Ps
 uo
 uo
 uo
@@ -50773,7 +51036,7 @@ Ah
 Bc
 aW
 kS
-hp
+Ew
 pD
 pD
 pD
@@ -50889,9 +51152,9 @@ lA
 lA
 lA
 lA
-ia
+Qw
 yt
-ia
+Qw
 lA
 lA
 lA
@@ -51036,7 +51299,7 @@ mt
 mt
 pI
 mX
-mp
+KJ
 pW
 pG
 Aj
@@ -51146,9 +51409,9 @@ lA
 lA
 lA
 lA
-ia
+Qw
 zT
-ia
+Qw
 lA
 lA
 lA
@@ -51539,7 +51802,7 @@ mo
 mo
 mo
 mo
-hp
+Ew
 gT
 hJ
 jh
@@ -51550,7 +51813,7 @@ lE
 ms
 nK
 pc
-hP
+NS
 pY
 qt
 lA
@@ -51807,7 +52070,7 @@ mr
 mw
 Dh
 pc
-hP
+NS
 pZ
 qu
 lA
@@ -52052,7 +52315,7 @@ bh
 aB
 aB
 aB
-bh
+Fv
 Rb
 ht
 hK
@@ -52321,10 +52584,10 @@ lH
 my
 oy
 nu
+KJ
 mp
 mp
-mp
-mp
+KJ
 pJ
 tL
 lA
@@ -52581,7 +52844,7 @@ nt
 hP
 nz
 nL
-hP
+NS
 oC
 tL
 lA
@@ -52700,7 +52963,7 @@ aa
 aa
 aa
 aa
-qh
+JJ
 zJ
 qh
 lA
@@ -52824,7 +53087,7 @@ eS
 ao
 cL
 da
-aR
+Rs
 hq
 if
 hq
@@ -52959,7 +53222,7 @@ aa
 aa
 qh
 zJ
-qh
+JJ
 lA
 lA
 lA
@@ -53075,7 +53338,7 @@ cd
 cp
 cp
 cp
-aX
+Qa
 eo
 eR
 fh
@@ -53086,13 +53349,13 @@ ha
 ie
 jj
 lb
-bh
+Fv
 kZ
 nl
 oQ
 ol
 oQ
-hP
+NS
 ns
 qx
 hP
@@ -53346,12 +53609,12 @@ lc
 bh
 li
 nl
-nl
+TK
 nl
 nl
 mp
 mp
-mp
+KJ
 mp
 pJ
 tL
@@ -53845,7 +54108,7 @@ aX
 bR
 aX
 aX
-aX
+Qa
 aX
 es
 eT
@@ -53861,10 +54124,10 @@ ku
 lk
 lP
 in
+Dv
 in
 in
-in
-in
+Dv
 Aj
 Aj
 Aj
@@ -54098,7 +54361,7 @@ au
 aK
 aY
 bl
-au
+gW
 AE
 cs
 cQ
@@ -54242,7 +54505,7 @@ ws
 fx
 fx
 fx
-ws
+UD
 Be
 aa
 ar
@@ -54366,7 +54629,7 @@ eT
 bU
 fG
 gj
-aR
+Rs
 io
 im
 kh
@@ -54617,10 +54880,10 @@ bO
 bS
 bS
 dp
-bB
+Da
 et
 eU
-aR
+Rs
 aR
 aR
 aR
@@ -54884,7 +55147,7 @@ gk
 hA
 iq
 jn
-le
+Uo
 jE
 mE
 mE
@@ -55144,9 +55407,9 @@ jm
 le
 jc
 mF
+Uo
 le
-le
-le
+Uo
 le
 le
 qf
@@ -55266,7 +55529,7 @@ zA
 zA
 zA
 zA
-ws
+UD
 Ye
 Ye
 ws
@@ -55392,7 +55655,7 @@ cV
 cV
 eY
 cV
-cV
+Np
 gR
 hE
 iu
@@ -55405,11 +55668,11 @@ no
 no
 ng
 nx
-le
+Uo
 qg
 qy
 qI
-qh
+JJ
 YV
 YV
 YV
@@ -55526,7 +55789,7 @@ zA
 ws
 wN
 Bu
-ws
+UD
 aa
 Be
 aa
@@ -55893,7 +56156,7 @@ aa
 aa
 YV
 YV
-au
+gW
 Bn
 Eb
 Gb
@@ -56028,11 +56291,11 @@ lA
 lA
 lA
 ws
-ws
+UD
 xz
 zm
 Wc
-ws
+UD
 ws
 ws
 ws
@@ -56163,7 +56426,7 @@ dS
 eA
 eZ
 fK
-cV
+Np
 gm
 gU
 ix
@@ -56300,7 +56563,7 @@ If
 Ze
 Wc
 Wf
-Bh
+UK
 lA
 lA
 lA
@@ -56409,7 +56672,7 @@ YV
 YV
 aj
 aQ
-bh
+Fv
 bh
 bh
 bh
@@ -56423,7 +56686,7 @@ fp
 cV
 aR
 aR
-aR
+Rs
 iB
 jt
 kl
@@ -56433,7 +56696,7 @@ mN
 mH
 nj
 Fg
-lg
+Wv
 YV
 YV
 qL
@@ -56925,7 +57188,7 @@ aA
 aR
 be
 bx
-bh
+Fv
 ci
 cF
 cV
@@ -56945,7 +57208,7 @@ iJ
 iJ
 iJ
 lm
-iJ
+yl
 iJ
 iJ
 YV
@@ -57071,7 +57334,7 @@ wN
 wN
 Pf
 Zf
-ws
+UD
 lA
 lA
 lA
@@ -57179,16 +57442,16 @@ aa
 aa
 aR
 Pu
-aR
+Rs
 bh
 bw
 bh
 bh
 cE
 cV
+Np
 cV
-cV
-cV
+Np
 fd
 cV
 cV
@@ -57461,7 +57724,7 @@ mO
 oL
 oG
 jF
-iJ
+yl
 YV
 YV
 qL
@@ -57575,7 +57838,7 @@ vf
 zp
 ws
 Dd
-ws
+UD
 Fe
 ws
 Ne
@@ -57584,7 +57847,7 @@ Cf
 Jf
 Ak
 AW
-ws
+UD
 lA
 lA
 lA
@@ -57834,7 +58097,7 @@ ws
 Dd
 ws
 Dd
-ws
+UD
 Py
 Te
 Df
@@ -57953,17 +58216,17 @@ Pu
 aR
 bh
 bF
-bI
+HT
 cw
 bI
 bI
-bI
+HT
 dZ
 eF
 eF
 fQ
 eF
-eF
+Ui
 eF
 eF
 eT
@@ -57971,10 +58234,10 @@ js
 lj
 lj
 lj
+Gt
 lj
 lj
-lj
-lj
+Gt
 lj
 lj
 YV
@@ -58080,14 +58343,14 @@ lA
 lA
 lA
 lA
-vD
+Ql
 uJ
 wa
 wW
 ui
 vo
 zp
-ws
+UD
 Ed
 Sd
 Dd
@@ -58222,7 +58485,7 @@ fR
 fM
 gM
 gQ
-eF
+Ui
 iW
 kB
 lj
@@ -58338,12 +58601,12 @@ lA
 lA
 sn
 vD
-vD
+Ql
 vD
 vD
 yC
 zB
-yC
+HG
 ws
 ws
 ws
@@ -58464,10 +58727,10 @@ aa
 aa
 aa
 aF
-aR
+Rs
 bk
 bG
-bI
+HT
 cz
 cS
 cS
@@ -58491,7 +58754,7 @@ Bg
 Ig
 Hg
 Ng
-lj
+Gt
 qL
 Fc
 an
@@ -58854,7 +59117,7 @@ lA
 lA
 lA
 lA
-vD
+Ql
 zE
 zE
 zz
@@ -58869,7 +59132,7 @@ Ff
 Mf
 Je
 Vf
-ws
+UD
 lA
 lA
 lA
@@ -58987,7 +59250,7 @@ cU
 dd
 dd
 Kb
-eF
+Ui
 Ob
 fT
 fP
@@ -58998,7 +59261,7 @@ Xn
 kC
 lj
 lj
-lj
+Gt
 lj
 lj
 lj
@@ -59112,19 +59375,19 @@ lA
 lA
 lA
 vD
-yC
+HG
 yg
 yC
-ws
+UD
 Hd
 ws
 ws
 ws
+UD
 ws
 ws
 ws
-ws
-ws
+UD
 ws
 ws
 lA
@@ -59260,7 +59523,7 @@ lV
 oi
 lY
 mv
-oU
+BH
 YV
 ax
 qO
@@ -59769,7 +60032,7 @@ iD
 kD
 ma
 ma
-ma
+Ti
 ma
 ma
 oU
@@ -60134,7 +60397,7 @@ Zz
 Zz
 YV
 YV
-jS
+Km
 uS
 oC
 oC
@@ -60544,7 +60807,7 @@ mV
 mT
 ok
 Dg
-ma
+Ti
 qL
 Sg
 an
@@ -60651,7 +60914,7 @@ YV
 jS
 jS
 jS
-jS
+Km
 jS
 kO
 kO
@@ -61053,9 +61316,9 @@ hG
 jW
 lS
 oo
-Ar
+IZ
 ma
-ma
+Ti
 ma
 oV
 Kg
@@ -62333,12 +62596,12 @@ aa
 aa
 aa
 aF
-Ar
+IZ
 Ar
 Az
 Az
 Bp
-Ar
+IZ
 aF
 aa
 aa
@@ -63109,7 +63372,7 @@ kV
 fC
 xU
 fC
-Ar
+IZ
 aF
 aa
 aa
@@ -63363,7 +63626,7 @@ aa
 aG
 ib
 Ar
-Ar
+IZ
 Ar
 Ar
 fw

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -48,6 +48,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aal" = (
@@ -148,6 +149,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aau" = (
@@ -554,6 +556,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -578,6 +581,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/range)
 "abe" = (
@@ -821,6 +825,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1233,6 +1238,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "acf" = (
@@ -1326,6 +1332,7 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -1343,6 +1350,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1377,6 +1385,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "acr" = (
@@ -1393,6 +1402,7 @@
 	name = "Security Pods";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "acs" = (
@@ -1404,6 +1414,7 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "act" = (
@@ -1626,6 +1637,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/processing)
 "acP" = (
@@ -1907,6 +1919,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "adm" = (
@@ -1967,6 +1980,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ads" = (
@@ -2194,6 +2208,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -2237,6 +2252,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "adP" = (
@@ -2249,6 +2265,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig/solitary_confinement)
 "adQ" = (
@@ -2275,6 +2292,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor,
 /area/station/security/main)
 "adR" = (
@@ -2310,6 +2328,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor,
 /area/station/security/main)
 "adU" = (
@@ -2480,6 +2499,7 @@
 	req_access = list(3)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2694,6 +2714,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2790,6 +2811,7 @@
 	name = "Toxins Research";
 	req_access = list(8)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/mixing)
 "aeI" = (
@@ -3057,6 +3079,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "afg" = (
@@ -3147,6 +3170,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "afq" = (
@@ -3275,6 +3299,7 @@
 	req_access = list(39)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreenfull"
@@ -3351,6 +3376,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -3561,6 +3587,7 @@
 	req_access = list(1)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -3864,6 +3891,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3874,6 +3902,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -4055,6 +4084,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "agU" = (
@@ -4174,6 +4204,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "ahd" = (
@@ -4345,6 +4376,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4375,6 +4407,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "ahv" = (
@@ -4533,6 +4566,7 @@
 	name = "Head of Security";
 	req_access = list(58)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4591,6 +4625,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ahJ" = (
@@ -4663,6 +4698,7 @@
 	name = "Warden's Office";
 	req_access = list(3)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4968,6 +5004,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "aip" = (
@@ -5261,6 +5298,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aiN" = (
@@ -5278,6 +5316,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "aiO" = (
@@ -5312,6 +5351,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "aiR" = (
@@ -5496,6 +5536,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5510,6 +5551,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ajk" = (
@@ -5588,6 +5630,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5629,6 +5672,7 @@
 	name = "Primary Tool Storage"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/storage/primary)
 "aju" = (
@@ -5643,6 +5687,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "ajv" = (
@@ -5695,6 +5740,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "ajz" = (
@@ -5866,6 +5912,7 @@
 	name = "Equipment Storage";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -5907,6 +5954,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Escape Hall"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -6359,6 +6407,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "akC" = (
@@ -6437,6 +6486,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "akL" = (
@@ -6473,6 +6523,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "akN" = (
@@ -6493,6 +6544,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -6547,6 +6599,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/interrogation)
 "akT" = (
@@ -6706,6 +6759,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -6849,9 +6903,11 @@
 	name = "Labor Shuttle";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/processing)
 "alw" = (
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "escape"
@@ -7146,6 +7202,7 @@
 	name = "Security Maintenance";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "alS" = (
@@ -7231,6 +7288,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "Detective"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "amb" = (
@@ -7260,6 +7318,7 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "amd" = (
@@ -7807,6 +7866,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "amU" = (
@@ -7818,6 +7878,7 @@
 	name = "Brig";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -7842,6 +7903,7 @@
 	name = "Brig";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -7877,6 +7939,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -8017,6 +8080,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "anm" = (
@@ -8481,6 +8545,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -8525,6 +8590,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -8567,6 +8633,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "Detective"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aoe" = (
@@ -8650,6 +8717,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "aol" = (
@@ -8780,6 +8848,7 @@
 	name = "Detective";
 	req_one_access = list(4,68)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -8853,6 +8922,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -8907,6 +8977,7 @@
 	name = "Engineering External Access";
 	req_access = list(13)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "aoM" = (
@@ -8915,6 +8986,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
 "aoN" = (
@@ -8933,6 +9005,7 @@
 	name = "Station Intercom (Security)";
 	pixel_x = -28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -9172,6 +9245,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/forensic_office)
 "apk" = (
@@ -9186,6 +9260,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "apm" = (
@@ -9262,6 +9337,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "apu" = (
@@ -9386,6 +9462,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "apD" = (
@@ -9465,6 +9542,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "apL" = (
@@ -9563,6 +9641,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "apX" = (
@@ -9625,6 +9704,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "aqf" = (
@@ -9637,6 +9717,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/locker)
 "aqh" = (
@@ -9657,6 +9738,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aqk" = (
@@ -9811,6 +9893,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aqw" = (
@@ -9857,6 +9940,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aqy" = (
@@ -9921,6 +10005,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "aqE" = (
@@ -10001,6 +10086,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "aqJ" = (
@@ -10455,6 +10541,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "arF" = (
@@ -10482,6 +10569,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "arI" = (
@@ -10502,6 +10590,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "Detective"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "arK" = (
@@ -10786,6 +10875,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "ase" = (
@@ -10851,6 +10941,7 @@
 /area/station/maintenance/dormitory)
 "asl" = (
 /obj/structure/stool/bed/chair/comfy/brown,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/library)
 "asm" = (
@@ -11065,6 +11156,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -11074,6 +11166,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "asE" = (
@@ -11143,6 +11236,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "asN" = (
@@ -11230,6 +11324,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Lobby"
 	},
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -11297,6 +11392,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "atf" = (
@@ -11372,6 +11468,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/cold_room)
 "atl" = (
@@ -11412,6 +11509,7 @@
 	name = "Reading Bay"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "atp" = (
@@ -11708,6 +11806,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "atQ" = (
@@ -12049,6 +12148,7 @@
 	name = "Garden"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "greencorner"
@@ -12062,6 +12162,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -12134,6 +12235,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -12147,6 +12249,7 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "auG" = (
@@ -12549,6 +12652,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "avu" = (
@@ -12728,6 +12832,7 @@
 	name = "Blueshield Office";
 	req_access = list(42)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -12755,6 +12860,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "avI" = (
@@ -12762,6 +12868,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -12825,12 +12932,9 @@
 	},
 /area/station/security/prison)
 "avP" = (
-/obj/structure/stool/bed/chair/comfy/black,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories)
 "avQ" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_y = -32
@@ -13044,6 +13148,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "awl" = (
@@ -13106,6 +13211,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "awr" = (
@@ -13191,6 +13297,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
 "awA" = (
@@ -13215,6 +13322,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "awC" = (
@@ -13230,6 +13338,7 @@
 /obj/structure/sign/poster/calendar{
 	pixel_y = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "awE" = (
@@ -13263,6 +13372,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "awI" = (
@@ -13333,6 +13443,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -13354,6 +13465,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "awS" = (
@@ -13377,6 +13489,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "awV" = (
@@ -13607,6 +13720,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -13728,6 +13842,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
 	},
@@ -13745,16 +13860,9 @@
 	},
 /area/station/civilian/gym)
 "axC" = (
-/obj/item/weapon/kitchen/utensil/fork{
-	pixel_x = 4
-	},
-/obj/item/weapon/kitchen/utensil/spoon{
-	pixel_x = -5
-	},
-/obj/structure/table/woodentable/fancy/black,
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
+/obj/item/device/flashlight/lamp/fir/special,
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "axD" = (
 /obj/structure/rack,
@@ -13929,6 +14037,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "axZ" = (
@@ -14017,6 +14126,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "ayg" = (
@@ -14031,6 +14141,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "ayh" = (
@@ -14186,6 +14297,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "ayw" = (
@@ -14213,6 +14325,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "ayy" = (
@@ -14746,6 +14859,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "azx" = (
@@ -14833,6 +14947,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -14904,16 +15019,12 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "azO" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "azP" = (
 /obj/structure/grille,
@@ -14959,6 +15070,7 @@
 	name = "E.V.A.";
 	req_one_access = list(1,5,11,18,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14996,6 +15108,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "azW" = (
@@ -15176,6 +15289,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aAl" = (
@@ -15292,6 +15406,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aAv" = (
@@ -15337,6 +15452,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aAA" = (
@@ -15350,6 +15466,7 @@
 	name = "Hydroponics Pasture";
 	req_access = list(35)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "aAC" = (
@@ -15480,6 +15597,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aAQ" = (
@@ -15541,6 +15659,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "aAX" = (
@@ -15570,6 +15689,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Lobby"
 	},
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -15607,6 +15727,7 @@
 	name = "Escape Airlock";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aBc" = (
@@ -15950,6 +16071,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "aBJ" = (
@@ -16030,6 +16152,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "aBP" = (
@@ -16076,6 +16199,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "aBS" = (
@@ -16093,6 +16217,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aBT" = (
@@ -16203,6 +16328,7 @@
 	req_access = list(50)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "aCe" = (
@@ -16284,6 +16410,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "aCn" = (
@@ -16586,6 +16713,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "aCV" = (
@@ -16670,6 +16798,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "aDe" = (
@@ -16801,6 +16930,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aDs" = (
@@ -16863,6 +16993,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aDA" = (
@@ -17027,6 +17158,7 @@
 	name = "Unisex Showers"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -17121,6 +17253,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aEc" = (
@@ -17172,6 +17305,7 @@
 /area/station/civilian/bar)
 "aEi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "redcorner"
@@ -17511,6 +17645,7 @@
 	req_access = list(55)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -17602,6 +17737,7 @@
 	dir = 4;
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aEX" = (
@@ -17759,6 +17895,7 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aFo" = (
+/obj/item/decoration/snowflake,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/science)
 "aFp" = (
@@ -17822,6 +17959,7 @@
 	name = "Dormitory"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -17832,6 +17970,7 @@
 	name = "Dormitory"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -17859,6 +17998,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aFw" = (
@@ -17900,6 +18040,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aFy" = (
@@ -17924,6 +18065,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aFz" = (
@@ -18130,6 +18272,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "aFW" = (
@@ -18191,6 +18334,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/fitness)
 "aGb" = (
@@ -18226,6 +18370,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "aGg" = (
@@ -18259,6 +18404,7 @@
 	dir = 4;
 	name = "Unisex Showers"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -18324,6 +18470,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aGq" = (
@@ -18603,6 +18750,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "aGR" = (
@@ -18660,6 +18808,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "aGY" = (
@@ -18684,6 +18833,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "aHa" = (
@@ -18837,6 +18987,7 @@
 	req_access = list(5,9)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -19084,6 +19235,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Primary Tool Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/storage/primary)
 "aHR" = (
@@ -19282,6 +19434,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aIm" = (
@@ -19378,6 +19531,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aIt" = (
@@ -19432,6 +19586,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "aIx" = (
@@ -19497,6 +19652,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "aID" = (
@@ -19615,6 +19771,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19989,6 +20146,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -20068,6 +20226,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -20077,12 +20236,14 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "aJH" = (
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -20179,6 +20340,7 @@
 	dir = 4;
 	name = "Unit 2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -20552,6 +20714,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aKA" = (
@@ -20599,6 +20762,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "aKF" = (
@@ -21160,6 +21324,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aLz" = (
@@ -21183,6 +21348,7 @@
 	name = "Escape Hall"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -21193,6 +21359,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Escape Hall"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aLD" = (
@@ -21336,6 +21503,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/garden)
 "aLU" = (
@@ -21357,6 +21525,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "aLW" = (
@@ -21481,6 +21650,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22129,6 +22299,7 @@
 	name = "Lethal Injection Storage";
 	req_access = list(58)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22378,6 +22549,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "aNU" = (
@@ -22400,6 +22572,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aNW" = (
@@ -22431,6 +22604,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aNY" = (
@@ -22713,6 +22887,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -22724,6 +22899,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Fitness"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -22742,6 +22918,7 @@
 	},
 /area/station/gateway)
 "aOD" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "greencorner"
 	},
@@ -22820,6 +22997,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aOL" = (
@@ -22970,6 +23148,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "aOY" = (
@@ -23529,6 +23708,7 @@
 	icon_state = "gr_window_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "aQa" = (
@@ -24017,6 +24197,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "aQR" = (
@@ -24038,6 +24219,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/storage/primary)
 "aQT" = (
@@ -24482,6 +24664,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -24537,6 +24720,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aRO" = (
@@ -24586,6 +24770,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "aRT" = (
@@ -25027,6 +25212,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/brainstorm_center)
 "aSP" = (
@@ -25061,6 +25247,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -25217,6 +25404,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor,
 /area/station/bridge)
 "aTd" = (
@@ -25253,6 +25441,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -25386,6 +25575,7 @@
 	icon_state = "gr_window_polarized";
 	id = "Patients"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
 "aTr" = (
@@ -25420,6 +25610,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
 "aTu" = (
@@ -25463,6 +25654,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "aTz" = (
@@ -25750,6 +25942,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/garden)
 "aTY" = (
@@ -25792,6 +25985,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aUc" = (
@@ -26200,6 +26394,7 @@
 	name = "Arrival Airlock";
 	req_one_access = list(65,48)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "aUO" = (
@@ -26256,6 +26451,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/patient_a)
 "aUT" = (
@@ -26291,6 +26487,7 @@
 	req_access = list(5)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -26721,6 +26918,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aVM" = (
@@ -26740,6 +26938,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aVN" = (
@@ -26808,6 +27007,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aVR" = (
@@ -26841,6 +27041,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "aVU" = (
@@ -26874,6 +27075,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aVW" = (
@@ -26939,6 +27141,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "aWb" = (
@@ -27061,6 +27264,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -27160,6 +27364,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aWq" = (
@@ -27198,6 +27403,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aWs" = (
@@ -27236,6 +27442,7 @@
 /area/station/hallway/secondary/entry)
 "aWv" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "escape"
 	},
@@ -27406,6 +27613,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aWN" = (
@@ -27551,6 +27759,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -27560,6 +27769,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aXc" = (
@@ -27593,6 +27803,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -27664,6 +27875,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/scibreak)
 "aXm" = (
@@ -27830,6 +28042,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "aXB" = (
@@ -28053,6 +28266,7 @@
 	req_access = list(62)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -28419,10 +28633,9 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aYD" = (
-/obj/item/device/flashlight/lamp/fir,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/gym)
 "aYE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -28525,6 +28738,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "aYP" = (
@@ -28692,6 +28906,7 @@
 	name = "Blueshield Storage";
 	req_access = list(42)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -28749,6 +28964,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Play Room"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/playroom)
 "aZj" = (
@@ -28910,6 +29126,7 @@
 	name = "Break Room";
 	req_access = list(47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -28976,6 +29193,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aZB" = (
@@ -28993,6 +29211,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "aZC" = (
@@ -29010,6 +29229,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "aZE" = (
@@ -29143,6 +29363,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -29374,6 +29595,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "bam" = (
@@ -29453,6 +29675,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -29784,6 +30007,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/bridge)
 "baW" = (
@@ -29807,6 +30031,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/bar)
 "baY" = (
@@ -29814,6 +30039,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "baZ" = (
@@ -29829,6 +30055,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/snowman,
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "bbb" = (
@@ -29855,6 +30082,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "bbd" = (
@@ -29895,6 +30123,7 @@
 	name = "Telecoms Server Access";
 	req_access = list(61)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30031,6 +30260,7 @@
 	name = "Telecoms Server Access";
 	req_access = list(61)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30151,6 +30381,7 @@
 	name = "Escape Medical Checkpoint";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -30216,6 +30447,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bbM" = (
@@ -30416,6 +30648,7 @@
 /obj/item/device/cardpay{
 	pixel_x = -10
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "bcd" = (
@@ -30520,6 +30753,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -30579,6 +30813,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "bcr" = (
@@ -30608,6 +30843,7 @@
 /area/station/medical/genetics_cloning)
 "bct" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -30729,6 +30965,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "bcF" = (
@@ -30753,6 +30990,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "bcI" = (
@@ -30796,6 +31034,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "bcN" = (
@@ -31234,6 +31473,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "bdD" = (
@@ -31523,6 +31763,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -31659,6 +31900,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -31884,10 +32126,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/weapon/flora/monkey,
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -31904,6 +32146,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "beH" = (
@@ -32114,6 +32357,7 @@
 	name = "Medbay";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -32395,6 +32639,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "bft" = (
@@ -32706,6 +32951,7 @@
 /area/station/medical/hallway)
 "bfZ" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -32780,6 +33026,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bgg" = (
@@ -32896,6 +33143,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bgq" = (
@@ -33018,6 +33266,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "bgB" = (
@@ -33042,6 +33291,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "bgD" = (
@@ -33669,6 +33919,7 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -33821,6 +34072,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -33897,6 +34149,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bil" = (
@@ -33996,6 +34249,7 @@
 	req_access = list(5)
 	},
 /obj/structure/curtain/medical,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -34063,6 +34317,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "biF" = (
@@ -34166,6 +34421,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -34243,6 +34499,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "biZ" = (
@@ -34277,6 +34534,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bje" = (
@@ -34549,6 +34807,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -34643,6 +34902,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bjX" = (
@@ -34690,6 +34950,7 @@
 /turf/simulated/wall,
 /area/space)
 "bkb" = (
+/obj/item/decoration/snowflake,
 /turf/simulated/wall,
 /area/space)
 "bkc" = (
@@ -34772,6 +35033,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bkj" = (
@@ -34817,6 +35079,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -34925,6 +35188,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bkz" = (
@@ -34959,6 +35223,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
 "bkD" = (
@@ -35079,6 +35344,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bkM" = (
@@ -35215,6 +35481,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "blb" = (
@@ -35245,6 +35512,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bld" = (
@@ -35270,6 +35538,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "ble" = (
@@ -35578,6 +35847,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "blC" = (
@@ -35977,6 +36247,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bmf" = (
@@ -36141,6 +36412,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteyellowfull"
@@ -36154,6 +36426,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -36233,6 +36506,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/bar)
 "bmz" = (
@@ -36283,6 +36557,7 @@
 /area/station/maintenance/engineering)
 "bmC" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "green"
@@ -36670,6 +36945,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -36860,6 +37136,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
 "bnN" = (
@@ -37015,6 +37292,7 @@
 "boc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "bod" = (
@@ -37081,6 +37359,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "bol" = (
@@ -37227,6 +37506,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -37237,6 +37517,7 @@
 	req_access = list(5,6)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -37300,6 +37581,7 @@
 	req_access = list(7)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
 	},
@@ -37310,6 +37592,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "boE" = (
@@ -37444,6 +37727,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -37712,6 +37996,7 @@
 /obj/machinery/holosign/surgery{
 	id = "op2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -37732,6 +38017,7 @@
 	icon_state = "gr_window_polarized";
 	id = "op2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery2)
 "bpr" = (
@@ -37866,6 +38152,7 @@
 	icon_state = "gr_window_polarized";
 	id = "op1"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
 "bpE" = (
@@ -37951,6 +38238,7 @@
 	dir = 4;
 	name = "Chapel"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -38197,6 +38485,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "bqo" = (
@@ -38457,6 +38746,7 @@
 	name = "Medbay Maintenance";
 	req_access = list(5,6)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
 "bqI" = (
@@ -38555,6 +38845,7 @@
 	name = "Escape Airlock";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "bqQ" = (
@@ -38594,6 +38885,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "green"
@@ -39264,6 +39556,7 @@
 	icon_state = "gr_window_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "bsg" = (
@@ -39345,6 +39638,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bsp" = (
@@ -39414,6 +39708,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -39443,6 +39738,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "bsA" = (
@@ -39659,6 +39955,7 @@
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -39696,6 +39993,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "bsX" = (
@@ -40039,6 +40337,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -40264,6 +40563,7 @@
 	name = "Medical Supplies";
 	req_access = list(72)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -40497,6 +40797,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/hallway)
 "bur" = (
@@ -40535,6 +40836,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "buv" = (
@@ -40769,6 +41071,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
 "buR" = (
@@ -40789,6 +41092,7 @@
 	icon_state = "gr_window_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "buS" = (
@@ -40798,6 +41102,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/structure/sign/directions/dock_tablo/arrival,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "buT" = (
@@ -40808,6 +41113,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -40931,6 +41237,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -40975,6 +41282,7 @@
 /turf/simulated/floor/bluegrid,
 /area/station/bridge/cmf_room)
 "bvi" = (
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41075,6 +41383,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -41152,6 +41461,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -41166,6 +41476,7 @@
 /obj/machinery/holosign/surgery{
 	id = "op1"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -41248,6 +41559,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "bvE" = (
@@ -41270,6 +41582,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "bvF" = (
@@ -41434,6 +41747,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "bvW" = (
@@ -41455,6 +41769,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -41478,6 +41793,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bvZ" = (
@@ -41691,6 +42007,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "green"
@@ -41890,6 +42207,7 @@
 	layer = 4;
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -41988,6 +42306,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vault"
 	},
@@ -42071,6 +42390,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42264,6 +42584,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42679,6 +43000,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bxY" = (
@@ -42797,6 +43119,7 @@
 	id = "teles_blast2";
 	name = "Test Chamber Blast Doors"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "byi" = (
@@ -42826,6 +43149,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -42873,6 +43197,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
 "byn" = (
@@ -43092,6 +43417,7 @@
 	name = "Chapel Office";
 	req_access = list(22)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -43113,6 +43439,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -43722,6 +44049,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43792,6 +44120,7 @@
 	name = "Internal Affairs";
 	req_access = list(38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -43841,6 +44170,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bzV" = (
@@ -44053,6 +44383,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/patient_b)
 "bAr" = (
@@ -44107,6 +44438,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bAw" = (
@@ -44121,6 +44453,7 @@
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room 2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -44243,6 +44576,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
 "bAJ" = (
@@ -44409,6 +44743,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bBb" = (
@@ -44473,6 +44808,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bBg" = (
@@ -44581,6 +44917,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "bBr" = (
@@ -45664,6 +46001,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bDp" = (
@@ -45683,6 +46021,7 @@
 	req_access = list(46)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -45739,6 +46078,7 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/civilian/dormitories/dormthree)
 "bDy" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vault"
 	},
@@ -45902,6 +46242,7 @@
 /area/station/hallway/primary/aft)
 "bDK" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -46136,6 +46477,7 @@
 	req_access = list(39)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreenfull"
@@ -46196,6 +46538,7 @@
 	req_one_access = list(12,25,28)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bEo" = (
@@ -46436,6 +46779,7 @@
 	name = "Hydroponics Maintenance";
 	req_one_access = list(35,28)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "bEM" = (
@@ -46563,6 +46907,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -46606,6 +46951,7 @@
 	name = "Hydroponics";
 	req_access = list(35)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -46674,6 +47020,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/cryo)
 "bFg" = (
@@ -46768,6 +47115,7 @@
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room 1"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -46796,6 +47144,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -46815,6 +47164,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "bFs" = (
@@ -47034,6 +47384,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -47142,6 +47493,7 @@
 /area/station/civilian/barbershop)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "green"
@@ -47209,6 +47561,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -47225,6 +47578,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -47234,6 +47588,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -47427,6 +47782,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -47696,6 +48052,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "bGR" = (
@@ -47774,6 +48131,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
 "bHb" = (
@@ -47858,6 +48216,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bHk" = (
@@ -47911,6 +48270,7 @@
 	name = "Confession Booth";
 	req_access = list(22)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "bHo" = (
@@ -47982,6 +48342,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
 "bHv" = (
@@ -48075,6 +48436,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/miningoffice)
 "bHC" = (
@@ -48236,6 +48598,7 @@
 	name = "Medbay right APC";
 	pixel_x = 27
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -48250,6 +48613,7 @@
 /area/station/engineering/monitoring)
 "bHS" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -48440,6 +48804,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "bIi" = (
@@ -48495,6 +48860,7 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bIn" = (
@@ -48514,6 +48880,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bIo" = (
@@ -48605,6 +48972,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = -27
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -49889,6 +50257,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "bKW" = (
@@ -49912,6 +50281,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "bKZ" = (
@@ -50055,6 +50425,7 @@
 	pixel_x = 8;
 	pixel_y = 16
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bLq" = (
@@ -50138,6 +50509,7 @@
 	req_access = list(5)
 	},
 /obj/structure/curtain/medical,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -50236,6 +50608,7 @@
 /obj/machinery/vending/wallmed2{
 	pixel_x = -26
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -50362,6 +50735,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "bLS" = (
@@ -50569,6 +50943,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bMm" = (
@@ -50630,6 +51005,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/bridge/hop_office)
 "bMs" = (
@@ -50671,6 +51047,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "bMu" = (
@@ -50770,12 +51147,14 @@
 "bMC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/hallway)
 "bMD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/hallway)
 "bME" = (
@@ -51014,6 +51393,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -51206,6 +51586,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
 "bNp" = (
@@ -51262,6 +51643,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bNt" = (
@@ -51519,6 +51901,7 @@
 	pixel_x = 30
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bNM" = (
@@ -51535,6 +51918,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "bNN" = (
@@ -51721,6 +52105,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -51852,6 +52237,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "bOu" = (
@@ -51883,6 +52269,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard)
 "bOx" = (
@@ -51893,6 +52280,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "bOy" = (
@@ -52330,6 +52718,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -52350,6 +52739,7 @@
 	id_tag = "Dorm2";
 	name = "Dorm 2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "bPr" = (
@@ -52416,6 +52806,7 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -52450,6 +52841,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -52579,6 +52971,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "bPI" = (
@@ -52997,6 +53390,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -53096,6 +53490,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "bQG" = (
@@ -53114,6 +53509,7 @@
 	pixel_y = -30
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bQI" = (
@@ -53334,6 +53730,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bRf" = (
@@ -53728,6 +54125,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -53762,6 +54160,7 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -53884,6 +54283,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bSC" = (
@@ -53901,6 +54301,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bSD" = (
@@ -53974,6 +54375,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -54092,6 +54494,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency3)
 "bSZ" = (
@@ -54116,6 +54519,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -54184,6 +54588,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bTr" = (
@@ -54320,6 +54725,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
 "bTO" = (
@@ -54395,6 +54801,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "bUc" = (
@@ -54525,6 +54932,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bUw" = (
@@ -54578,6 +54986,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "bUA" = (
@@ -54630,6 +55039,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluecorner"
 	},
@@ -54939,6 +55349,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "bVL" = (
@@ -55041,6 +55452,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "bVU" = (
@@ -55129,6 +55541,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bWe" = (
@@ -55203,6 +55616,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bWl" = (
@@ -55247,6 +55661,7 @@
 	},
 /obj/structure/sign/directions/dock_tablo/tablo3,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "bWw" = (
@@ -55273,6 +55688,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "escape"
 	},
@@ -55483,6 +55899,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bXr" = (
@@ -55671,6 +56088,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -55758,6 +56176,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -55819,6 +56238,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bYk" = (
@@ -55831,6 +56251,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bYl" = (
@@ -56040,6 +56461,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"bYO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/brig)
 "bYP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
@@ -56523,6 +56948,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -56636,6 +57062,7 @@
 	name = "Atmospherics Monitoring";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "cbo" = (
@@ -56821,6 +57248,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "cbX" = (
@@ -57018,6 +57446,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "ccQ" = (
@@ -57039,6 +57468,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -57691,6 +58121,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "cfl" = (
@@ -57860,6 +58291,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "cfK" = (
@@ -57879,6 +58311,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "cfN" = (
@@ -58198,6 +58631,7 @@
 	name = "Mixing Room Exterior Airlock";
 	req_access = list(8)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
 "cgF" = (
@@ -58239,6 +58673,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cgK" = (
@@ -58298,6 +58733,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "cgU" = (
@@ -58311,6 +58747,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "cgW" = (
@@ -58339,6 +58776,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "chb" = (
@@ -58503,12 +58941,14 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "chr" = (
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -58659,6 +59099,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -58718,6 +59159,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "chZ" = (
@@ -59103,6 +59545,7 @@
 	name = "Library"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "cjt" = (
@@ -59200,6 +59643,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "cjG" = (
@@ -59257,6 +59701,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "cjO" = (
@@ -59274,6 +59719,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "cjT" = (
@@ -59300,6 +59746,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "cjZ" = (
@@ -59544,6 +59991,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "green"
@@ -59694,6 +60142,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "clk" = (
@@ -59796,6 +60245,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "clv" = (
@@ -59905,6 +60355,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -59965,6 +60416,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -60139,6 +60591,7 @@
 	name = "Toxins Research";
 	req_access = list(8)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
 	},
@@ -60172,6 +60625,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "cmr" = (
@@ -60619,6 +61073,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -60758,10 +61213,15 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"cnS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/medbay)
 "cnU" = (
 /obj/machinery/disposal,
 /obj/structure/window/thin/reinforced,
@@ -60782,6 +61242,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/yellow,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "cnY" = (
@@ -60948,6 +61409,7 @@
 /obj/machinery/atm{
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "caution"
@@ -61002,6 +61464,7 @@
 	icon_state = "gr_window_polarized";
 	id = "kitchen"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "coz" = (
@@ -61095,6 +61558,7 @@
 	icon_state = "gr_window_polarized";
 	id = "Library"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "coN" = (
@@ -61697,6 +62161,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cpV" = (
@@ -62061,6 +62526,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -62238,6 +62704,7 @@
 	dir = 4;
 	name = "Unit 3"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -62567,6 +63034,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -62579,6 +63047,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -62767,6 +63236,7 @@
 /obj/machinery/door/airlock{
 	name = "Firefighting equipment"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency3)
 "csB" = (
@@ -62923,6 +63393,7 @@
 	name = "MiniSat Antechamber";
 	req_one_access = list(66)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -63276,6 +63747,7 @@
 /area/station/security/armoury)
 "ctJ" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -63484,6 +63956,7 @@
 	name = "Research Division Access";
 	req_one_access = list(47,9)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/genetics)
 "cuo" = (
@@ -63687,6 +64160,7 @@
 	name = "Garden"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "green"
@@ -63972,6 +64446,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"cvQ" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "cvR" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = "o2_in";
@@ -63998,6 +64479,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "green"
@@ -64046,6 +64528,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cvZ" = (
@@ -64079,6 +64562,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cwd" = (
@@ -64131,6 +64615,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cwE" = (
@@ -65077,6 +65562,7 @@
 /obj/item/weapon/pen{
 	pixel_x = 10
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -65368,6 +65854,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "blue"
@@ -65685,6 +66172,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "cAW" = (
@@ -65719,6 +66207,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -66071,6 +66560,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cBU" = (
@@ -66733,6 +67223,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -66854,6 +67345,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
 "cEf" = (
@@ -67303,6 +67795,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -67528,6 +68021,7 @@
 	name = "Toilet"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -67538,6 +68032,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "cGG" = (
@@ -67852,6 +68347,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cHG" = (
@@ -68372,6 +68868,7 @@
 	req_access = list(5)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -68808,6 +69305,7 @@
 	name = "Shower"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -68957,6 +69455,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "green"
@@ -69022,6 +69521,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -69145,6 +69645,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cMu" = (
@@ -69325,6 +69826,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -69615,6 +70117,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
+"dbN" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "ddb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -69659,6 +70168,7 @@
 	icon_state = "gr_window_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "deC" = (
@@ -69697,6 +70207,7 @@
 	locked = 1;
 	name = "Escape Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "dib" = (
@@ -69752,6 +70263,7 @@
 	name = "Morgue";
 	req_access = list(9)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -69804,6 +70316,10 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"dmm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/incinerator)
 "doG" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -69822,6 +70338,16 @@
 /obj/structure/sign/warning/secure_area/armory,
 /turf/simulated/wall/r_wall,
 /area/station/security/armoury)
+"dpZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "dqn" = (
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
@@ -69831,6 +70357,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -69984,6 +70511,10 @@
 	icon_state = "cult"
 	},
 /area/station/civilian/library)
+"dwO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/toilet)
 "dxb" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -70087,6 +70618,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "dCb" = (
@@ -70126,6 +70658,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "dEb" = (
@@ -70146,6 +70679,7 @@
 	},
 /area/station/security/armoury)
 "dFc" = (
+/obj/item/decoration/snowflake,
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/aft)
 "dFe" = (
@@ -70201,6 +70735,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/drone_fabrication)
+"dKs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/prison)
 "dLf" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -70228,6 +70766,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "dNy" = (
@@ -70527,6 +71066,12 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/altar)
+"edq" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor/garden{
+	icon_state = "asteroid"
+	},
+/area/station/civilian/garden)
 "eeb" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin{
@@ -70625,10 +71170,18 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
 /area/station/medical/reception)
+"ejG" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/rnd/xenobiology)
 "ejR" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -70678,6 +71231,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"end" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos)
 "enu" = (
 /obj/structure/sign/departments/holy{
 	pixel_y = 32
@@ -70753,6 +71310,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "eqG" = (
@@ -70791,6 +71349,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "etF" = (
@@ -70895,6 +71454,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"eza" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4;
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/security/processing)
 "ezi" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -70909,12 +71481,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"ezo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/brainstorm_center)
 "ezx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "eAb" = (
@@ -70995,8 +71572,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"eFq" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "eGb" = (
 /obj/item/stack/medical/ointment{
 	pixel_y = 4
@@ -71041,6 +71626,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -71127,6 +71713,10 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
+"eNZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/hallway)
 "ePa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
@@ -71144,6 +71734,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "ePF" = (
@@ -71168,12 +71759,21 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"eQf" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "eQF" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/garden)
 "eQG" = (
@@ -71184,10 +71784,12 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "eQY" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "caution"
@@ -71201,6 +71803,10 @@
 /obj/structure/sign/warning/pods,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/dormitory)
+"eRj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/library)
 "eRo" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -71271,6 +71877,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "eUl" = (
@@ -71302,6 +71909,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -71355,13 +71963,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "eXz" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/bar)
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/medical/reception)
+"eYq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "eZb" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -71381,6 +71996,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"fak" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/engineering)
 "fbb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -71471,6 +72090,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "fmb" = (
@@ -71489,6 +72109,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "fmS" = (
@@ -71521,6 +72142,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"fni" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/disposal)
 "fob" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -71635,6 +72260,7 @@
 	name = "Recycler External Access";
 	req_access = list(67)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "ftb" = (
@@ -71693,6 +72319,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -71727,12 +72354,17 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"fzi" = (
+/obj/machinery/vending/newyearmate,
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "fzR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "fAb" = (
@@ -71776,6 +72408,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
+"fBC" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/hos)
 "fBF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -71838,6 +72474,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "fDT" = (
@@ -71925,6 +72562,7 @@
 	req_access = list(10)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "fHn" = (
@@ -71970,6 +72608,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72042,6 +72681,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
+"fMB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/chemistry)
 "fMX" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -72088,6 +72731,10 @@
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
+"fPa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/bridge)
 "fPM" = (
 /obj/structure/bookcase/manuals/engineering,
 /obj/structure/sign/poster/random{
@@ -72112,6 +72759,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"fRi" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/rnd/xenobiology)
 "fRW" = (
 /obj/structure/object_wall/pod{
 	dir = 1;
@@ -72139,6 +72793,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"fSY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/construction/assembly_line)
 "fTb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/item/device/radio/intercom{
@@ -72256,6 +72914,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"fYY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "fZb" = (
 /obj/structure/closet/bombcloset,
 /obj/item/device/radio/intercom{
@@ -72268,6 +72930,10 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
+"fZj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/armoury)
 "gab" = (
 /obj/machinery/door/airlock/security{
 	dir = 4;
@@ -72277,11 +72943,16 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
 	},
 /area/station/medical/reception)
+"gar" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall,
+/area/station/maintenance/eva)
 "gbb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -72329,6 +73000,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"gez" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/misc_lab)
 "gfa" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "0,3"
@@ -72394,6 +73069,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "gjb" = (
@@ -72516,8 +73192,13 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
+"gqN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/primary)
 "gqW" = (
 /obj/structure/rack,
 /obj/structure/cable{
@@ -72562,6 +73243,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"grw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/primary/fore)
 "gsb" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/lockbox/anti_singulo,
@@ -72613,6 +73298,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -72707,6 +73393,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
 "gCb" = (
@@ -72770,6 +73457,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/garden)
 "gGb" = (
@@ -72799,6 +73487,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"gGD" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/central)
 "gGO" = (
 /obj/structure/sign/warning/docking,
 /turf/simulated/wall,
@@ -72917,6 +73609,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"gLA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/engine)
 "gMb" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/thin/reinforced{
@@ -73348,6 +74044,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "hgJ" = (
@@ -73362,6 +74059,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"hgK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/reception)
 "hhb" = (
 /obj/structure/object_wall/mining{
 	icon_state = "2-8";
@@ -73394,6 +74095,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "hiq" = (
@@ -73465,6 +74167,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "hmR" = (
@@ -73497,6 +74200,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
 "hob" = (
@@ -73504,6 +74208,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "hpb" = (
@@ -73511,6 +74216,7 @@
 	name = "Sauna"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -73594,6 +74300,10 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
+"htY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/forensic_office)
 "huy" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "1,3"
@@ -73690,6 +74400,10 @@
 	icon_state = "white"
 	},
 /area/station/rnd/xenobiology)
+"hzS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/nuke_storage)
 "hBb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -73751,6 +74465,10 @@
 	icon_state = "4,5"
 	},
 /area/shuttle/supply/station)
+"hFV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "hGb" = (
 /obj/structure/sign/warning/securearea,
 /turf/simulated/wall/r_wall,
@@ -73809,6 +74527,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"hHl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/break_room)
 "hHs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -73829,6 +74551,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "hIf" = (
@@ -74486,6 +75209,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "isb" = (
@@ -74538,6 +75262,7 @@
 	name = "Engineering Storage";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "iur" = (
@@ -74546,6 +75271,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "iuu" = (
@@ -74635,6 +75361,7 @@
 	name = "Engineering Storage";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "iyb" = (
@@ -74757,8 +75484,23 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
+"iCV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/hallway)
 "iDb" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "browncorner"
 	},
@@ -74876,6 +75618,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "iHp" = (
@@ -74895,6 +75638,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"iHG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "greencorner"
+	},
+/area/station/hallway/primary/port)
 "iIo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -74979,6 +75737,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
+"iOk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/storage)
 "iPb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -75073,6 +75835,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "blue"
@@ -75145,6 +75908,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency3)
+"iVe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/mass_driver)
 "iVS" = (
 /obj/machinery/power/grounding_rod,
 /obj/structure/cable{
@@ -75157,6 +75924,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"iVV" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/antechamber_interior)
 "iWb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -75175,6 +75946,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "green"
@@ -75216,17 +75988,23 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "iZb" = (
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central)
+"iZf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/surgery2)
 "iZg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -75241,6 +76019,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"iZk" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
+"iZq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/interrogation)
 "jab" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75275,6 +76063,7 @@
 /area/station/construction)
 "jaX" = (
 /obj/machinery/computer/crew,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -75300,6 +76089,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"jbS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/cryo)
 "jcb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75355,6 +76148,7 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -75381,6 +76175,10 @@
 /obj/item/device/lens/nude,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"jgg" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/primary/central)
 "jhb" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -75550,6 +76348,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"jpw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/xenobiology)
 "jpD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75612,6 +76414,7 @@
 	name = "Engineering Storage";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "jsb" = (
@@ -75620,6 +76423,7 @@
 	req_access = list(26)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/janitor)
 "jsD" = (
@@ -75646,6 +76450,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"jtW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/janitor)
 "jub" = (
 /obj/structure/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -75671,6 +76479,15 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
+"jwn" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/medical/virology)
 "jwo" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
@@ -75754,6 +76571,7 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -75763,6 +76581,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "jBg" = (
@@ -75871,6 +76690,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "jGb" = (
@@ -75878,6 +76698,10 @@
 /obj/item/weapon/storage/box/matches,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"jGJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint)
 "jHb" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -75894,6 +76718,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -76060,6 +76885,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"jQK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/fore)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76097,11 +76926,16 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage_secure)
+"jUo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/chapel)
 "jVb" = (
 /obj/machinery/door/airlock{
 	dir = 4;
 	name = "Private Restroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -76188,6 +77022,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "jZb" = (
@@ -76269,6 +77104,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "kdb" = (
@@ -76334,6 +77170,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "keS" = (
@@ -76442,6 +77279,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"kkG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/lab)
 "klb" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -76523,6 +77364,10 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/crematorium)
+"koS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/office)
 "koU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool,
@@ -76556,6 +77401,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
+"kqH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/exit)
 "krf" = (
 /obj/machinery/power/emitter,
 /turf/simulated/floor/plating,
@@ -76604,6 +77453,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/red,
 /turf/simulated/floor/plating,
 /area/station/bridge/teleporter)
 "kss" = (
@@ -76631,6 +77481,10 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"ktT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/tox_launch)
 "kub" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -76688,6 +77542,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "kwS" = (
@@ -76758,6 +77613,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kAR" = (
@@ -76769,6 +77625,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "kAS" = (
@@ -76916,6 +77773,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "kKb" = (
@@ -76930,6 +77788,10 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
+"kKd" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/ai_monitored/eva)
 "kLb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/turf_decal/set_burned,
@@ -77117,8 +77979,13 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel)
+"kVG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/hop_office)
 "kYG" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -77176,6 +78043,10 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
+"lan" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall/r_wall,
+/area/station/aisat)
 "lar" = (
 /obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall,
@@ -77206,6 +78077,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"lcm" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "lcB" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -77271,6 +78146,10 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"lfQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/captain_quarters)
 "lga" = (
 /obj/item/weapon/reagent_containers/food/snacks/soap/nanotrasen,
 /obj/structure/dryer{
@@ -77300,6 +78179,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "lhP" = (
@@ -77640,6 +78520,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "lBb" = (
@@ -77680,6 +78561,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lCU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/cold_room)
 "lDb" = (
 /obj/structure/grille,
 /obj/structure/window/thin/reinforced{
@@ -77768,6 +78653,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lGH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/medbreak)
 "lHb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -77902,6 +78791,10 @@
 	icon_state = "barber"
 	},
 /area/station/civilian/locker)
+"lMy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/construction)
 "lNb" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
@@ -77926,6 +78819,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "lOb" = (
@@ -78029,11 +78923,22 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
+"lSW" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/aft)
 "lTb" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/chem_dispenser/old,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lTm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/barbershop)
 "lUb" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -78042,6 +78947,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "lUd" = (
@@ -78049,6 +78955,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -78227,8 +79134,13 @@
 /obj/structure/cable{
 	dir = 8
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
+"mdE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/cargo)
 "meb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78479,6 +79391,7 @@
 	req_access = list(5,9)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -78590,6 +79503,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"mxv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/snowman,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "myb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -78620,6 +79538,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "myS" = (
@@ -78669,6 +79588,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
+"mDo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/psych)
 "mDC" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -78734,6 +79657,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "mHb" = (
@@ -78749,6 +79673,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -78785,6 +79710,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "mKa" = (
@@ -78840,6 +79766,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "mMb" = (
@@ -78858,6 +79785,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"mMw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/scibreak)
 "mNb" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -78921,10 +79852,23 @@
 /area/station/engineering/engine)
 "mQb" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
+"mQf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/robotics)
+"mRT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel)
+"mRV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/gateway)
 "mTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -79046,6 +79990,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -79090,6 +80035,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/tox_launch)
+"ndH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/meeting_room)
 "neb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79221,6 +80170,7 @@
 /area/station/maintenance/medbay)
 "nob" = (
 /obj/structure/mineral_door/wood,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "noT" = (
@@ -79244,6 +80194,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/playroom)
 "npd" = (
@@ -79273,6 +80224,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "nqm" = (
@@ -79282,6 +80234,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "nrb" = (
@@ -79361,6 +80314,7 @@
 	req_one_access = list(13,45,1)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "nub" = (
@@ -79452,6 +80406,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "redcorner"
@@ -79465,6 +80420,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "nzb" = (
@@ -79484,6 +80440,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "nAb" = (
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -79581,6 +80538,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"nFy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycleroffice)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -79626,6 +80587,7 @@
 /area/station/civilian/garden)
 "nIb" = (
 /obj/structure/mineral_door/wood,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/maintenance/engineering)
 "nJb" = (
@@ -79697,6 +80659,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -79714,6 +80677,10 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"nOS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/range)
 "nPb" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -79803,6 +80770,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/fitness)
+"nVn" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/comms{
+	name = "Cyborg Station"
+	})
 "nVQ" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -79866,6 +80839,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "nZG" = (
@@ -80074,6 +81048,10 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/simulated/floor/plating,
 /area/station/construction)
+"ofK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/hydroponics)
 "ofX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80165,6 +81143,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "onb" = (
@@ -80260,6 +81239,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "ovb" = (
@@ -80415,6 +81395,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"oCJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/genetics)
 "oDb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -80485,6 +81469,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -80530,6 +81515,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "oMJ" = (
@@ -80581,6 +81567,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "oRm" = (
@@ -80594,6 +81581,14 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"oRL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/arrival)
+"oTl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/morgue)
 "oTJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -80699,6 +81694,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"pbi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/forensic_office)
+"pbC" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/scibreak)
+"pck" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/blueshield)
 "pcJ" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -80719,6 +81726,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/lobby)
 "pdc" = (
@@ -80876,6 +81884,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"poG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/interrogation)
 "pqb" = (
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
@@ -80930,6 +81942,10 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/central)
+"ptK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/virology)
 "puI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80992,6 +82008,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "pyb" = (
@@ -81172,6 +82189,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "pEt" = (
@@ -81221,6 +82239,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -81244,6 +82263,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
+"pNr" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/monitoring)
 "pNN" = (
 /obj/structure/rack,
 /obj/item/device/flashlight,
@@ -81252,6 +82275,10 @@
 /obj/item/weapon/wirecutters,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"pNW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/atmos)
 "pOb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -81382,6 +82409,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"pUW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/kitchen)
 "pVE" = (
 /obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
 /obj/effect/decal/cleanable/vomit{
@@ -81404,6 +82435,13 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
+/area/station/hallway/primary/central)
+"pXh" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
 /area/station/hallway/primary/central)
 "pXY" = (
 /obj/item/weapon/flora/random,
@@ -81686,6 +82724,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "qmd" = (
@@ -81884,6 +82923,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "qwt" = (
@@ -81898,8 +82938,22 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
+"qxS" = (
+/obj/machinery/door/airlock/external{
+	dir = 4;
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/security/processing)
 "qyj" = (
 /obj/item/stack/rods,
 /obj/structure/grille{
@@ -81915,6 +82969,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"qza" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/xenobiology)
 "qAF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81939,6 +82997,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "qCp" = (
@@ -81993,6 +83052,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "qEe" = (
@@ -82004,6 +83064,7 @@
 /obj/structure/transit_tube{
 	icon_state = "N-S"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -82059,6 +83120,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
+"qGI" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/cmo)
 "qJb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82129,6 +83194,7 @@
 /area/station/engineering/singularity)
 "qMb" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -82181,6 +83247,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/arrival)
+"qNZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/altar)
 "qPb" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -82229,6 +83299,7 @@
 	dir = 8;
 	network = list("SS13","Research")
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -82417,6 +83488,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "qYi" = (
@@ -82437,6 +83509,7 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -82484,6 +83557,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"rcJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/drone_fabrication)
 "rda" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
@@ -82524,6 +83601,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "reM" = (
@@ -82799,6 +83877,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"rrO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/tools)
 "rrP" = (
 /obj/structure/transit_tube{
 	icon_state = "D-SW"
@@ -82871,6 +83953,10 @@
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"ruS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/chiefs_office)
 "rvb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 1
@@ -82968,6 +84054,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"rzt" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/fitness)
 "rAb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83042,6 +84132,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"rCP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/office)
 "rDb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83116,6 +84210,10 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
+"rGF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/chargebay)
 "rHb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83151,6 +84249,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"rJB" = (
+/obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "rKb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83178,6 +84286,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"rLS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/theatre)
 "rLZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -83198,6 +84310,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"rMo" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "rNb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83375,6 +84491,10 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"rWK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hor)
 "rXf" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "loadingarea"
@@ -83400,6 +84520,10 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"rYQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/miningoffice)
 "rZb" = (
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen{
@@ -83437,6 +84561,10 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"say" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/ai_upload)
 "sbb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83484,6 +84612,17 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/virology)
+"sdV" = (
+/obj/machinery/door/airlock/external{
+	dir = 4;
+	name = "Arrival Airlock"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "sdW" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "0,6"
@@ -83526,6 +84665,13 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"sfR" = (
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "sgb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -83593,6 +84739,7 @@
 	name = "Virology";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreenfull"
@@ -83618,8 +84765,13 @@
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
+"skm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/engine)
 "slb" = (
 /mob/living/carbon/monkey,
 /turf/simulated/floor{
@@ -83695,6 +84847,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "snG" = (
@@ -83802,6 +84955,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "ssb" = (
@@ -83876,6 +85030,10 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"swL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/main)
 "sxb" = (
 /obj/item/seeds/ambrosiavulgarisseed,
 /obj/item/seeds/carrotseed,
@@ -83948,6 +85106,10 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"sAW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "sBb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -83972,6 +85134,7 @@
 	name = "Isolation B";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -83980,6 +85143,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"sCi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/chapel)
 "sCm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84092,6 +85259,7 @@
 	name = "Monkey Pen";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -84222,6 +85390,10 @@
 /obj/machinery/light/smart,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
+"sOa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/playroom)
 "sOb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84238,6 +85410,10 @@
 /obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall,
 /area/station/cargo/recycler)
+"sOj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "sOX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -84258,6 +85434,7 @@
 	name = "Isolation A";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -84281,6 +85458,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"sQO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/crematorium)
 "sRb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -84404,6 +85585,10 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"sVZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/execution)
 "sWb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -84471,6 +85656,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84567,6 +85753,17 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"tfR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "tfZ" = (
 /obj/effect/decal/turf_decal/wood{
 	dir = 8;
@@ -84719,6 +85916,7 @@
 	name = "Atmospherics Closets";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "tpb" = (
@@ -84775,11 +85973,11 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "tze" = (
-/obj/structure/stool/bed/chair/comfy/black,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "white"
 	},
-/area/station/civilian/bar)
+/area/station/rnd/hallway)
 "tzl" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -84899,6 +86097,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"tIw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry)
 "tIJ" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -84913,6 +86115,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
 "tKb" = (
@@ -84940,6 +86143,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "tMB" = (
@@ -84947,6 +86151,10 @@
 	icon_state = "stairs_middle"
 	},
 /area/station/civilian/chapel)
+"tNm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/qm)
 "tOb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -85079,6 +86287,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "ucb" = (
@@ -85090,6 +86299,23 @@
 	icon_state = "blue"
 	},
 /area/station/medical/genetics)
+"ucs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"ucZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/eva)
 "udd" = (
 /obj/structure/sign/barber{
 	buildable_sign = 0;
@@ -85125,6 +86351,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "uek" = (
@@ -85165,6 +86392,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "ugb" = (
@@ -85177,6 +86405,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "uha" = (
@@ -85233,6 +86462,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/bar)
+"ulx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/telesci)
 "uml" = (
 /obj/structure/stool/bed/chair/pew/right,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -85253,6 +86486,7 @@
 	icon_state = "gr_window_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "unb" = (
@@ -85276,22 +86510,19 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"unx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/storage)
 "uob" = (
 /obj/machinery/light/smart,
 /obj/machinery/atmospherics/components/binary/valve/digital/open,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "uof" = (
-/obj/item/weapon/reagent_containers/food/condiment/peppermill,
-/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/structure/table/woodentable/fancy/black,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/storage/tech)
 "uoD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -85367,6 +86598,15 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"uvm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/medical/medbreak)
 "uwT" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -85383,6 +86623,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"uyb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/garden)
 "uyE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85437,6 +86681,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"uCB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/surgery)
 "uDb" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -85484,6 +86732,10 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"uGk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/dormitory)
 "uHk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -85550,6 +86802,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "uOD" = (
@@ -85561,11 +86814,16 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/locker)
+"uPg" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hallway)
 "uPw" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -85643,8 +86901,13 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"vas" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/bar)
 "vbU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85659,6 +86922,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "vcK" = (
@@ -85687,6 +86951,7 @@
 	icon_state = "gr_window_polarized";
 	id = "privateoffice"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "vls" = (
@@ -85715,6 +86980,26 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"voI" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/storage)
+"vpx" = (
+/obj/structure/barricade/wooden,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"vrT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/execution)
 "vsv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -85746,6 +87031,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
 "vwv" = (
@@ -85757,11 +87043,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
+"vwL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/dormitory)
 "vyg" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "4,0"
 	},
 /area/shuttle/supply/station)
+"vyh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/patient_a)
 "vyZ" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
@@ -85856,6 +87150,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/qm)
 "vJB" = (
@@ -85867,6 +87162,7 @@
 	name = "Chief Engineer";
 	req_access = list(56)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "vKd" = (
@@ -85875,6 +87171,18 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"vLg" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/bridge/captain_quarters)
+"vNi" = (
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/aft)
 "vNR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -86044,6 +87352,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/processing)
 "wdR" = (
@@ -86065,6 +87374,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"weB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/brig)
 "wfg" = (
 /obj/structure/table/woodentable,
 /obj/item/folder_holder{
@@ -86174,6 +87487,10 @@
 	icon_state = "3,3"
 	},
 /area/shuttle/supply/station)
+"wjw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/prison)
 "wjJ" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -86214,6 +87531,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "wnq" = (
@@ -86259,6 +87577,7 @@
 	name = "Bar Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -86276,6 +87595,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "woS" = (
@@ -86337,8 +87657,13 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
+"wtX" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/locker)
 "wuI" = (
 /obj/item/weapon/cigbutt,
 /turf/simulated/floor/plating,
@@ -86382,6 +87707,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
+"wzH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor,
+/area/station/hallway/primary/aft)
 "wAe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -86434,6 +87771,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"wEW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/main)
 "wFY" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -86483,6 +87824,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "wII" = (
@@ -86537,6 +87879,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -86631,6 +87974,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -86655,6 +87999,7 @@
 /obj/structure/noticeboard/chaplain{
 	pixel_y = 32
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -86691,6 +88036,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"xmW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/cmf_room)
 "xnL" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -86803,6 +88152,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"xxx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge)
+"xyc" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/processing)
 "xAg" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,1"
@@ -86854,6 +88211,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"xGw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/mixing)
 "xGD" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -87010,8 +88371,13 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
+"xQc" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/starboard)
 "xQr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -87159,6 +88525,10 @@
 /obj/structure/lattice,
 /turf/environment/space,
 /area/space)
+"yam" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/science)
 "yaV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
@@ -87195,6 +88565,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"yfb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/server)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -92478,7 +93852,7 @@ bjC
 inL
 baT
 bOt
-inL
+hFV
 aaa
 aaa
 aaa
@@ -93503,10 +94877,10 @@ aGy
 aGy
 aaa
 aaa
-odL
+oRL
 aGU
 aIm
-odL
+oRL
 aaa
 aaa
 aXZ
@@ -96086,7 +97460,7 @@ aXZ
 aXZ
 aXZ
 apT
-apT
+tIw
 apT
 aCR
 atE
@@ -96362,7 +97736,7 @@ bgj
 apT
 xnL
 xnL
-apT
+tIw
 btD
 btD
 btD
@@ -96587,7 +97961,7 @@ aGy
 aGy
 aaa
 aaa
-odL
+oRL
 aGU
 aIm
 odL
@@ -96873,7 +98247,7 @@ bgj
 bgj
 bgj
 bgj
-apT
+tIw
 uDb
 bXU
 aEb
@@ -97632,22 +99006,22 @@ aXZ
 aXZ
 mhC
 aGp
-apT
+tIw
 aYx
 bWv
-xnL
+sdV
 aDy
 aYx
 apT
 aYx
 cxD
-xnL
-apT
+sdV
+tIw
 aYx
 cKo
 bwe
 aJK
-apT
+tIw
 aaa
 btD
 btD
@@ -97889,7 +99263,7 @@ aXZ
 aXZ
 apT
 aGj
-apT
+tIw
 bWw
 bTo
 bTo
@@ -98144,7 +99518,7 @@ bOx
 bOx
 bOx
 aHw
-apT
+tIw
 aGp
 apT
 wwg
@@ -98415,7 +99789,7 @@ bgP
 bhd
 bHe
 bHe
-bio
+fni
 bIn
 bio
 bio
@@ -98643,7 +100017,7 @@ aKJ
 aKJ
 aaa
 aaa
-apT
+tIw
 bDP
 atE
 aJT
@@ -98666,8 +100040,8 @@ ajb
 vaa
 bHe
 bll
-bHe
-bHe
+rCP
+rCP
 bHe
 bHe
 hJt
@@ -99164,7 +100538,7 @@ aJW
 ajb
 uMv
 apE
-bsG
+cvQ
 bfh
 bHe
 bfi
@@ -100720,7 +102094,7 @@ aOb
 aQq
 aVO
 aZM
-qlZ
+tNm
 jYz
 jYz
 myC
@@ -101234,7 +102608,7 @@ aOI
 aRi
 aWO
 aZQ
-qlZ
+tNm
 xoX
 rXf
 bmA
@@ -101470,7 +102844,7 @@ rOr
 aRn
 aRn
 aRn
-apT
+tIw
 btv
 aWu
 xrW
@@ -101500,9 +102874,9 @@ khG
 tbS
 xQr
 bio
+fni
 bio
-bio
-bio
+fni
 bio
 bio
 gGO
@@ -101715,12 +103089,12 @@ apW
 qXB
 apW
 aXX
+kqH
 aRn
 aRn
 aRn
-aRn
-aRn
-aRn
+kqH
+kqH
 apy
 apy
 baR
@@ -101748,7 +103122,7 @@ aFg
 aRp
 aWV
 avg
-aFg
+voI
 aFg
 aFg
 qmV
@@ -101965,12 +103339,12 @@ aaa
 aYA
 hIb
 hIb
-aRn
+kqH
 hIb
 hIb
 aRn
 dDb
-aRn
+kqH
 bqP
 aYA
 bqO
@@ -101998,7 +103372,7 @@ bhr
 bku
 xeC
 bmW
-aSM
+mdE
 qAF
 nLo
 aFg
@@ -102018,7 +103392,7 @@ bxC
 byS
 bzs
 uIO
-uIO
+tfR
 bCt
 wnL
 nMG
@@ -102498,7 +103872,7 @@ boz
 bqW
 bsg
 aYg
-apT
+tIw
 btx
 aWu
 xrW
@@ -102509,16 +103883,16 @@ aSP
 aSP
 aSP
 aSP
+wtX
 aSP
-aSP
-aSM
+mdE
 aSM
 ncT
 aEM
 aFg
 aSa
 kwS
-aYD
+bxz
 bxz
 bxz
 ooW
@@ -102733,7 +104107,7 @@ aRn
 aRn
 aRn
 aRn
-aRn
+kqH
 aVq
 aVq
 aYe
@@ -102748,14 +104122,14 @@ aYe
 aYe
 aVq
 tWb
+kqH
 aRn
 aRn
 aRn
-aRn
-aRn
+kqH
 tPb
 aRn
-apT
+tIw
 apT
 bbv
 cEp
@@ -102789,8 +104163,8 @@ bxz
 bFS
 bAh
 uIO
-uIO
-uIO
+tfR
+tfR
 vQD
 gWa
 euT
@@ -103024,7 +104398,7 @@ aYb
 beJ
 arB
 qoN
-aSP
+wtX
 bBw
 ixO
 qAF
@@ -103288,7 +104662,7 @@ qAF
 vdm
 aFg
 bcf
-bxz
+mxv
 bba
 vIi
 pal
@@ -103499,7 +104873,7 @@ aaa
 aaa
 aaa
 aaa
-aRn
+kqH
 fbb
 aSf
 aUV
@@ -103545,7 +104919,7 @@ nws
 aSM
 aFg
 aFg
-aFg
+voI
 aFg
 aFg
 aFg
@@ -103560,7 +104934,7 @@ byq
 bze
 bAl
 uIO
-uIO
+tfR
 bCt
 lcO
 kZC
@@ -103776,14 +105150,14 @@ bpj
 brl
 aVq
 aJL
-aFG
+jGJ
 aFG
 jHM
-aFG
+jGJ
 aNS
 aPf
 aNS
-aFG
+jGJ
 aFG
 bbw
 msb
@@ -103791,7 +105165,7 @@ bmT
 boc
 bwD
 bEm
-beY
+aQX
 beY
 beY
 tMk
@@ -103806,7 +105180,7 @@ bEW
 bEW
 aFg
 uhJ
-bFS
+rMo
 ofm
 vBO
 ggb
@@ -103815,7 +105189,7 @@ hne
 lLb
 aMg
 bzg
-aFg
+voI
 myS
 aah
 aah
@@ -104019,7 +105393,7 @@ aQJ
 aQJ
 asb
 aRn
-aRn
+kqH
 aRn
 aYo
 bmP
@@ -104048,10 +105422,10 @@ bhj
 aqg
 bxs
 aRm
-biv
+fzi
 bfb
 biv
-aSP
+wtX
 aSM
 kFh
 aSM
@@ -104072,7 +105446,7 @@ ofm
 bTT
 aFg
 bzj
-aFg
+voI
 aah
 aah
 aah
@@ -104275,18 +105649,18 @@ auf
 aQJ
 aQJ
 bjL
-aRn
+kqH
 bmQ
 aRn
 aRn
+kqH
+aRn
+kqH
 aRn
 aRn
+kqH
 aRn
-aRn
-aRn
-aRn
-aRn
-aRn
+kqH
 aIl
 aRn
 aRn
@@ -104319,16 +105693,16 @@ spt
 aSM
 brd
 brd
+rYQ
 brd
-brd
-brd
+rYQ
 brd
 bsD
 shv
 ofm
 lab
 aFg
-aFg
+voI
 aFg
 aah
 aah
@@ -104527,7 +105901,7 @@ aah
 aah
 aaa
 aaa
-aRn
+kqH
 anj
 aTJ
 bOM
@@ -104565,7 +105939,7 @@ aZK
 aZK
 aZK
 lkl
-aSP
+wtX
 itt
 aOY
 aSM
@@ -104816,7 +106190,7 @@ aFG
 bck
 qEb
 beb
-aSP
+wtX
 bBp
 bES
 aVt
@@ -105039,8 +106413,8 @@ akD
 aah
 aaa
 aah
-acG
-acG
+eQf
+eQf
 acG
 anx
 apN
@@ -105075,7 +106449,7 @@ aTd
 eKs
 aNi
 aNi
-aNi
+ofK
 aNi
 aNi
 aNi
@@ -105085,7 +106459,7 @@ aNi
 aNi
 aNi
 aSM
-aSM
+mdE
 aSM
 uyE
 bcE
@@ -105553,9 +106927,9 @@ aeZ
 aah
 aaa
 aah
-acG
-acG
-acG
+eQf
+eQf
+eQf
 aoZ
 apM
 apm
@@ -105580,9 +106954,9 @@ aOr
 aGW
 aFL
 aFL
+gqN
 aFL
-aFL
-aFL
+gqN
 aFL
 bbJ
 bdM
@@ -105602,7 +106976,7 @@ gWz
 pVE
 rku
 bDk
-brd
+rYQ
 aYl
 bEl
 bcw
@@ -105812,7 +107186,7 @@ aaa
 aah
 aaa
 aah
-acG
+eQf
 atI
 atI
 atI
@@ -105831,7 +107205,7 @@ clm
 prb
 aJX
 aWD
-aGW
+rrO
 ait
 cnw
 aPL
@@ -105854,14 +107228,14 @@ aVg
 aVg
 aZs
 ayy
-aNi
+ofK
 aNi
 aNi
 aNi
 bDk
 brd
 brd
-brd
+rYQ
 brd
 brd
 brd
@@ -106114,7 +107488,7 @@ aFJ
 aNi
 kFb
 bmC
-aNi
+ofK
 bDk
 pNN
 kGX
@@ -106125,7 +107499,7 @@ bNk
 eqq
 bvq
 bvV
-bNk
+nFy
 bNk
 aaa
 aaa
@@ -106345,7 +107719,7 @@ clm
 aJR
 aMp
 atQ
-aGW
+rrO
 aNb
 aOs
 aPO
@@ -106842,16 +108216,16 @@ aaa
 aaa
 aaa
 aah
+rzt
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
+rzt
 avp
-gqE
-gqE
-gqE
-gqE
-gqE
-gqE
-avp
-avp
-avp
+rzt
 avp
 avp
 avp
@@ -106883,7 +108257,7 @@ fmP
 bcq
 bcq
 aNi
-aNi
+ofK
 aNi
 aNi
 gYf
@@ -107129,7 +108503,7 @@ aYY
 bdv
 coa
 tpw
-tpw
+iHG
 vWU
 awq
 aEJ
@@ -107153,7 +108527,7 @@ bNk
 xVq
 mtS
 lqO
-bNk
+nFy
 aBd
 aaa
 aaa
@@ -107376,7 +108750,7 @@ aKc
 aGW
 aGW
 aGW
-aGW
+rrO
 aFL
 aSt
 aJk
@@ -107624,12 +108998,12 @@ awh
 awh
 awh
 awh
-avp
+rzt
 avp
 avp
 aHn
 avp
-avp
+rzt
 avp
 cnx
 cnx
@@ -107643,20 +109017,20 @@ gBX
 bdv
 bdZ
 bmY
-aMZ
+pUW
 aMZ
 aMZ
 aMZ
 aDd
 oMQ
 oGL
-aMZ
+pUW
 pgZ
 aNv
 byQ
 bDp
 bDp
-bDp
+lCU
 bDp
 bDp
 bDp
@@ -107667,7 +109041,7 @@ bNk
 mTP
 mtS
 izb
-bNk
+nFy
 bNk
 aaa
 aaa
@@ -107887,7 +109261,7 @@ aie
 aig
 nPb
 aKe
-avp
+rzt
 qJb
 cny
 aFL
@@ -107911,16 +109285,16 @@ ezx
 pvI
 aMX
 aOJ
-bDp
+lCU
 bEp
 bHC
 bIM
 bJX
 rnx
-bDp
+lCU
 bdE
 tgJ
-bNk
+nFy
 bsT
 mtS
 lqO
@@ -108401,14 +109775,14 @@ aIv
 aHs
 aIx
 aKg
-avp
+rzt
 cnt
 cnz
 aFL
+gqN
 aFL
 aFL
-aFL
-aFL
+gqN
 aFL
 aFL
 akt
@@ -108434,7 +109808,7 @@ asp
 avr
 wZc
 bDk
-bNk
+nFy
 btH
 lqO
 bwa
@@ -108659,7 +110033,7 @@ aii
 aIy
 aIE
 avp
-avp
+rzt
 aOz
 aOz
 aQZ
@@ -108682,11 +110056,11 @@ aMZ
 aAf
 aLK
 aYy
-bDp
+lCU
 bEq
 bHO
 bJa
-bDp
+lCU
 bDp
 bDp
 bEW
@@ -108936,12 +110310,12 @@ aAX
 aMZ
 aMZ
 aMZ
-aNi
+ofK
 aNi
 aNi
 bDp
 bDp
-bDp
+lCU
 bDp
 bDp
 gYZ
@@ -108953,13 +110327,13 @@ gib
 bvB
 qTO
 bNk
+nFy
 bNk
 bNk
 bNk
 bNk
 bNk
-bNk
-bNk
+nFy
 aaa
 aah
 aaa
@@ -108985,7 +110359,7 @@ aUb
 aUb
 bIZ
 bIZ
-bIZ
+fak
 aZA
 bIZ
 bIZ
@@ -109426,7 +110800,7 @@ awh
 vwg
 clT
 aGd
-avp
+rzt
 aIH
 aKm
 aMO
@@ -109463,7 +110837,7 @@ vWx
 oUI
 pAG
 bNk
-bNk
+nFy
 bvE
 kNq
 bNk
@@ -109502,7 +110876,7 @@ nIb
 clf
 csJ
 ctZ
-bIZ
+fak
 cfb
 bQl
 bIZ
@@ -109514,11 +110888,11 @@ cAW
 ciY
 cAW
 cAW
+dmm
 ltU
 ltU
 ltU
-ltU
-ltU
+dmm
 ltU
 ltU
 aah
@@ -109669,26 +111043,26 @@ aaa
 aaa
 aaa
 aah
-avp
+rzt
 gqE
 gqE
 gqE
 gqE
 gqE
 gqE
+rzt
+avp
+rzt
 avp
 avp
 avp
-avp
-avp
-avp
-avp
+rzt
 avp
 aHx
 agO
 agO
 agO
-aOz
+sOa
 aQh
 aRd
 aSG
@@ -109714,7 +111088,7 @@ bDn
 bDn
 bDn
 bGQ
-bDn
+rLS
 bDn
 bDn
 bDn
@@ -109726,7 +111100,7 @@ bvH
 bNk
 bNk
 bNk
-bNk
+nFy
 bNk
 bNk
 ybN
@@ -109741,7 +111115,7 @@ cgO
 bZZ
 bZZ
 bZZ
-cap
+sAW
 aah
 aaa
 aaa
@@ -109965,9 +111339,9 @@ aMZ
 beo
 aGn
 aGn
+vas
 aGn
-aGn
-bDn
+rLS
 bEu
 bEs
 bED
@@ -110014,7 +111388,7 @@ cMp
 cIC
 bIZ
 bIZ
-bIZ
+fak
 bIZ
 bIZ
 cfe
@@ -110206,10 +111580,10 @@ alZ
 aOP
 azj
 aOz
+sOa
 aOz
 aOz
-aOz
-aOz
+sOa
 bdN
 bdZ
 npd
@@ -110217,7 +111591,7 @@ aMZ
 aMZ
 awO
 aDd
-aMZ
+pUW
 aET
 bmx
 aTH
@@ -110261,7 +111635,7 @@ aaa
 aaa
 aaa
 aaa
-bIZ
+fak
 cyz
 mnb
 cGR
@@ -110269,7 +111643,7 @@ cjQ
 cMl
 cMq
 coV
-bIZ
+fak
 bmc
 bmc
 bmo
@@ -110512,7 +111886,7 @@ cbB
 bZZ
 bZZ
 bZZ
-cap
+sAW
 aah
 aaa
 aaa
@@ -110715,13 +112089,13 @@ baE
 bhI
 alZ
 aCq
+mRV
 aCq
 aCq
 aCq
+mRV
 aCq
-aCq
-aCq
-aCq
+mRV
 aCq
 aCq
 bdQ
@@ -110744,7 +112118,7 @@ bEs
 bFR
 bDn
 bDn
-bDn
+rLS
 bDn
 aSM
 aSM
@@ -110777,7 +112151,7 @@ aaa
 aaa
 bIZ
 bIZ
-bIZ
+fak
 nob
 nqb
 bIZ
@@ -110984,7 +112358,7 @@ aCq
 bdP
 aKd
 bgE
-aGn
+vas
 vWz
 ujL
 aNk
@@ -111050,10 +112424,10 @@ xLM
 bQl
 bQl
 cyw
+rcJ
 cyw
 cyw
-cyw
-cyw
+rcJ
 cyw
 cyw
 cyw
@@ -111061,7 +112435,7 @@ cyw
 bmM
 szj
 szj
-ltU
+dmm
 ckn
 ckn
 ckn
@@ -111253,9 +112627,9 @@ bHL
 gTX
 bAV
 bDn
+rLS
 bDn
-bDn
-bDn
+rLS
 bDn
 aSM
 bDk
@@ -111268,7 +112642,7 @@ qaV
 tFz
 pvb
 bxm
-cap
+sAW
 cij
 cuZ
 cbf
@@ -111314,7 +112688,7 @@ dKo
 bWJ
 hbs
 czH
-cyw
+rcJ
 olb
 cpV
 jli
@@ -111489,7 +112863,7 @@ aHz
 aUZ
 aUZ
 aUZ
-aCq
+mRV
 mLE
 aCq
 mLE
@@ -111521,7 +112895,7 @@ bFW
 bFW
 bFW
 bFW
-bFW
+lTm
 bFW
 xqb
 bxl
@@ -111563,7 +112937,7 @@ bIZ
 aSL
 bQl
 xHP
-cyw
+rcJ
 cyx
 czd
 kiS
@@ -111573,7 +112947,7 @@ kiS
 rSY
 cyw
 ltU
-ltU
+dmm
 ltU
 ltU
 aaa
@@ -111773,13 +113147,13 @@ aEh
 bxg
 ate
 bDk
-bFW
+lTm
 bGn
 bGw
 bHp
 bHK
 bIO
-bFW
+lTm
 xqb
 bQl
 bHa
@@ -111789,9 +113163,9 @@ cfT
 cuZ
 cap
 sOh
+sAW
 cap
-cap
-cap
+sAW
 hnr
 hnr
 cap
@@ -111974,8 +113348,8 @@ aah
 alm
 alm
 wcY
-ahJ
-acJ
+eza
+qxS
 wcY
 alm
 agO
@@ -111998,7 +113372,7 @@ aNh
 aNh
 bLc
 bMU
-aCq
+mRV
 aPi
 hLb
 aFU
@@ -112012,7 +113386,7 @@ bci
 byj
 bfx
 bkj
-aGn
+vas
 neo
 dbM
 avN
@@ -112028,7 +113402,7 @@ bEU
 aGn
 bIp
 bHU
-aGn
+vas
 tgJ
 bFW
 bGo
@@ -112085,7 +113459,7 @@ czH
 czd
 hbR
 czH
-cyw
+rcJ
 aah
 aah
 aaa
@@ -112270,9 +113644,9 @@ aYd
 aQC
 bgE
 ayv
-dWf
+eFq
 avN
-dWf
+avN
 auv
 aNn
 aGk
@@ -112282,7 +113656,7 @@ dWf
 avN
 dWf
 bEM
-aGn
+vas
 aGn
 aGn
 aGn
@@ -112293,12 +113667,12 @@ bGy
 bHs
 bIl
 bIQ
-bFW
+lTm
 aMh
 bQl
 bIZ
 bIZ
-bIZ
+fak
 bIZ
 bIZ
 bIZ
@@ -112323,7 +113697,7 @@ bIZ
 bIZ
 bIZ
 jir
-jir
+vpx
 aPx
 bIZ
 bIZ
@@ -112526,11 +113900,11 @@ aCq
 aYk
 aKj
 bgb
-aGn
-avP
+vas
+aEh
 axC
 azO
-aGn
+vas
 baX
 beG
 bmy
@@ -112544,7 +113918,7 @@ lrT
 wAe
 wAe
 gvk
-bFW
+lTm
 bGr
 bGC
 bHt
@@ -112575,7 +113949,7 @@ bIZ
 cKa
 cKe
 bTd
-tlE
+rJB
 avh
 cGN
 tKb
@@ -112769,7 +114143,7 @@ cfv
 agO
 cjX
 bMV
-aCq
+mRV
 aJd
 aUZ
 aVS
@@ -112783,10 +114157,10 @@ aCq
 byk
 aOX
 beb
-aGn
-tze
-uof
-eXz
+vas
+aEh
+azO
+azO
 aGn
 bhH
 beF
@@ -112809,9 +114183,9 @@ bHu
 bHu
 bFW
 bIZ
+fak
 bIZ
-bIZ
-bIZ
+fak
 bIZ
 cKa
 bBB
@@ -112847,15 +114221,15 @@ bPO
 bIZ
 bSi
 crH
-crH
+gLA
 crH
 cyw
-cyw
+rcJ
 dqn
 cyw
+rcJ
 cyw
-cyw
-cyw
+rcJ
 cyw
 aaa
 aah
@@ -113002,7 +114376,7 @@ afj
 akd
 akd
 akd
-akd
+xyc
 akd
 adK
 akd
@@ -113010,11 +114384,11 @@ ayr
 ayr
 ayr
 ayr
-ani
+wjw
 ani
 ani
 aAz
-ani
+wjw
 ayr
 aqd
 alZ
@@ -113028,14 +114402,14 @@ bLd
 dgb
 aKo
 aCq
+mRV
 aCq
 aCq
 aCq
 aCq
 aCq
-aCq
-aCq
-aCq
+mRV
+mRV
 aCq
 byl
 tqo
@@ -113053,23 +114427,23 @@ aGn
 aGn
 aGn
 aGn
-aSM
+mdE
 bDo
+mdE
 aSM
 aSM
-aSM
-aMR
+gGD
 rzr
 udd
 beM
 beM
 bJM
-aMR
+gGD
 aMS
 aOe
 bAf
 rCb
-bIZ
+fak
 bIZ
 bBx
 bCE
@@ -113103,7 +114477,7 @@ cJZ
 gHx
 bIZ
 lcG
-crH
+gLA
 cyg
 cAC
 cCm
@@ -113113,7 +114487,7 @@ ead
 bVt
 bdH
 iLC
-crH
+gLA
 aaa
 aaa
 aah
@@ -113272,7 +114646,7 @@ apq
 asu
 axL
 aBJ
-ayr
+dKs
 alZ
 alZ
 alZ
@@ -113512,7 +114886,7 @@ aaa
 acX
 acX
 acX
-acX
+poG
 adJ
 ajA
 ajd
@@ -113530,7 +114904,7 @@ axL
 asF
 aBT
 ayr
-ayr
+dKs
 ayr
 ayr
 ayr
@@ -113554,7 +114928,7 @@ bBf
 beq
 bfy
 bgL
-bhJ
+ucs
 bjQ
 blR
 blR
@@ -113583,7 +114957,7 @@ cro
 cro
 bxT
 aBc
-bIZ
+fak
 bKj
 bBD
 bCE
@@ -113790,11 +115164,11 @@ aFv
 aNd
 bLn
 bMZ
-ayr
+dKs
 aru
 axT
 aKY
-agO
+gar
 bLk
 aYi
 aCu
@@ -113811,7 +115185,7 @@ aCu
 beK
 aKx
 bbo
-bbo
+iZk
 bbo
 bbo
 bbo
@@ -113819,7 +115193,7 @@ aMN
 aKx
 bbo
 bbo
-aGs
+sfR
 bbo
 bbo
 bbo
@@ -114034,7 +115408,7 @@ adH
 cYb
 alb
 adM
-ani
+wjw
 ani
 ani
 akP
@@ -114057,7 +115431,7 @@ aYi
 aCu
 aCv
 aDF
-aCu
+kKd
 aFW
 aCv
 aCu
@@ -114071,7 +115445,7 @@ xYD
 aNU
 vbW
 vbW
-aNU
+jgg
 aPv
 aKx
 iYb
@@ -114083,7 +115457,7 @@ bgC
 bcO
 bcO
 bcO
-bnN
+fPa
 bpx
 bnN
 bnN
@@ -114131,7 +115505,7 @@ uoD
 nQw
 bQl
 bQl
-crH
+gLA
 ogb
 wrF
 cuf
@@ -114306,18 +115680,18 @@ axL
 bNh
 ayr
 agO
-agO
+ucZ
 agO
 agO
 alZ
 aYi
-aCu
+kKd
 aCv
 aDF
 aCu
 aFX
 aCv
-aCu
+kKd
 aCv
 aCv
 aCv
@@ -114398,7 +115772,7 @@ xFm
 hXz
 hmh
 iPJ
-crH
+gLA
 aah
 cCr
 cCr
@@ -114537,7 +115911,7 @@ iuu
 abm
 aeP
 abo
-acX
+poG
 abB
 agJ
 afH
@@ -114561,7 +115935,7 @@ ani
 auh
 bLx
 bNr
-ayr
+dKs
 aqf
 atc
 cgt
@@ -114582,7 +115956,7 @@ aCu
 bCX
 aKx
 bbo
-aGZ
+dpZ
 aaa
 aaa
 aMR
@@ -114599,7 +115973,7 @@ bcO
 bcO
 jOb
 bpy
-bra
+kVG
 bra
 bow
 bsW
@@ -114607,7 +115981,7 @@ kwb
 bra
 bra
 bra
-bra
+kVG
 cwX
 aKx
 cxL
@@ -114615,9 +115989,9 @@ aMR
 aaa
 bLW
 bLW
+uof
 bLW
-bLW
-bLW
+uof
 aaa
 bIZ
 bJc
@@ -114651,10 +116025,10 @@ cuf
 cuf
 czN
 cip
+gLA
 crH
 crH
-crH
-crH
+gLA
 crH
 cCr
 cCr
@@ -114788,24 +116162,24 @@ aah
 bEP
 bEP
 bEP
-bEP
+sVZ
 bEP
 bEP
 adJ
 adr
 adJ
 acX
-adH
+iZq
 abC
 adH
-adH
+iZq
 adH
 adH
 adH
 akx
 aeo
 adM
-ani
+wjw
 ani
 ani
 aCZ
@@ -114815,7 +116189,7 @@ aqs
 ayt
 aCs
 ani
-ani
+wjw
 ani
 uql
 ayr
@@ -114868,9 +116242,9 @@ bra
 cwZ
 bxW
 cxO
-aMR
+gGD
 aaa
-bLW
+uof
 cpY
 csa
 ctT
@@ -115073,7 +116447,7 @@ aAH
 aCt
 atp
 aNo
-axN
+sOj
 axN
 axN
 axN
@@ -115099,7 +116473,7 @@ bbo
 aGZ
 aaa
 aaa
-aUG
+xxx
 iQb
 aTa
 fMX
@@ -115131,7 +116505,7 @@ bLW
 cgS
 cqr
 bKG
-bLW
+uof
 aaa
 bIZ
 bYd
@@ -115330,13 +116704,13 @@ are
 ash
 auQ
 aNr
-axN
+sOj
 axo
 bhX
 bzC
 aGx
 bHo
-axN
+sOj
 alZ
 aYi
 aCu
@@ -115369,7 +116743,7 @@ bfv
 bWe
 bcO
 bnN
-bnN
+fPa
 bra
 bHH
 bmm
@@ -115424,7 +116798,7 @@ czN
 wHd
 crH
 crH
-crH
+gLA
 crH
 cCc
 kbw
@@ -115563,15 +116937,15 @@ njb
 abt
 aaZ
 adM
+weB
 adM
 adM
-adM
-adM
+weB
 afp
 ahI
 aiM
 adM
-adM
+weB
 ajq
 akf
 amD
@@ -115612,7 +116986,7 @@ aKx
 bbo
 aGZ
 aaa
-aUG
+xxx
 bsV
 bwh
 bzD
@@ -115639,7 +117013,7 @@ bra
 kOb
 bDW
 bEd
-bLW
+uof
 bKl
 bLY
 bNz
@@ -115812,13 +117186,13 @@ aaa
 aaa
 aaa
 bEP
-bEP
+sVZ
 rQH
 ayK
 aal
 abf
 acU
-aaZ
+vrT
 adV
 aeK
 afc
@@ -115904,7 +117278,7 @@ bDB
 bEE
 cqr
 cqr
-bLW
+uof
 dJZ
 bPG
 ckI
@@ -116107,7 +117481,7 @@ bjH
 bHl
 bFU
 atG
-axN
+sOj
 alZ
 aYi
 hGb
@@ -116125,7 +117499,7 @@ aML
 aKx
 iAb
 aUG
-aUG
+xxx
 aUG
 btf
 bwj
@@ -116137,9 +117511,9 @@ ehb
 ekb
 epb
 eub
+ndH
 bcO
-bcO
-bcO
+ndH
 bcO
 bra
 bra
@@ -116149,7 +117523,7 @@ bra
 bra
 bzN
 bra
-bra
+kVG
 cxb
 ovb
 bfA
@@ -116348,7 +117722,7 @@ aki
 anC
 adM
 ani
-ani
+wjw
 ani
 aRP
 aou
@@ -116390,7 +117764,7 @@ bzH
 bEz
 bbz
 bbz
-bbz
+say
 bbz
 bbz
 bbz
@@ -116402,11 +117776,11 @@ aaa
 aah
 aaa
 aaa
-byw
+xmW
 fTn
 byt
 lJR
-byw
+xmW
 cxd
 ovb
 cxP
@@ -116446,7 +117820,7 @@ dka
 crH
 lcB
 cyk
-ogb
+skm
 cCH
 amy
 etF
@@ -116584,13 +117958,13 @@ aaj
 aao
 uia
 aao
-abl
+fZj
 sCX
 abJ
 aba
 acT
 abl
-abl
+fZj
 abl
 abl
 abl
@@ -116624,10 +117998,10 @@ axN
 bnA
 alZ
 aYi
-aCu
+kKd
 aCv
 aDN
-aCu
+kKd
 aGb
 aCv
 aCv
@@ -116687,7 +118061,7 @@ bVo
 fxg
 cJV
 chV
-chV
+lMy
 chV
 jal
 chV
@@ -116700,14 +118074,14 @@ crK
 crK
 vJB
 crK
-crK
+ruS
 fSs
 jIX
 cyK
 crH
 dWu
 crH
-crH
+gLA
 qwn
 crH
 cpU
@@ -116872,7 +118246,7 @@ asU
 aso
 auR
 avW
-axN
+sOj
 ayn
 bnJ
 bzI
@@ -116911,9 +118285,9 @@ bbz
 aah
 blW
 blW
+hzS
 blW
-blW
-blW
+hzS
 blW
 aah
 byw
@@ -116924,7 +118298,7 @@ byw
 cxe
 ovb
 bfA
-bLW
+uof
 aGw
 bJb
 bQf
@@ -116932,7 +118306,7 @@ bKp
 bQt
 cqr
 bOY
-bLW
+uof
 bhY
 bJZ
 bZE
@@ -117094,7 +118468,7 @@ aaa
 aah
 aah
 aah
-aaj
+nOS
 aao
 aaE
 aaT
@@ -117103,12 +118477,12 @@ abM
 ceU
 acg
 add
-abl
+fZj
 adY
 adv
 aep
 ahW
-abl
+fZj
 azw
 ahO
 aio
@@ -117117,7 +118491,7 @@ aeq
 ajw
 alI
 ali
-adJ
+bYO
 adJ
 adJ
 adJ
@@ -117139,11 +118513,11 @@ adW
 adW
 bNs
 aCu
+kKd
 aCu
 aCu
-aCu
-aCu
-aCr
+kKd
+grw
 aCr
 aCr
 aNU
@@ -117176,24 +118550,24 @@ aaa
 byw
 byw
 bwS
-byw
+xmW
 byw
 bgv
 ovb
 ljb
 bLW
 bLW
-bLW
+uof
 bLW
 bIA
 bLW
+uof
 bLW
 bLW
-bLW
+fSY
 bVo
 bVo
-bVo
-bVo
+fSY
 cag
 bTv
 bUX
@@ -117201,11 +118575,11 @@ bVo
 bIZ
 bIZ
 cdi
-czu
+lSW
 cgR
 qGz
 cWd
-bIZ
+fak
 bNi
 bIZ
 crK
@@ -117449,7 +118823,7 @@ cim
 cAZ
 sth
 cBL
-czc
+vNi
 czu
 cCk
 czu
@@ -117612,7 +118986,7 @@ aao
 aao
 aaF
 aao
-abl
+fZj
 abR
 dFb
 ctH
@@ -117712,7 +119086,7 @@ bOW
 bFY
 anm
 bVL
-bQG
+wzH
 bFY
 bUT
 bVE
@@ -117976,7 +119350,7 @@ gMs
 clt
 jmW
 cBU
-bIZ
+fak
 mnb
 bXX
 crK
@@ -118131,7 +119505,7 @@ abT
 aas
 aJb
 acu
-abl
+fZj
 aeG
 aeW
 aeh
@@ -118148,7 +119522,7 @@ alj
 adM
 ami
 aqE
-adJ
+bYO
 arC
 ati
 ati
@@ -118161,7 +119535,7 @@ aef
 aef
 aef
 aef
-aef
+vwL
 aef
 aef
 aef
@@ -118169,10 +119543,10 @@ bNM
 aef
 aef
 aef
-aef
+vwL
 aef
 aHl
-aHl
+jQK
 aHl
 aMR
 hZb
@@ -118194,7 +119568,7 @@ bcV
 bcV
 biQ
 aaa
-blW
+hzS
 bwH
 bim
 bre
@@ -118204,13 +119578,13 @@ aaa
 byA
 byA
 bxj
-byA
+nVn
 byA
 bgx
 aKx
 lkb
 bJe
-bJe
+jtW
 bJe
 bJe
 bJe
@@ -118220,7 +119594,7 @@ iHe
 bPH
 iHe
 bVJ
-cdV
+pNr
 bPc
 cat
 ckO
@@ -118235,21 +119609,21 @@ jFK
 clx
 clx
 bSP
-bSP
+hHl
 crK
 qwt
 cfk
 lsD
 crK
 crK
-crK
+ruS
 cfz
 pcJ
 cyK
 crH
 czV
 crH
-crH
+gLA
 qwn
 crH
 oMx
@@ -118383,7 +119757,7 @@ aCN
 aEH
 aEf
 aIX
-abl
+fZj
 abS
 aar
 ctH
@@ -118455,7 +119829,7 @@ blW
 blW
 blW
 blW
-blW
+hzS
 blW
 aah
 byA
@@ -118466,7 +119840,7 @@ byA
 aIR
 aKx
 bht
-bJe
+jtW
 bKv
 bMh
 bNH
@@ -118478,7 +119852,7 @@ bVG
 bVv
 tei
 cdV
-cdV
+pNr
 cal
 bTW
 bQK
@@ -118502,7 +119876,7 @@ cmB
 rcb
 xRo
 jkp
-ogb
+skm
 cCO
 cLS
 evT
@@ -118675,11 +120049,11 @@ apC
 bBH
 awT
 awT
+avP
+avP
 awT
 awT
-awT
-awT
-awT
+avP
 awT
 awT
 awT
@@ -118930,7 +120304,7 @@ avF
 cea
 cea
 aBe
-awT
+avP
 awM
 awM
 awM
@@ -118940,10 +120314,10 @@ awM
 awT
 bOH
 bOP
-awT
+avP
 bQC
 bRg
-awT
+avP
 aeJ
 aef
 caq
@@ -118958,7 +120332,7 @@ btJ
 bwq
 bBr
 bEA
-bbz
+say
 bbz
 bbz
 bbz
@@ -118972,11 +120346,11 @@ aaa
 aah
 aaa
 aaa
-byA
+nVn
 byD
 bzX
 bBR
-byA
+nVn
 cxi
 aKx
 lbb
@@ -118984,7 +120358,7 @@ bJe
 biT
 bMj
 aJr
-bJe
+jtW
 bHT
 cdV
 bSR
@@ -119152,14 +120526,14 @@ aaa
 aAu
 aax
 aaL
-aaj
+nOS
 aJf
 aQG
 abe
 abq
 abh
 adB
-aaV
+wEW
 adi
 ack
 cdJ
@@ -119180,12 +120554,12 @@ afV
 aod
 aoz
 arJ
-cea
+pck
 cea
 bmu
 aui
 awv
-cea
+pck
 aBe
 awT
 azG
@@ -119209,7 +120583,7 @@ aMN
 aKx
 iBb
 aUG
-aUG
+xxx
 aUG
 btY
 bwr
@@ -119225,13 +120599,13 @@ bdc
 bdc
 bdc
 bdc
+lfQ
 bdc
 bdc
-bdc
 byE
 byE
 byE
-byE
+fYY
 byE
 byE
 aIR
@@ -119481,11 +120855,11 @@ bdT
 bkv
 bfO
 bnY
-bpL
+vLg
 bAs
 bDC
 agK
-byE
+fYY
 bpH
 byF
 bzY
@@ -119663,7 +121037,7 @@ cAd
 cAd
 cAd
 aaV
-aaV
+wEW
 aaV
 aaV
 aaV
@@ -119711,10 +121085,10 @@ awT
 awT
 awT
 bPq
-awT
+avP
 bQF
 awT
-awT
+avP
 chY
 aef
 aOe
@@ -119724,7 +121098,7 @@ aKx
 aRR
 aGZ
 aaa
-aUG
+xxx
 bub
 bwt
 bBE
@@ -119747,7 +121121,7 @@ bpE
 brZ
 bzZ
 bBT
-byE
+fYY
 bek
 bDW
 bgZ
@@ -119763,7 +121137,7 @@ cfW
 apA
 czn
 bPa
-bSV
+end
 ckw
 czE
 cBg
@@ -119968,7 +121342,7 @@ bNX
 bOC
 azz
 bPy
-azz
+dbN
 aAv
 azz
 aFj
@@ -120008,7 +121382,7 @@ byE
 bPp
 bxX
 ccT
-bJe
+jtW
 bKB
 cgr
 mLb
@@ -120212,10 +121586,10 @@ cea
 cea
 aZb
 cea
-cea
+pck
 cea
 aBe
-awT
+avP
 awQ
 awQ
 bIN
@@ -120239,7 +121613,7 @@ aRR
 aGZ
 aaa
 aaa
-aUG
+xxx
 iRb
 aSD
 aTg
@@ -120267,7 +121641,7 @@ bDW
 cxQ
 bJe
 ckL
-bJe
+jtW
 bJe
 bJe
 bEY
@@ -120277,7 +121651,7 @@ cgh
 cdF
 cds
 swb
-bSV
+end
 cEX
 caN
 dOS
@@ -120297,7 +121671,7 @@ rsM
 cko
 doK
 cvU
-crH
+gLA
 cts
 hRU
 fLt
@@ -120305,7 +121679,7 @@ bVM
 cCS
 dIT
 cJq
-crH
+gLA
 crH
 crH
 crH
@@ -120474,7 +121848,7 @@ aeJ
 aBe
 aef
 awT
-awT
+avP
 awT
 awT
 bMz
@@ -120483,7 +121857,7 @@ bOE
 bOK
 bPP
 aEa
-aEa
+dwO
 aEa
 aEa
 wYU
@@ -120535,7 +121909,7 @@ rMb
 bGN
 bSV
 bSV
-bSV
+end
 cbV
 cXS
 bSV
@@ -120548,14 +121922,14 @@ chq
 bSV
 bSV
 bSV
+end
 bSV
 bSV
 bSV
 bSV
 bSV
 bSV
-bSV
-bSV
+end
 bSV
 czh
 hTt
@@ -120690,7 +122064,7 @@ aaa
 cAd
 aaa
 aah
-aaV
+wEW
 bQb
 bQb
 aaV
@@ -120766,7 +122140,7 @@ biZ
 bfC
 bfC
 bgU
-bdc
+lfQ
 bpL
 bpL
 bpL
@@ -120815,7 +122189,7 @@ odb
 cur
 fBF
 vNR
-bSV
+end
 bSV
 crH
 crH
@@ -120958,7 +122332,7 @@ abx
 aav
 acM
 ach
-rnU
+swL
 rnU
 agg
 agg
@@ -120972,7 +122346,7 @@ agg
 alD
 akq
 kRb
-ahC
+pbi
 ahC
 ahC
 anz
@@ -120980,7 +122354,7 @@ apJ
 aqB
 arM
 cea
-cea
+pck
 cea
 cea
 aeJ
@@ -121001,7 +122375,7 @@ aBP
 aCE
 aDO
 aEw
-aEa
+dwO
 aFm
 aEa
 nMk
@@ -121226,7 +122600,7 @@ ahk
 aiV
 aiz
 agg
-adJ
+bYO
 alR
 adJ
 uUU
@@ -121256,7 +122630,7 @@ bPW
 aEa
 aGi
 aEa
-aEa
+dwO
 hIp
 aEa
 crb
@@ -121267,7 +122641,7 @@ mbQ
 aNU
 vbW
 vbW
-aNU
+jgg
 aPv
 bau
 iYb
@@ -121277,23 +122651,23 @@ bjW
 bme
 bki
 bdc
-bdc
+lfQ
 bdc
 bdc
 bdc
 bpL
-bpL
-bpL
+vLg
+vLg
 byE
 byE
 bso
 byE
 byE
-byE
+fYY
 aIR
 ovb
 bht
-cdA
+pNW
 aHq
 aIu
 sxb
@@ -121486,7 +122860,7 @@ agg
 akb
 aBe
 amM
-uUU
+htY
 amn
 ane
 ant
@@ -121501,7 +122875,7 @@ cyv
 aBe
 aOV
 aOV
-aOV
+aYD
 aOV
 aOV
 aOV
@@ -121521,7 +122895,7 @@ aEa
 bfp
 aKx
 aRR
-aRR
+pXh
 aRR
 aRR
 aRR
@@ -121723,12 +123097,12 @@ cAd
 aaa
 aaV
 aaV
+wEW
 aaV
 aaV
 aaV
-aaV
-aaV
-aaV
+wEW
+wEW
 aaV
 adj
 agg
@@ -121739,7 +123113,7 @@ cMW
 ahX
 aiY
 aix
-agg
+fBC
 aeJ
 aBe
 amL
@@ -121767,9 +123141,9 @@ aEG
 aEG
 aEG
 bQh
-aEa
+dwO
 thb
-aEa
+dwO
 aEa
 vCd
 oxG
@@ -121778,7 +123152,7 @@ aEa
 bfl
 aKT
 aIP
-aIP
+eYq
 aIP
 aIP
 aIP
@@ -121807,7 +123181,7 @@ cro
 cro
 bye
 bht
-cdA
+pNW
 swb
 aHk
 cce
@@ -121828,7 +123202,7 @@ snv
 snv
 snv
 bVS
-bSV
+end
 kif
 bVD
 cwe
@@ -122075,7 +123449,7 @@ aIA
 cdA
 cLk
 bLt
-bSV
+end
 bNO
 bNO
 cKs
@@ -122245,7 +123619,7 @@ adm
 aef
 cyv
 aeM
-agg
+fBC
 bLu
 aet
 ajf
@@ -122270,7 +123644,7 @@ aBe
 aeJ
 aeJ
 axW
-aOV
+aYD
 aBh
 aBh
 aBh
@@ -122283,7 +123657,7 @@ bON
 bQj
 aEa
 thb
-aEa
+dwO
 aEa
 thb
 aEa
@@ -122291,15 +123665,15 @@ aCD
 aEa
 cnN
 bFH
-bFH
+yam
 bFH
 bjy
-bjy
+kkG
 bjy
 aFV
 aFV
 bjy
-bjy
+kkG
 bjy
 bFG
 bDW
@@ -122311,19 +123685,19 @@ bkE
 bkE
 bkE
 bkE
-bkE
+fMB
 fwb
 bjO
 bxi
 bIS
+unx
 bIS
 bIS
 bIS
 bIS
 bIS
 bIS
-bIS
-bIS
+unx
 bIS
 cdA
 cdA
@@ -122525,7 +123899,7 @@ asA
 atF
 atW
 aOV
-aOV
+aYD
 aOV
 aOV
 aBh
@@ -122543,7 +123917,7 @@ thb
 tkb
 aEa
 aLt
-aEa
+dwO
 aLt
 aEa
 chC
@@ -122557,7 +123931,7 @@ bBF
 bBF
 bEG
 bHZ
-bjy
+kkG
 bev
 bOQ
 bfe
@@ -122795,7 +124169,7 @@ bOn
 bOn
 bOn
 bQu
-aEa
+dwO
 aEa
 aEa
 aEa
@@ -122847,9 +124221,9 @@ rOb
 rOb
 bSq
 bSV
+end
 bSV
-bSV
-bSV
+end
 bSV
 bRZ
 cgw
@@ -123075,7 +124449,7 @@ bIh
 byZ
 bbG
 bSs
-bkE
+fMB
 qkb
 bmj
 cvd
@@ -123107,7 +124481,7 @@ bTw
 bGb
 bPd
 bPZ
-bSV
+end
 bQT
 ciw
 bUt
@@ -123306,19 +124680,19 @@ aEG
 aEG
 aOV
 aOV
-aOV
+aYD
 aOV
 aOV
 aOV
 chC
 qoW
 aSK
-aSK
+pbC
 aVy
 aSK
 aSK
 aSK
-aSK
+pbC
 and
 blf
 bjy
@@ -123354,7 +124728,7 @@ bSv
 cCg
 bLF
 bLF
-bLF
+iZf
 ayH
 bLF
 bLF
@@ -123552,7 +124926,7 @@ aaa
 aaa
 aef
 asz
-aOV
+aYD
 aHP
 axg
 aEG
@@ -123575,7 +124949,7 @@ aVz
 aXd
 aRU
 aTF
-aSN
+mMw
 bhC
 cpx
 bjy
@@ -123585,7 +124959,7 @@ agX
 bbS
 bFx
 bjy
-bjy
+kkG
 byZ
 bbG
 bMv
@@ -123621,7 +124995,7 @@ cLj
 cdA
 cce
 bQa
-bSV
+end
 aVR
 bVD
 bUw
@@ -123788,9 +125162,9 @@ aaa
 aaa
 aaa
 afl
-afl
+uGk
 doG
-afl
+uGk
 afl
 asI
 aef
@@ -123818,11 +125192,11 @@ aKO
 aKO
 aQN
 ayh
-aOV
+aYD
 chC
 aHS
 aHS
-aHS
+ezo
 aHS
 aHS
 aHS
@@ -123853,7 +125227,7 @@ lAA
 bkE
 bkE
 bkE
-bkE
+fMB
 aGI
 btU
 bxi
@@ -123861,9 +125235,9 @@ bIS
 bIS
 bFM
 bIS
+unx
 bIS
-bIS
-bIS
+unx
 bIS
 bIS
 bLF
@@ -124077,13 +125451,13 @@ aKP
 tfb
 aOV
 chC
-aHS
+ezo
 aRE
 bNb
 xwC
 gUO
 tmb
-aSN
+mMw
 aUh
 aVA
 aXh
@@ -124360,14 +125734,14 @@ bLG
 bcb
 bbG
 cpX
-lmV
+eXz
 bjo
 bkH
 czt
 cwC
 cwC
 kmb
-lmV
+eXz
 bTK
 btU
 bsu
@@ -124386,7 +125760,7 @@ aHm
 bMB
 aHm
 bfQ
-bLF
+iZf
 cdA
 cdA
 cdA
@@ -124580,7 +125954,7 @@ aaa
 aaa
 aef
 asy
-aOV
+aYD
 ayZ
 azI
 aGo
@@ -124589,9 +125963,9 @@ aQj
 aCL
 aCL
 tgb
-aOV
+aYD
 chC
-aHS
+ezo
 cjL
 czf
 bWK
@@ -124612,12 +125986,12 @@ bjy
 bjy
 bjy
 bjy
-bjy
+kkG
 bLH
 bcb
 bbG
 cpX
-lmV
+eXz
 jHb
 bkH
 czz
@@ -124632,7 +126006,7 @@ aUa
 bAA
 bAP
 bKP
-bkV
+jbS
 bkV
 bkV
 bTc
@@ -124840,11 +126214,11 @@ asy
 aOV
 aOV
 aOV
-aOV
+aYD
 aOV
 aOV
 aDS
-aOV
+aYD
 aOV
 aOV
 chC
@@ -125624,24 +126998,24 @@ bRm
 bRm
 bAU
 bAU
-bAU
+rWK
 bAU
 bAU
 aVT
 mdr
-bAU
+rWK
 cAM
 nVQ
 bmI
 bmI
 bmI
 bmI
+mQf
+bjt
+mQf
 bjt
 bjt
-bjt
-bjt
-bjt
-bjt
+mQf
 bNd
 bbM
 cpX
@@ -125652,7 +127026,7 @@ ccu
 hBb
 cbb
 bAT
-lmV
+eXz
 lFb
 bth
 mQb
@@ -126387,7 +127761,7 @@ bGX
 aCl
 bFH
 aFa
-bRm
+iOk
 aHX
 aHX
 aLe
@@ -126440,13 +127814,13 @@ bJo
 bJo
 bJo
 bMX
+uCB
 bQR
 bQR
 bQR
 bQR
 bQR
-bQR
-bQR
+uCB
 cdA
 cdA
 cKT
@@ -126490,7 +127864,7 @@ coD
 clS
 cEL
 cEL
-cCW
+lan
 cCW
 cCW
 cCW
@@ -126669,7 +128043,7 @@ bxG
 bCv
 bGE
 bIL
-bjt
+mQf
 bNd
 bcb
 cpX
@@ -126679,7 +128053,7 @@ jXb
 eKb
 jCb
 gRb
-lmV
+eXz
 aCW
 lKb
 aIq
@@ -126693,7 +128067,7 @@ bkV
 bpn
 bJg
 bkV
-bxi
+eNZ
 boJ
 bfY
 bzo
@@ -126718,7 +128092,7 @@ rFb
 rRb
 rZb
 ckA
-ckA
+ptK
 pDK
 sIb
 pDK
@@ -126930,7 +128304,7 @@ bjt
 bNd
 bcb
 cpi
-bjk
+hgK
 bjp
 cwM
 cwC
@@ -126957,7 +128331,7 @@ aFY
 aFY
 bSQ
 aFY
-aFY
+iCV
 aaM
 cCh
 cGn
@@ -126974,7 +128348,7 @@ cmW
 sSb
 cmW
 sab
-oax
+jwn
 snb
 rFb
 rLb
@@ -127158,8 +128532,8 @@ bRf
 bRf
 bFH
 aEW
-bRm
-bRm
+iOk
+iOk
 bRm
 aLi
 bRm
@@ -127183,7 +128557,7 @@ blu
 cqg
 bGG
 bjt
-bjt
+mQf
 bNd
 bcb
 cki
@@ -127193,7 +128567,7 @@ bmv
 bnR
 bqb
 kdb
-lmV
+eXz
 bnm
 cNe
 bFh
@@ -127258,7 +128632,7 @@ clD
 cpm
 cmL
 cnA
-cCW
+lan
 aaa
 aaa
 cEY
@@ -127428,7 +128802,7 @@ aTn
 aXB
 bHx
 bOi
-bSz
+xGw
 bcl
 bfo
 bmI
@@ -127445,7 +128819,7 @@ bNd
 bcb
 bRF
 bjk
-bjk
+hgK
 bjk
 bjk
 bjk
@@ -127474,13 +128848,13 @@ bJm
 bJm
 bUz
 cEe
-bMF
+mDo
 bMF
 bMF
 acZ
 ckA
 ckA
-ckA
+ptK
 ckA
 ckA
 rlb
@@ -127488,7 +128862,7 @@ rxb
 bKs
 rTb
 scb
-oax
+jwn
 spb
 rIb
 bhu
@@ -127520,7 +128894,7 @@ cCW
 cFP
 cFP
 cFP
-cFP
+lcm
 cFP
 cFP
 cFP
@@ -127745,13 +129119,13 @@ ryb
 aky
 rUb
 sdb
-ckA
+ptK
 pDK
 sCb
 ckA
 sPb
 pDK
-ckA
+ptK
 aaa
 aaa
 aah
@@ -127946,15 +129320,15 @@ aIe
 bde
 bfF
 bEb
-bEb
+yfb
 bEb
 bEb
 bEb
 bxJ
 bCy
 bGT
-bxJ
-bxJ
+rGF
+rGF
 bNd
 bcb
 cpX
@@ -128002,7 +129376,7 @@ ckA
 alg
 ckA
 ckA
-ckA
+ptK
 sqb
 sDb
 ckA
@@ -128202,7 +129576,7 @@ cje
 cml
 bcr
 bfG
-bEb
+yfb
 bFp
 bru
 bIf
@@ -128215,7 +129589,7 @@ bxJ
 bNu
 bPo
 bJB
-bqm
+oCJ
 bqm
 dYb
 uhb
@@ -128232,7 +129606,7 @@ bwV
 bvR
 bDE
 cNh
-bxt
+vyh
 bxt
 bxt
 bxt
@@ -128519,7 +129893,7 @@ sfb
 ckA
 ssb
 sFb
-ckA
+ptK
 sFb
 ssb
 ckA
@@ -128542,7 +129916,7 @@ bHf
 cDl
 cDD
 cFJ
-cFP
+lcm
 cFP
 cnJ
 cnM
@@ -128695,7 +130069,7 @@ aah
 aah
 bRf
 bRf
-bRf
+ktT
 bRf
 bRf
 aDW
@@ -128713,10 +130087,10 @@ aTr
 aWe
 bOf
 aEt
-bSz
+xGw
 bco
 bfI
-bEb
+yfb
 cxx
 byz
 lgb
@@ -128767,7 +130141,7 @@ cLu
 bFo
 aah
 aah
-ckA
+ptK
 rpb
 bKi
 bMx
@@ -128806,7 +130180,7 @@ coA
 cFP
 cFP
 cpN
-cFP
+lcm
 cFP
 cFP
 cpu
@@ -128955,7 +130329,7 @@ aaa
 aaa
 aBA
 bFH
-bFH
+yam
 aEW
 bFH
 bSz
@@ -128968,7 +130342,7 @@ bSz
 bSz
 bSz
 bSz
-bSz
+xGw
 bcH
 bSz
 bcN
@@ -128977,7 +130351,7 @@ bEb
 blH
 boY
 bzw
-bEb
+yfb
 lPa
 boG
 boG
@@ -129003,21 +130377,21 @@ caY
 bsz
 aNc
 aSk
+vyh
 bxt
 bxt
 bxt
-bxt
 bJm
 bJm
 bJm
 bJm
 bJm
-bJm
+qGI
 bJm
 bMF
+mDo
 bMF
-bMF
-bMF
+mDo
 bMF
 cFU
 cak
@@ -129084,7 +130458,7 @@ fAU
 bva
 cIe
 cCW
-cCW
+lan
 bxa
 byf
 agm
@@ -129243,7 +130617,7 @@ bLV
 bNJ
 bPt
 bSs
-bqm
+oCJ
 biu
 biM
 bkX
@@ -129320,7 +130694,7 @@ cqp
 cFP
 cFP
 nrz
-cFP
+lcm
 cFP
 cFP
 cqj
@@ -129473,7 +130847,7 @@ aJe
 aFa
 bGX
 aIi
-bSz
+xGw
 aLu
 aME
 aOc
@@ -129484,13 +130858,13 @@ cjC
 aUz
 aWc
 aXx
-bWa
+uPg
 uRB
 bfP
 bEb
 bEb
 bEb
-bEb
+yfb
 bEb
 bxP
 bCB
@@ -129505,11 +130879,11 @@ bJi
 bJi
 dkb
 bJi
+oTl
 bJi
+oTl
 bJi
-bJi
-bJi
-bJi
+oTl
 bJi
 bvR
 bvR
@@ -129570,7 +130944,7 @@ cCI
 cDx
 cmG
 cFJ
-cFP
+lcm
 cFP
 cmj
 cDj
@@ -129723,7 +131097,7 @@ axZ
 ayB
 aZX
 azg
-cbD
+jpw
 aBm
 bGX
 bGX
@@ -129745,13 +131119,13 @@ bah
 coU
 bfG
 beT
-bJJ
+ulx
 bpb
 brM
 bJJ
 bJJ
 bJJ
-bJJ
+ulx
 bJJ
 bJJ
 ccr
@@ -129964,14 +131338,14 @@ aaa
 cbD
 cbD
 cbD
+jpw
+cbD
+cbD
+jpw
 cbD
 cbD
 cbD
-cbD
-cbD
-cbD
-cbD
-cbD
+jpw
 cbD
 cbD
 axq
@@ -129988,7 +131362,7 @@ cbD
 aFo
 aFx
 bSz
-bSz
+xGw
 bSz
 bSz
 bSz
@@ -129998,7 +131372,7 @@ bSz
 aXF
 bSz
 bcL
-bSz
+xGw
 bcQ
 bgi
 biX
@@ -130010,7 +131384,7 @@ byh
 bOz
 bOz
 bOz
-bJJ
+ulx
 fEm
 bPu
 bMv
@@ -130222,11 +131596,11 @@ cbD
 cjq
 cjT
 ckC
-cjv
+qza
 cjq
 aNg
 ckC
-cjv
+qza
 cjq
 aZq
 ckC
@@ -130245,11 +131619,11 @@ cbD
 aVE
 cfc
 aJu
-bWa
+uPg
 bdi
 aND
 aQA
-boO
+tze
 aUE
 bOr
 aXE
@@ -130272,7 +131646,7 @@ bNe
 bPu
 bMv
 fJJ
-bJi
+oTl
 cyN
 dmb
 bTL
@@ -130295,8 +131669,8 @@ bHY
 bHY
 bHY
 bHY
-bHY
-bHY
+lGH
+lGH
 bHY
 bgc
 bgh
@@ -130542,7 +131916,7 @@ bJi
 aSh
 bAm
 qWb
-bxi
+eNZ
 bOV
 bFh
 aTt
@@ -130557,7 +131931,7 @@ bDS
 bHY
 bgd
 bgg
-bHY
+lGH
 bHY
 bHY
 cKZ
@@ -130604,7 +131978,7 @@ cFJ
 cFP
 cFP
 cFP
-cFP
+lcm
 cFP
 cFP
 cFP
@@ -130732,15 +132106,15 @@ aaa
 aah
 aaa
 aaa
-cbD
+jpw
 cjr
 ckC
 ckC
-cjv
+qza
 cjr
 ckC
 ckC
-cjv
+qza
 cjr
 ckC
 ckC
@@ -130764,15 +132138,15 @@ bdi
 aNP
 aQI
 bJC
-bJC
+gez
 bJC
 bal
 bJC
 bJC
+gez
 bJC
-bJC
-bJC
-bJC
+gez
+gez
 bJJ
 bpl
 brT
@@ -130781,12 +132155,12 @@ bym
 bOz
 bPX
 bOz
-bJJ
+ulx
 bNd
 bPA
 bMv
 cvT
-bJi
+oTl
 bgq
 drb
 fVb
@@ -130795,10 +132169,10 @@ bfX
 bgt
 bhb
 beR
-bJi
+oTl
+eNZ
 bxi
-bxi
-bxi
+eNZ
 bxi
 anW
 aSm
@@ -130856,7 +132230,7 @@ clO
 cmJ
 cmQ
 cnC
-cFJ
+iVV
 aaa
 aaa
 cEW
@@ -131009,15 +132383,15 @@ cey
 cxZ
 azt
 cbD
+jpw
 cbD
 cbD
 cbD
-cbD
-aEd
+sCi
 aFy
 aEd
 bWa
-bWa
+uPg
 bWa
 bWa
 bJC
@@ -131030,7 +132404,7 @@ bJC
 bTU
 bLi
 bLj
-bJJ
+ulx
 bpm
 brT
 buJ
@@ -131042,14 +132416,14 @@ bJJ
 bNu
 cuI
 cqi
-bVh
+xQc
 bJi
 bJi
 bqH
 bJi
+oTl
 bJi
-bJi
-bJi
+oTl
 bJi
 bJi
 bJi
@@ -131063,12 +132437,12 @@ aUU
 bDl
 bGg
 bKu
-bKu
+uvm
 sBb
-bKu
+uvm
 bQi
 bRt
-bHY
+lGH
 bTh
 cLg
 bHY
@@ -131239,11 +132613,11 @@ aaa
 aaa
 aaa
 aah
+jpw
 cbD
 cbD
-cbD
-cbD
-cbD
+jpw
+jpw
 aqL
 abz
 arV
@@ -131258,14 +132632,14 @@ cqU
 cnU
 ckF
 cuF
-cjv
+qza
 asQ
 coY
 ayE
 ctC
 cxZ
 awP
-cbD
+jpw
 aaa
 aaa
 aah
@@ -131277,7 +132651,7 @@ aJI
 aJI
 aJI
 aPl
-bJC
+gez
 aLo
 aUw
 aWk
@@ -131292,7 +132666,7 @@ axD
 ayP
 ayb
 bJJ
-bJJ
+ulx
 bJJ
 bJJ
 bJJ
@@ -131313,7 +132687,7 @@ bgo
 cak
 cDG
 cJo
-bxi
+eNZ
 bOc
 aSl
 bHY
@@ -131325,7 +132699,7 @@ bNU
 bPv
 bRN
 chb
-bHY
+lGH
 bHY
 bHY
 bHY
@@ -131507,7 +132881,7 @@ cey
 asx
 atm
 asx
-asx
+fRi
 auW
 atm
 asx
@@ -131544,10 +132918,10 @@ bLj
 bMJ
 bLj
 awV
+ulx
 bJJ
 bJJ
-bJJ
-bJJ
+ulx
 bJJ
 axl
 aAL
@@ -131571,17 +132945,17 @@ cBy
 cCp
 nOb
 bxi
-bxi
-bxi
+eNZ
+eNZ
+lGH
 bHY
 bHY
 bHY
+lGH
+lGH
 bHY
 bHY
-bHY
-bHY
-bHY
-bHY
+lGH
 bHY
 bej
 cak
@@ -131645,7 +133019,7 @@ aaa
 aaa
 aaa
 cEC
-cCW
+lan
 cEC
 cEC
 cEC
@@ -131791,7 +133165,7 @@ bpR
 akB
 aAS
 aPk
-bJC
+gez
 aTj
 aWg
 aWl
@@ -131813,7 +133187,7 @@ azN
 bOb
 bPC
 ctz
-aKs
+eRj
 aKs
 aKs
 aKs
@@ -132021,7 +133395,7 @@ cey
 asQ
 atz
 auj
-asQ
+ejG
 asQ
 atz
 asQ
@@ -132079,14 +133453,14 @@ fPM
 aSq
 cBk
 aSo
-aKs
+eRj
 cLy
 cak
 bhA
 aKs
+eRj
 aKs
-aKs
-aKs
+eRj
 aKs
 aEZ
 aHR
@@ -132267,11 +133641,11 @@ aaa
 aaa
 aaa
 aah
+jpw
 cbD
+jpw
 cbD
-cbD
-cbD
-cbD
+jpw
 arm
 arU
 arW
@@ -132292,7 +133666,7 @@ cey
 bdd
 cbD
 cbD
-cbD
+jpw
 cbD
 aaa
 aaa
@@ -132319,11 +133693,11 @@ bJC
 ayN
 bsa
 aIU
+mRT
 aIU
 aIU
 aIU
-aIU
-aIU
+mRT
 bab
 bPL
 bSA
@@ -132543,11 +133917,11 @@ nub
 aWp
 awa
 aWM
-cjv
+qza
 ayj
 cey
 cMz
-cbD
+jpw
 aaa
 aaa
 aah
@@ -132563,13 +133937,13 @@ aLw
 ayd
 aLb
 bJC
-bJC
+gez
 bJC
 aYa
 bJC
+gez
 bJC
-bJC
-bJC
+gez
 bJC
 bJC
 bJC
@@ -132792,11 +134166,11 @@ cbD
 cxT
 ckC
 nXs
-cjv
+qza
 cjr
 ckC
 ckC
-cjv
+qza
 cjr
 ckC
 ckC
@@ -133045,7 +134419,7 @@ aaa
 aaa
 aaa
 aaa
-cbD
+jpw
 nXs
 nXs
 rxg
@@ -133053,7 +134427,7 @@ cjv
 cjr
 ckC
 kZn
-cjv
+qza
 cjr
 ckC
 qoQ
@@ -133085,11 +134459,11 @@ aIU
 aIU
 aIU
 aIU
+mRT
 aIU
+mRT
 aIU
-aIU
-aIU
-aIU
+mRT
 aIU
 eRq
 aIU
@@ -133306,7 +134680,7 @@ cbD
 ckC
 iNb
 nXs
-cjv
+qza
 avx
 aYM
 ckC
@@ -133332,14 +134706,14 @@ bpR
 bnl
 aEY
 ayi
-qFO
+sQO
 aQD
 aRF
 aUL
 qFO
 koU
 aIU
-aIU
+mRT
 bQn
 asO
 bjr
@@ -133349,7 +134723,7 @@ bSE
 wxr
 blN
 bpw
-aIU
+mRT
 bse
 stq
 bOs
@@ -133561,15 +134935,15 @@ aaa
 aaa
 cbD
 cbD
+jpw
 cbD
 cbD
 cbD
 cbD
+jpw
 cbD
 cbD
-cbD
-cbD
-cbD
+jpw
 cbD
 cfw
 ayR
@@ -133850,8 +135224,8 @@ qFO
 aQF
 aPm
 aTx
-qFO
-aKv
+sQO
+koS
 aKv
 eCz
 bMe
@@ -133880,7 +135254,7 @@ mrb
 ecb
 aXN
 aKs
-aKs
+eRj
 aKs
 aKs
 bNQ
@@ -134139,7 +135513,7 @@ aXP
 ato
 ccq
 bNG
-aKs
+eRj
 aKs
 aKs
 aKs
@@ -134360,7 +135734,7 @@ aLE
 aLO
 aup
 aJN
-aKv
+koS
 aMe
 aSX
 aTo
@@ -134393,7 +135767,7 @@ ilb
 mtb
 bHv
 cIE
-aKs
+eRj
 cLF
 ary
 aKs
@@ -134623,7 +135997,7 @@ aUJ
 bHk
 aLY
 aLY
-aKv
+koS
 avm
 ePF
 bsw
@@ -134640,11 +136014,11 @@ aTs
 aTw
 aUT
 ueK
-aKs
+eRj
 bYM
 cvy
 ebb
-aKs
+eRj
 aKs
 bSC
 dLf
@@ -134653,7 +136027,7 @@ aKs
 aKs
 cIu
 arA
-aKs
+eRj
 bNp
 bNE
 bFo
@@ -134901,7 +136275,7 @@ aKs
 aKs
 aKs
 aKs
-aKs
+eRj
 bWm
 jbb
 oKb
@@ -135388,14 +136762,14 @@ aup
 aup
 aup
 aOS
+koS
 aKv
 aKv
 aKv
-aKv
-aKv
+koS
 bHn
 aKv
-aIU
+mRT
 bQn
 azS
 bao
@@ -135405,7 +136779,7 @@ wyS
 sUp
 wMu
 rjR
-aIU
+mRT
 juo
 pXY
 bOs
@@ -135647,7 +137021,7 @@ aup
 aOR
 aMi
 aOj
-aKv
+koS
 aTP
 aKB
 aLZ
@@ -135655,20 +137029,20 @@ aKv
 wLi
 wLi
 wLi
-wLi
+iVe
 bpO
 aQa
 caG
-aQa
+qNZ
 buR
 bsf
-aQa
+qNZ
 aQa
 aQa
 byZ
 bcb
 bhQ
-bWu
+uyb
 gFL
 gFL
 gFL
@@ -136196,7 +137570,7 @@ cCt
 bdn
 bZb
 bZc
-bFo
+cnS
 bAM
 jib
 jTb
@@ -136675,7 +138049,7 @@ aMi
 aRx
 aKM
 aPt
-aup
+jUo
 jBg
 bnc
 hUb
@@ -136949,11 +138323,11 @@ oyN
 oyN
 wpm
 kUt
-aQa
+qNZ
 aah
 aah
 aah
-bWu
+uyb
 bZk
 cdd
 aRO
@@ -136967,7 +138341,7 @@ cCJ
 cLR
 bfj
 eNb
-bFo
+cnS
 iFb
 jlb
 aVF
@@ -137198,14 +138572,14 @@ wjJ
 gMY
 wLi
 wLi
-wLi
+iVe
 aQa
-aQa
+qNZ
 kAR
 kAR
 kAR
 aQa
-aQa
+qNZ
 aQa
 aaa
 aaa
@@ -138245,11 +139619,11 @@ bWu
 htg
 cuN
 cxu
-cuE
+edq
 cuE
 cuE
 nHY
-bWu
+uyb
 aTX
 bWu
 aUX
@@ -138477,11 +139851,11 @@ aah
 aah
 aaa
 aaa
-wLi
+iVe
 wtw
 wtw
 wtw
-wLi
+iVe
 aah
 aaa
 aaa
@@ -138499,7 +139873,7 @@ aaa
 aaa
 aaa
 bWu
-bWu
+uyb
 gHG
 tfZ
 aXM

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -13860,8 +13860,8 @@
 	},
 /area/station/civilian/gym)
 "axC" = (
-/obj/item/device/flashlight/lamp/fir/special,
 /obj/item/weapon/present,
+/obj/item/device/flashlight/lamp/fir/special/alternative,
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "axD" = (

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -459,9 +459,9 @@
 /turf/unsimulated/floor,
 /area/centcom/specops)
 "aaS" = (
-/obj/structure/window/fulltile/reinforced/indestructible,
-/turf/unsimulated/floor,
-/area/centcom/control)
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/centcom/living)
 "aaT" = (
 /obj/structure/window/fulltile/reinforced/indestructible,
 /obj/item/decoration/garland,
@@ -869,6 +869,7 @@
 	name = "Command Airlock";
 	req_access = list(19)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac,
 /area/shuttle/escape/centcom)
 "abY" = (
@@ -1238,6 +1239,7 @@
 /obj/machinery/door/airlock/erokez/med{
 	name = "Medbay Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac/medbay,
 /area/shuttle/escape/centcom)
 "adg" = (
@@ -1267,6 +1269,7 @@
 	name = "Security Airlock";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac/sec2,
 /area/shuttle/escape/centcom)
 "adi" = (
@@ -1485,6 +1488,7 @@
 /area/shuttle/escape/centcom)
 "adM" = (
 /obj/machinery/computer/communications/evac,
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac,
 /area/shuttle/escape/centcom)
 "adN" = (
@@ -1606,6 +1610,7 @@
 /obj/structure/object_wall/evac{
 	icon_state = "5,17"
 	},
+/obj/item/decoration/snowflake,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "aee" = (
@@ -1699,6 +1704,7 @@
 /obj/machinery/door/airlock/erokez/eng{
 	name = "Engineering Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac,
 /area/shuttle/escape/centcom)
 "aeq" = (
@@ -1778,6 +1784,7 @@
 /obj/machinery/door/airlock/command{
 	name = "Thunderdome"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -1808,6 +1815,7 @@
 /obj/machinery/door/unpowered/shuttle/pod{
 	dock_tag = "shuttle_escape"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac,
 /area/shuttle/escape/centcom)
 "aeG" = (
@@ -1916,6 +1924,7 @@
 /obj/structure/object_wall/evac{
 	icon_state = "10,18"
 	},
+/obj/item/decoration/snowflake,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "aeU" = (
@@ -2047,6 +2056,7 @@
 /obj/structure/object_wall/evac{
 	icon_state = "5,16"
 	},
+/obj/item/decoration/garland,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "afk" = (
@@ -4552,6 +4562,7 @@
 /obj/structure/object_wall/evac{
 	icon_state = "5,13"
 	},
+/obj/item/decoration/snowflake,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "alh" = (
@@ -6821,6 +6832,7 @@
 	id = "ERTBase";
 	name = "ERT"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/specops)
 "apR" = (
@@ -7693,6 +7705,7 @@
 	dock_tag = "shuttle_escape";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac/sec2,
 /area/shuttle/escape/centcom)
 "arF" = (
@@ -9831,6 +9844,7 @@
 /obj/structure/object_wall/evac{
 	icon_state = "11,12"
 	},
+/obj/item/decoration/snowflake,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "avO" = (
@@ -13281,6 +13295,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -14279,12 +14294,14 @@
 /turf/simulated/shuttle/plating,
 /area/velocity)
 "aFj" = (
+/obj/item/decoration/snowflake,
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
 	},
 /area/shuttle/administration/centcom)
 "aFk" = (
 /obj/machinery/door/airlock/external,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/shuttle/administration/centcom)
 "aFn" = (
@@ -14645,6 +14662,7 @@
 	name = "General Access";
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/shuttle/administration/centcom)
 "aFZ" = (
@@ -14944,6 +14962,7 @@
 /obj/machinery/door/airlock/glass{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
@@ -18925,14 +18944,12 @@
 	},
 /area/custom/syndicate_mothership/elite_squad)
 "aPB" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Living Quarters";
-	req_access = list(105)
+/obj/structure/object_wall/standart{
+	icon_state = "wall3"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/living)
+/obj/item/decoration/snowflake,
+/turf/environment/space,
+/area/shuttle/administration/centcom)
 "aPC" = (
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/donut_box,
@@ -19125,6 +19142,7 @@
 	name = "Waiting Room";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -19139,6 +19157,7 @@
 	name = "Holding Facility";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -19447,6 +19466,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -19523,6 +19543,7 @@
 	icon_state = "8";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -20172,6 +20193,7 @@
 	name = "General Access";
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -23156,6 +23178,7 @@
 /obj/machinery/door/airlock/external{
 	dock_tag = "centcomm_admin"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -23593,9 +23616,7 @@
 /area/velocity)
 "ciz" = (
 /obj/item/weapon/present,
-/turf/unsimulated/floor{
-	icon_state = "vaultfull"
-	},
+/turf/unsimulated/floor/carpet/green,
 /area/centcom/holding)
 "cjb" = (
 /obj/machinery/door_control{
@@ -26373,12 +26394,9 @@
 	},
 /area/velocity)
 "gYJ" = (
-/obj/item/weapon/present,
-/turf/unsimulated/floor{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/centcom/holding)
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/centcom/specops)
 "gZb" = (
 /turf/unsimulated/floor{
 	dir = 1;
@@ -27669,6 +27687,7 @@
 /area/centcom/holding)
 "jQb" = (
 /obj/structure/mineral_door/wood,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},
@@ -27956,9 +27975,7 @@
 	},
 /area/centcom/holding)
 "kqb" = (
-/turf/unsimulated/floor{
-	icon_state = "vaultfull"
-	},
+/turf/unsimulated/floor/carpet/red,
 /area/centcom/holding)
 "krb" = (
 /turf/unsimulated/floor{
@@ -28150,6 +28167,7 @@
 "kMb" = (
 /obj/structure/table,
 /obj/item/weapon/present,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28157,6 +28175,7 @@
 "kNb" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28164,6 +28183,7 @@
 "kOb" = (
 /obj/structure/table,
 /obj/item/weapon/lighter/zippo,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28171,6 +28191,7 @@
 "kPb" = (
 /obj/structure/table,
 /obj/item/weapon/dice/d20,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28181,6 +28202,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28720,6 +28742,15 @@
 	},
 /turf/unsimulated/floor,
 /area/centcom/control)
+"mbC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/decoration/snowman,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration/centcom)
 "mcb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -29013,33 +29044,26 @@
 /area/centcom/tdome/tdomeobserve)
 "mHb" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/unsimulated/floor{
-	icon_state = "grass2"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/unsimulated/floor/snow,
 /area/centcom/evac)
 "mIb" = (
-/obj/structure/flora/ausbushes/pointybush,
-/turf/unsimulated/floor{
-	icon_state = "grass2"
-	},
+/obj/item/decoration/snowman,
+/turf/unsimulated/floor/snow,
 /area/centcom/evac)
 "mJb" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/unsimulated/floor{
-	icon_state = "grass2"
-	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/unsimulated/floor/snow,
 /area/centcom/evac)
 "mKb" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/unsimulated/floor{
-	icon_state = "grass2"
-	},
+/obj/structure/flora/bush,
+/turf/unsimulated/floor/snow,
 /area/centcom/evac)
 "mLb" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/unsimulated/floor{
-	icon_state = "grass2"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/unsimulated/floor/snow,
 /area/centcom/evac)
 "mMb" = (
 /obj/machinery/computer/security/telescreen,
@@ -29067,6 +29091,7 @@
 /area/shuttle/escape/centcom)
 "mQb" = (
 /obj/machinery/computer/shuttle,
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac,
 /area/shuttle/escape/centcom)
 "mQF" = (
@@ -29606,6 +29631,7 @@
 	opacity = 0
 	},
 /obj/structure/plasticflaps/explosion_proof,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/holding)
 "oab" = (
@@ -29619,6 +29645,7 @@
 	layer = 3.5
 	},
 /obj/structure/centcom_barrier,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/control)
 "obb" = (
@@ -29636,6 +29663,7 @@
 	dir = 4
 	},
 /obj/structure/plasticflaps/explosion_proof,
+/obj/item/decoration/tinsel,
 /obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/control)
@@ -29745,6 +29773,7 @@
 /obj/structure/object_wall/evac{
 	icon_state = "5,8"
 	},
+/obj/item/decoration/snowflake,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "oqb" = (
@@ -29829,6 +29858,7 @@
 /obj/structure/object_wall/evac{
 	icon_state = "11,16"
 	},
+/obj/item/decoration/garland,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "oBb" = (
@@ -30217,6 +30247,7 @@
 /area/shuttle/escape/centcom)
 "pyb" = (
 /obj/machinery/computer/crew/erokez,
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor/evac,
 /area/shuttle/escape/centcom)
 "pzb" = (
@@ -30252,12 +30283,14 @@
 /obj/structure/object_wall/evac{
 	icon_state = "5,9"
 	},
+/obj/item/decoration/garland,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "pGb" = (
 /obj/structure/object_wall/evac{
 	icon_state = "11,9"
 	},
+/obj/item/decoration/garland,
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "pHb" = (
@@ -30614,29 +30647,26 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/tdome)
 "tBw" = (
-/obj/item/device/flashlight/lamp/fir/special,
 /obj/item/weapon/present,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "neutral"
+/obj/item/device/flashlight/lamp/fir/special/alternative{
+	pixel_x = 16
 	},
+/turf/unsimulated/floor/carpet/green,
 /area/centcom/holding)
 "tKy" = (
 /obj/item/decoration/snowflake,
 /turf/unsimulated/wall,
 /area/custom/syndicate_mothership/droppod_garage)
 "tQg" = (
-/obj/item/weapon/present,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/centcom/holding)
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/centcom/prison)
 "tWq" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 4
@@ -30696,9 +30726,7 @@
 /area/velocity)
 "uWM" = (
 /obj/item/weapon/present,
-/turf/unsimulated/floor{
-	icon_state = "neutralcorner"
-	},
+/turf/unsimulated/floor/carpet/red,
 /area/centcom/holding)
 "vak" = (
 /obj/machinery/door/airlock/external{
@@ -30839,7 +30867,6 @@
 	},
 /area/velocity)
 "xKK" = (
-/obj/item/decoration/snowman,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -54422,7 +54449,7 @@ aDG
 bbi
 aBp
 aBp
-aBp
+gYJ
 aBp
 aBp
 aBp
@@ -54682,7 +54709,7 @@ ayY
 bfm
 bgb
 bwb
-aBp
+gYJ
 aBp
 aaM
 okm
@@ -55512,9 +55539,9 @@ aaM
 aaM
 aHv
 mHb
-mIb
+mKb
 mJb
-hWb
+mIb
 mKb
 mLb
 aHv
@@ -55697,20 +55724,20 @@ aaM
 aaM
 aBp
 aBp
-aBp
+gYJ
 bib
 bib
 bib
 bib
 bib
 aBp
+gYJ
 aBp
 aBp
+gYJ
 aBp
 aBp
-aBp
-aBp
-aBp
+gYJ
 aBp
 aaM
 aHv
@@ -55960,7 +55987,7 @@ aEK
 aEK
 aEK
 aBp
-aBp
+gYJ
 frb
 aFr
 aFr
@@ -56468,7 +56495,7 @@ aaM
 aaM
 aaM
 aaM
-aBp
+gYJ
 aCl
 aAE
 aCV
@@ -56718,10 +56745,10 @@ aaM
 aaM
 aaM
 aBp
+gYJ
 aBp
 aBp
-aBp
-aBp
+gYJ
 aBp
 aBp
 aBp
@@ -56982,7 +57009,7 @@ gbb
 gbb
 gbb
 frb
-aBp
+gYJ
 bib
 aAE
 aCV
@@ -56991,10 +57018,10 @@ aFp
 aBp
 aBp
 aBp
+gYJ
 aBp
 aBp
-aBp
-aBp
+gYJ
 aBp
 aBp
 aBp
@@ -57245,7 +57272,7 @@ aAE
 aCV
 aBQ
 aHN
-aBp
+gYJ
 aGt
 aLt
 aMl
@@ -57254,7 +57281,7 @@ azE
 azE
 aMl
 aFu
-aBp
+gYJ
 aBp
 aBp
 aaM
@@ -57513,7 +57540,7 @@ bIb
 bIb
 aMa
 aMe
-aBp
+gYJ
 aaM
 aGn
 aGn
@@ -57744,7 +57771,7 @@ aaM
 aaM
 aaM
 aaM
-aBp
+gYJ
 gAb
 fzb
 grb
@@ -58007,7 +58034,7 @@ hAb
 hab
 hjb
 aBp
-aBp
+gYJ
 aBp
 aBp
 aBp
@@ -58261,13 +58288,13 @@ aaM
 aaM
 aBp
 aBp
-aBp
+gYJ
 aBp
 aBp
 aBM
 aDD
 aCL
-aBp
+gYJ
 aDW
 aAE
 aCV
@@ -58284,7 +58311,7 @@ anv
 bKb
 azG
 aMv
-aBp
+gYJ
 aaM
 aaM
 aaM
@@ -58536,7 +58563,7 @@ bLb
 bib
 azR
 bfq
-aBp
+gYJ
 anv
 bLb
 azR
@@ -58787,7 +58814,7 @@ aAE
 aCV
 aBQ
 gLb
-aBp
+gYJ
 aHn
 bLb
 bib
@@ -59033,12 +59060,12 @@ aeD
 aeD
 aeD
 aeD
-aBp
+gYJ
 aBF
 hcb
 aAP
 aBm
-aBp
+gYJ
 apP
 aAD
 aBG
@@ -59053,7 +59080,7 @@ aBp
 aBp
 aBp
 aBp
-aBp
+gYJ
 aBp
 aBp
 aaM
@@ -59300,9 +59327,9 @@ aBp
 qFs
 apQ
 qFs
+gYJ
 aBp
-aBp
-aBp
+gYJ
 kEE
 azn
 aGv
@@ -59551,7 +59578,7 @@ aaM
 aBp
 aBp
 aBp
-aBp
+gYJ
 anv
 gtb
 fWb
@@ -59562,11 +59589,11 @@ aGp
 aBp
 aBp
 aBp
+gYJ
 aBp
+gYJ
 aBp
-aBp
-aBp
-aBp
+gYJ
 aBp
 aaM
 aaM
@@ -59817,7 +59844,7 @@ aDY
 aDY
 aBR
 aLE
-aBp
+gYJ
 azm
 azm
 azm
@@ -59843,7 +59870,7 @@ aAm
 iMb
 iSb
 jbb
-aAm
+aaS
 aaM
 aKu
 aaM
@@ -60062,7 +60089,7 @@ hYb
 lpG
 aBp
 aBp
-aBp
+gYJ
 aBp
 aBp
 aCS
@@ -60081,7 +60108,7 @@ bcT
 bcT
 bcT
 bcT
-aBp
+gYJ
 aBp
 aaM
 aaM
@@ -60353,7 +60380,7 @@ aJK
 aAm
 aJq
 aJK
-aAm
+aaS
 iNb
 iTb
 jcb
@@ -60603,11 +60630,11 @@ aIh
 aAm
 aAm
 eIp
-aAm
+aaS
 aAm
 eIp
 aAm
-aAm
+aaS
 eIp
 aAm
 aAm
@@ -61110,7 +61137,7 @@ ayU
 aEF
 aBG
 aBS
-aBp
+gYJ
 aIh
 iab
 aIh
@@ -61359,14 +61386,14 @@ aCV
 aCV
 aBQ
 bCb
-aBp
+gYJ
 aBp
 bfr
 ahQ
 aBp
+gYJ
 aBp
-aBp
-aBp
+gYJ
 aBp
 aHQ
 aIh
@@ -61602,11 +61629,11 @@ lpG
 gGb
 lpG
 afs
-aBp
+gYJ
 aBI
 aBI
 aBI
-aBp
+gYJ
 aCb
 aAD
 aBG
@@ -61628,17 +61655,17 @@ aBp
 bby
 ibb
 aIE
-aAm
+aaS
 aAm
 aAm
 aAm
 aKa
+aaS
 aAm
-aAm
-aAm
+aaS
 aLd
 aAm
-aAm
+aaS
 iNb
 iUb
 jdb
@@ -61881,7 +61908,7 @@ aBG
 aBG
 aBS
 aLM
-aBp
+gYJ
 aAm
 aAm
 aAm
@@ -61900,7 +61927,7 @@ iNb
 iNb
 iNb
 iNb
-aAm
+aaS
 aKu
 aaM
 aNs
@@ -62122,14 +62149,14 @@ bib
 bib
 aEl
 aBp
-aaR
+fMW
 aqf
-aaR
+fMW
 aBp
-aaR
+fMW
 aFQ
-aaR
-aBp
+fMW
+gYJ
 aBp
 aBp
 aBp
@@ -62372,7 +62399,7 @@ aaM
 aaM
 aaM
 aaM
-aBp
+gYJ
 aAY
 aAP
 aAP
@@ -62382,7 +62409,7 @@ aBp
 aDK
 aEG
 aEM
-aBp
+gYJ
 hkb
 aDY
 aBR
@@ -62390,10 +62417,10 @@ aBp
 aMk
 aMr
 aBp
+gYJ
 aBp
 aBp
-aBp
-aBp
+gYJ
 aBp
 aaM
 aaM
@@ -62402,7 +62429,7 @@ aaM
 aaM
 aAm
 aJu
-aJu
+dvN
 aJu
 aJu
 aJu
@@ -62411,7 +62438,7 @@ aLe
 aJu
 aJu
 aJu
-aJu
+dvN
 aJu
 aJu
 aJu
@@ -62635,7 +62662,7 @@ bib
 bib
 bib
 bmb
-aBp
+gYJ
 aDK
 aAE
 fVb
@@ -62915,7 +62942,7 @@ aaM
 aaM
 aaM
 aaM
-aaS
+ewk
 aJP
 aJP
 jWB
@@ -63145,11 +63172,11 @@ avI
 avI
 avI
 avI
+tQg
 avI
+tQg
 avI
-avI
-avI
-avI
+tQg
 aCq
 aAE
 fVb
@@ -63157,7 +63184,7 @@ aCM
 aAE
 aCV
 aBQ
-aaR
+fMW
 bfk
 bfk
 bfk
@@ -63172,7 +63199,7 @@ aaM
 aaM
 aaM
 aaM
-aaS
+ewk
 aJP
 aKe
 hyu
@@ -63199,9 +63226,9 @@ aON
 lDb
 doQ
 aSj
+doQ
 aSj
-aSj
-aSj
+doQ
 aSj
 aSj
 mqb
@@ -63414,7 +63441,7 @@ aCM
 aAE
 aCV
 aBQ
-aaR
+fMW
 bfk
 bfk
 bfv
@@ -63438,7 +63465,7 @@ aKp
 aLg
 aKp
 aKp
-aJu
+dvN
 aJu
 jgb
 aJP
@@ -63667,7 +63694,7 @@ avI
 aDK
 aAD
 aEO
-aBp
+gYJ
 aEe
 aEs
 aFo
@@ -63686,7 +63713,7 @@ aaM
 aBp
 aBp
 aBp
-aJu
+dvN
 aJP
 aKf
 aKp
@@ -63921,7 +63948,7 @@ avI
 fsb
 avI
 avI
-avI
+tQg
 avI
 aBp
 aBp
@@ -63961,11 +63988,11 @@ aJu
 aJu
 lmj
 jZb
-aOF
-kpb
-gYJ
-aPz
-leb
+kqb
+kqb
+uWM
+kqb
+kqb
 aOF
 aRU
 aRH
@@ -63974,7 +64001,7 @@ aTo
 aRH
 aSH
 aUo
-aSj
+doQ
 lKb
 aSj
 mzb
@@ -64219,11 +64246,11 @@ iPb
 aNs
 kab
 uWM
-tQg
+ciz
 tBw
-tQg
-aPy
-leb
+ciz
+kqb
+aOF
 aRV
 aRH
 aSJ
@@ -64479,8 +64506,8 @@ kqb
 ciz
 ciz
 ciz
-ciz
-kqb
+uWM
+aOF
 aRU
 aUH
 lKb
@@ -64732,12 +64759,12 @@ jHb
 iPb
 aNs
 kab
-krb
-gYJ
-gYJ
-gYJ
-aPz
-ldb
+kqb
+ciz
+ciz
+ciz
+kqb
+aOF
 aRV
 aRH
 aSL
@@ -64989,11 +65016,11 @@ aJu
 aJu
 lmj
 jXb
-aOF
-krb
-aPy
-aPy
-ldb
+kqb
+kqb
+kqb
+kqb
+kqb
 aOF
 aRU
 aRH
@@ -65002,7 +65029,7 @@ aTp
 aRH
 aSH
 aUp
-aSj
+doQ
 lKb
 aSj
 mzb
@@ -65228,7 +65255,7 @@ aaM
 aBp
 aBp
 aBp
-aJu
+dvN
 aJP
 aKf
 aKp
@@ -65241,7 +65268,7 @@ aJu
 aJu
 jgb
 aJP
-aJu
+dvN
 aaM
 aaM
 aNs
@@ -65494,7 +65521,7 @@ aKp
 qpz
 aKp
 aKp
-aJu
+dvN
 aJu
 jgb
 aJP
@@ -65769,10 +65796,10 @@ aRE
 aNs
 aSj
 aSj
+doQ
 aSj
 aSj
-aSj
-aSj
+doQ
 aSj
 lKb
 aSj
@@ -66514,17 +66541,17 @@ aAm
 aAm
 aAm
 aJu
-aJu
+dvN
 aJu
 aJu
 aAm
-aAm
+aaS
 aLi
 aAm
 aAm
 aJu
 aJu
-aJu
+dvN
 aJu
 aJu
 aaM
@@ -66792,7 +66819,7 @@ aaM
 aAm
 aQi
 aBK
-aAm
+aaS
 aaM
 aaM
 aaM
@@ -67046,7 +67073,7 @@ aAm
 aAm
 aAm
 aAm
-aAm
+aaS
 aBE
 aBE
 aAm
@@ -67532,7 +67559,7 @@ aEW
 aEW
 aft
 hvb
-hvb
+aPB
 aGT
 aFX
 aGy
@@ -67540,7 +67567,7 @@ hvb
 aIm
 aIG
 aIV
-hvb
+aPB
 hvb
 afH
 aEW
@@ -67793,7 +67820,7 @@ aGA
 aFX
 aFX
 aFX
-hvb
+aPB
 aIn
 aIG
 aIG
@@ -67817,7 +67844,7 @@ aAm
 aNz
 aAM
 aAM
-aPB
+goT
 kGb
 kYb
 ljb
@@ -68072,10 +68099,10 @@ aJu
 aaM
 aAm
 aAm
+aaS
 aAm
 aAm
-aAm
-aAm
+aaS
 kZb
 kYb
 ljb
@@ -68300,7 +68327,7 @@ aCV
 aCV
 aBp
 aEW
-hvb
+aPB
 aFF
 aFX
 aGC
@@ -68816,19 +68843,19 @@ gub
 aEX
 hvb
 hvb
+aPB
 hvb
+aPB
+aGE
 hvb
+aPB
 hvb
 aGE
 hvb
+aPB
 hvb
 hvb
-aGE
-hvb
-hvb
-hvb
-hvb
-hvb
+aPB
 aEW
 aJu
 aKY
@@ -68847,7 +68874,7 @@ aJf
 aJf
 aJf
 aQl
-aAm
+aaS
 lkb
 aBK
 aRW
@@ -69587,7 +69614,7 @@ gub
 aEZ
 hvb
 hvb
-hvb
+aPB
 aGE
 hvb
 hvb
@@ -69847,16 +69874,16 @@ aFJ
 aFZ
 aFX
 aGV
-hvb
+aPB
 aFX
-aHS
+mbC
 aFX
-hvb
+aPB
 aFX
 aGa
 aGa
 aFX
-hvb
+aPB
 aEW
 aJu
 aJP
@@ -70357,7 +70384,7 @@ aaM
 aEz
 aEW
 hvb
-hvb
+aPB
 aGa
 aFX
 aGX
@@ -70872,14 +70899,14 @@ aEz
 aEW
 aEW
 hvb
-hvb
+aPB
 aGF
 aGZ
 hvb
 aEW
 aEW
 aEW
-hvb
+aPB
 aIW
 aJk
 hvb
@@ -71132,7 +71159,7 @@ afu
 hvb
 aGG
 aHa
-hvb
+aPB
 aEW
 aEW
 aEW
@@ -71417,7 +71444,7 @@ aOh
 aPc
 aOh
 aAm
-aAm
+aaS
 lkb
 aBK
 aRW
@@ -71926,7 +71953,7 @@ aaM
 aaM
 aaM
 aaM
-aAm
+aaS
 aHm
 aHm
 aHm
@@ -73468,7 +73495,7 @@ aaM
 aaM
 aaM
 aaM
-aAm
+aaS
 aHm
 aHm
 aHm
@@ -73730,7 +73757,7 @@ aHm
 aHm
 aHm
 aHm
-aAm
+aaS
 lkb
 aBK
 aRW

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -464,6 +464,7 @@
 /area/centcom/control)
 "aaT" = (
 /obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/living)
 "aaU" = (
@@ -482,6 +483,7 @@
 "aaW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/tdome)
 "aaX" = (
@@ -491,6 +493,7 @@
 /area/centcom/evac)
 "aaY" = (
 /obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/custom/wizard_station)
 "aaZ" = (
@@ -826,6 +829,7 @@
 /area/shuttle/escape/centcom)
 "abQ" = (
 /obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/tdome)
 "abR" = (
@@ -935,6 +939,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -948,6 +953,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -1460,6 +1466,7 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "adK" = (
@@ -1671,6 +1678,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "aen" = (
@@ -2259,6 +2267,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Waiting Room"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -2380,6 +2389,7 @@
 	name = "Gateway room";
 	req_access = list(150)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -3004,6 +3014,7 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -3305,6 +3316,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor{
 	icon_state = "plating"
 	},
@@ -3791,6 +3803,7 @@
 	name = "Barracks";
 	req_access = list(150)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "grimy"
 	},
@@ -4289,6 +4302,7 @@
 	req_access = list(150);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -4509,6 +4523,7 @@
 	req_access = list(150);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -4779,6 +4794,7 @@
 	req_access = list(150);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -4963,6 +4979,7 @@
 	name = "Kitchen";
 	req_access = list(150)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -5498,6 +5515,7 @@
 	name = "Drop Pods room";
 	req_access = list(150)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -6592,6 +6610,7 @@
 	dir = 9;
 	icon_state = "siding_wood_line"
 	},
+/obj/item/decoration/snowman,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},
@@ -6612,6 +6631,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -6956,6 +6976,7 @@
 	name = "Special Operations";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -8495,6 +8516,7 @@
 	dir = 4;
 	icon_state = "loadingarea"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -8748,6 +8770,7 @@
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
@@ -8757,6 +8780,7 @@
 /obj/machinery/door/airlock/centcom{
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -9007,6 +9031,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -9025,6 +9050,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -9195,6 +9221,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -9470,6 +9497,7 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -9856,6 +9884,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/decoration/snowman,
 /turf/unsimulated/floor{
 	dir = 4;
 	icon_state = "green"
@@ -10112,6 +10141,7 @@
 	layer = 3.5;
 	pixel_x = -20
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -10653,6 +10683,7 @@
 	layer = 3.5;
 	pixel_x = -20
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -10864,6 +10895,7 @@
 	icon_state = "9";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -10884,6 +10916,7 @@
 	layer = 3.5;
 	pixel_x = -20
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -11061,6 +11094,7 @@
 /obj/machinery/door/airlock/centcom{
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "bluefull"
@@ -11076,6 +11110,7 @@
 	icon_state = "7";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -11091,6 +11126,7 @@
 	layer = 3.5;
 	pixel_x = -26
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -11100,6 +11136,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -11109,6 +11146,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cryogenic Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -11120,6 +11158,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/velocity)
 "ayt" = (
@@ -11219,6 +11258,7 @@
 	layer = 3.5;
 	pixel_x = -26
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -11525,6 +11565,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/specops)
 "azp" = (
@@ -11546,6 +11587,7 @@
 	layer = 3.5;
 	pixel_x = -26
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -11640,6 +11682,7 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -11838,6 +11881,7 @@
 	id = "velocity_main";
 	name = "Security Doors"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/plating,
 /area/velocity)
 "azQ" = (
@@ -12077,6 +12121,7 @@
 	layer = 3.5;
 	pixel_x = -26
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12416,6 +12461,7 @@
 	name = "Brig";
 	req_access = list(109)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12826,6 +12872,7 @@
 	name = "General Access";
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -12935,6 +12982,7 @@
 	id = "ERTBase";
 	name = "ERT"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -13059,6 +13107,7 @@
 	name = "Brig";
 	req_access = list(109)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -13068,6 +13117,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/specops)
 "aCu" = (
@@ -13608,6 +13658,7 @@
 	req_access = list(103);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -13667,6 +13718,7 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -14185,6 +14237,7 @@
 	id = "ERTBase";
 	name = "ERT"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -14207,6 +14260,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "aFg" = (
@@ -14521,6 +14575,7 @@
 	name = "Ready Room";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -14976,6 +15031,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Salvage Shuttle Dock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/plating,
 /area/centcom/evac)
 "aGO" = (
@@ -15328,6 +15384,7 @@
 /area/custom/arena)
 "aHD" = (
 /obj/structure/window/fulltile/reinforced,
+/obj/item/decoration/garland,
 /turf/simulated/shuttle/plating,
 /area/shuttle/administration/centcom)
 "aHE" = (
@@ -15345,9 +15402,7 @@
 	},
 /area/custom/syndicate_mothership)
 "aHF" = (
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 1
-	},
+/obj/item/device/flashlight/lamp/fir,
 /turf/unsimulated/floor{
 	icon_state = "black"
 	},
@@ -15357,9 +15412,11 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/plating,
 /area/centcom/evac)
 "aHH" = (
+/obj/item/decoration/snowman,
 /turf/unsimulated/floor{
 	dir = 6;
 	icon_state = "black"
@@ -15380,6 +15437,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -15765,6 +15823,7 @@
 	name = "Special Operations";
 	req_access = list(103)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -15852,6 +15911,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -16073,6 +16133,7 @@
 	name = "Special Operations";
 	req_access = list(103)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16292,6 +16353,7 @@
 	req_access = list(109);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "wood"
@@ -16412,6 +16474,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/control)
 "aKq" = (
@@ -16728,6 +16791,7 @@
 	req_access = list(105);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16738,6 +16802,7 @@
 	req_access = list(105);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16772,6 +16837,7 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16781,6 +16847,7 @@
 	name = "General Access";
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16951,6 +17018,7 @@
 	name = "Teleport Room";
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "engine"
 	},
@@ -17400,6 +17468,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/living)
 "aMA" = (
@@ -17416,6 +17485,7 @@
 /area/shuttle/syndicate/start)
 "aMB" = (
 /obj/machinery/door/airlock/external,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -17715,6 +17785,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -17773,6 +17844,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -17921,6 +17993,7 @@
 	icon_state = "*";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -17935,6 +18008,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 6;
 	icon_state = "green"
@@ -18498,6 +18572,7 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
+/obj/item/weapon/present,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -18969,6 +19044,7 @@
 	name = "Courthouse";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -19073,6 +19149,7 @@
 	req_access = list(105);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -19212,6 +19289,7 @@
 	name = "Conference Room";
 	req_access = list(108)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "wood"
@@ -19229,6 +19307,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor,
 /area/centcom/living)
 "aQQ" = (
@@ -19239,6 +19318,7 @@
 /area/centcom/living)
 "aQR" = (
 /obj/machinery/door/airlock/glass,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -19415,6 +19495,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Courthouse"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor/carpet,
 /area/centcom/living)
 "aSb" = (
@@ -19460,6 +19541,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -19476,6 +19558,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -19485,6 +19568,7 @@
 	name = "Creed's Office";
 	req_access = list(108)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -19930,6 +20014,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Courthouse"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -21162,6 +21247,7 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "aYP" = (
@@ -22361,6 +22447,7 @@
 	icon_state = "door_closed";
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -22494,6 +22581,7 @@
 	name = "Velocity Shuttle";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -23245,6 +23333,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "bNO" = (
@@ -23254,6 +23343,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -23501,6 +23591,12 @@
 	icon_state = "brown"
 	},
 /area/velocity)
+"ciz" = (
+/obj/item/weapon/present,
+/turf/unsimulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/centcom/holding)
 "cjb" = (
 /obj/machinery/door_control{
 	id = "ck_warehouse";
@@ -23592,6 +23688,14 @@
 	icon_state = "vaultfull"
 	},
 /area/velocity)
+"crf" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/unsimulated/floor,
+/area/centcom/evac)
 "csb" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -23918,6 +24022,13 @@
 	icon_state = "hydrofloor"
 	},
 /area/velocity)
+"cWy" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor,
+/area/velocity)
 "cXb" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
@@ -24159,6 +24270,10 @@
 	icon_state = "white"
 	},
 /area/velocity)
+"doQ" = (
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/centcom/tdome)
 "dpb" = (
 /obj/structure/rail_centcomm{
 	icon_state = "rail_03"
@@ -24239,6 +24354,10 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/space)
+"dvN" = (
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/centcom/control)
 "dwb" = (
 /obj/structure/rail_centcomm{
 	icon_state = "rail_01"
@@ -24280,6 +24399,7 @@
 "dAb" = (
 /obj/machinery/door/airlock/centcom,
 /obj/effect/landmark/trololo,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "hydrofloor"
 	},
@@ -24371,6 +24491,7 @@
 	icon_state = "door_locked";
 	locked = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor{
 	icon_state = "vwall12"
 	},
@@ -24392,6 +24513,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/velocity)
 "dMb" = (
@@ -24693,6 +24815,7 @@
 	icon_state = "3";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -24722,6 +24845,7 @@
 /area/velocity)
 "eob" = (
 /obj/machinery/door/airlock/glass,
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor{
 	icon_state = "vwall12"
 	},
@@ -24790,6 +24914,11 @@
 	},
 /turf/unsimulated/wall,
 /area/space)
+"ewk" = (
+/obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
+/turf/unsimulated/floor,
+/area/centcom/control)
 "exb" = (
 /obj/structure/table/reinforced,
 /turf/unsimulated/floor{
@@ -24834,6 +24963,7 @@
 	icon_state = "1";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -24917,6 +25047,7 @@
 	req_access = list(105);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "wood"
@@ -24930,6 +25061,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/velocity)
 "eKb" = (
@@ -24970,6 +25102,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -24988,6 +25121,7 @@
 	icon_state = "5";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -25071,6 +25205,7 @@
 	icon_state = "3";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -25280,6 +25415,7 @@
 	icon_state = "1";
 	layer = 3.5
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -25419,6 +25555,7 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/velocity)
 "fJf" = (
@@ -25427,6 +25564,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -25441,6 +25579,12 @@
 	oxygen = 21.8366
 	},
 /area/shuttle/specops/centcom)
+"fLy" = (
+/obj/item/decoration,
+/turf/unsimulated/floor{
+	icon_state = "engine"
+	},
+/area/space)
 "fMb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'LETHAL TURRETS'. Enter at your own risk!";
@@ -25456,6 +25600,11 @@
 	},
 /turf/unsimulated/floor,
 /area/centcom/prison)
+"fMW" = (
+/obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
+/turf/unsimulated/floor,
+/area/centcom/specops)
 "fNb" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -25763,6 +25912,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "gob" = (
@@ -25788,6 +25938,16 @@
 	icon_state = "bcircuit"
 	},
 /area/custom/syndicate_mothership/control)
+"goT" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Living Quarters";
+	req_access = list(105)
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/living)
 "gpb" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -25937,6 +26097,7 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -26145,6 +26306,12 @@
 	icon_state = "yellow"
 	},
 /area/centcom/specops)
+"gSJ" = (
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/evac)
 "gTb" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/gun/energy,
@@ -26205,6 +26372,13 @@
 	icon_state = "engine"
 	},
 /area/velocity)
+"gYJ" = (
+/obj/item/weapon/present,
+/turf/unsimulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/centcom/holding)
 "gZb" = (
 /turf/unsimulated/floor{
 	dir = 1;
@@ -26473,6 +26647,13 @@
 	icon_state = "blue"
 	},
 /area/centcom/evac)
+"hyu" = (
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/centcom/control)
 "hzb" = (
 /turf/unsimulated/floor{
 	dir = 5;
@@ -26540,6 +26721,12 @@
 	icon_state = "blue"
 	},
 /area/centcom/evac)
+"hHi" = (
+/obj/item/decoration/snowman,
+/turf/unsimulated/floor{
+	icon_state = "brown"
+	},
+/area/centcom/holding)
 "hIb" = (
 /turf/unsimulated/floor{
 	dir = 8;
@@ -26655,6 +26842,7 @@
 	id = "ERTBase";
 	name = "ERT"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -26674,6 +26862,7 @@
 	name = "Courthouse";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -26871,6 +27060,7 @@
 	name = "Cockpit";
 	req_access = list(109)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
@@ -26937,6 +27127,7 @@
 	name = "Server Room";
 	req_access = list(101)
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -26969,6 +27160,11 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/living)
+"iOj" = (
+/obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
+/turf/unsimulated/floor,
+/area/centcom/holding)
 "iPb" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -27236,6 +27432,7 @@
 	name = "Waiting Room";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -27458,6 +27655,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 10;
 	icon_state = "green"
@@ -27510,6 +27708,13 @@
 	icon_state = "wood"
 	},
 /area/centcom/holding)
+"jUr" = (
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/centcom/control)
 "jVb" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets{
@@ -27538,6 +27743,12 @@
 	icon_state = "brown"
 	},
 /area/centcom/holding)
+"jWB" = (
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/control)
 "jXb" = (
 /turf/unsimulated/floor{
 	dir = 1;
@@ -27606,6 +27817,15 @@
 	icon_state = "grass2"
 	},
 /area/centcom/living)
+"kcs" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 4
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/evac)
 "kcE" = (
 /obj/machinery/light{
 	dir = 8
@@ -27752,6 +27972,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -27928,6 +28149,7 @@
 /area/centcom/holding)
 "kMb" = (
 /obj/structure/table,
+/obj/item/weapon/present,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28118,6 +28340,10 @@
 	icon_state = "yellow"
 	},
 /area/centcom/holding)
+"lmj" = (
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/centcom/holding)
 "lmm" = (
 /turf/unsimulated/floor{
 	icon_state = "bcircuitoff"
@@ -28184,6 +28410,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 9;
 	icon_state = "green"
@@ -28199,6 +28426,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 5;
 	icon_state = "green"
@@ -28218,6 +28446,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -28332,6 +28561,11 @@
 	icon_state = "grimy"
 	},
 /area/centcom/living)
+"lLW" = (
+/obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
+/turf/unsimulated/floor,
+/area/velocity)
 "lMb" = (
 /obj/structure/object_wall/evac{
 	icon_state = "4,7"
@@ -28355,6 +28589,7 @@
 /obj/structure/sign/mark{
 	icon_state = "x3"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "greencorner"
@@ -28377,6 +28612,15 @@
 	icon_state = "white"
 	},
 /area/centcom/control)
+"lPq" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 8
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/evac)
 "lQb" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -28405,6 +28649,7 @@
 /obj/structure/sign/mark{
 	icon_state = "x3"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	dir = 4;
 	icon_state = "greencorner"
@@ -28512,6 +28757,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -28541,6 +28787,7 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -28590,6 +28837,7 @@
 "mnb" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
+/obj/item/weapon/present,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28635,6 +28883,12 @@
 	icon_state = "vaultfull"
 	},
 /area/centcom/tdome)
+"mrh" = (
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/velocity)
 "msb" = (
 /obj/machinery/light/small,
 /turf/unsimulated/floor{
@@ -28715,6 +28969,16 @@
 	icon_state = "floorplating"
 	},
 /area/custom/syndicate_mothership/elite_squad)
+"mAB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "wood"
+	},
+/area/centcom/living)
 "mDb" = (
 /obj/machinery/vending/coffee,
 /turf/unsimulated/floor{
@@ -28927,6 +29191,7 @@
 	dock_tag = "centcomm_ferry";
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "greenfull"
 	},
@@ -28967,6 +29232,7 @@
 	req_access = list(101);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -29137,6 +29403,7 @@
 "nBb" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/fancy/crayons,
+/obj/item/weapon/present,
 /turf/unsimulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -29369,6 +29636,7 @@
 	dir = 4
 	},
 /obj/structure/plasticflaps/explosion_proof,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/control)
 "obR" = (
@@ -29449,6 +29717,10 @@
 	},
 /turf/simulated/shuttle/floor/evac/sec2,
 /area/shuttle/escape/centcom)
+"okm" = (
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/centcom/evac)
 "olb" = (
 /obj/structure/object_wall/evac{
 	density = 0;
@@ -29589,6 +29861,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape/centcom)
+"oFF" = (
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall/log,
+/area/custom/wizard_station)
 "oHb" = (
 /obj/structure/object_wall/evac{
 	icon_state = "11,13"
@@ -29609,6 +29885,11 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape/centcom)
+"oJt" = (
+/obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
+/turf/unsimulated/floor,
+/area/custom/syndicate_mothership)
 "oKb" = (
 /obj/structure/stool/bed/roller,
 /obj/machinery/iv_drip,
@@ -29632,6 +29913,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape/centcom)
+"oNZ" = (
+/obj/structure/sign/mark{
+	icon_state = "yup"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor,
+/area/centcom/evac)
 "oOb" = (
 /obj/machinery/light{
 	dir = 8
@@ -29650,6 +29942,7 @@
 	dir = 4
 	},
 /obj/random/vending/cola,
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -29742,6 +30035,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -29780,6 +30074,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -29793,6 +30088,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "phb" = (
@@ -29851,6 +30147,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -29942,6 +30239,7 @@
 	req_access = list(1);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "pDb" = (
@@ -30104,6 +30402,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/transport1/centcom)
+"qbF" = (
+/obj/structure/sign/mark{
+	icon_state = "yup"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor,
+/area/centcom/evac)
 "qcb" = (
 /obj/structure/object_wall/evac{
 	icon_state = "1,20"
@@ -30127,6 +30436,17 @@
 	},
 /turf/environment/space,
 /area/space)
+"qpz" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Bridge";
+	req_access = list(109);
+	dir = 4
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/control)
 "qsd" = (
 /obj/machinery/recharge_station,
 /obj/structure/sign/poster/contraband/borg_fancy_2{
@@ -30158,10 +30478,15 @@
 	name = "ERT";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"qMZ" = (
+/obj/item/decoration,
+/turf/unsimulated/wall,
+/area/centcom/evac)
 "qOG" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/unsimulated/floor/cult/lava,
@@ -30183,6 +30508,22 @@
 	icon_state = "floor"
 	},
 /area/velocity)
+"rtd" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor,
+/area/centcom/evac)
+"rMu" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor,
+/area/centcom/evac)
 "rXM" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/shuttle/floor/vox,
@@ -30277,6 +30618,25 @@
 	icon_state = "floor"
 	},
 /area/centcom/tdome)
+"tBw" = (
+/obj/item/device/flashlight/lamp/fir/special,
+/obj/item/weapon/present,
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/centcom/holding)
+"tKy" = (
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/custom/syndicate_mothership/droppod_garage)
+"tQg" = (
+/obj/item/weapon/present,
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/centcom/holding)
 "tWq" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 4
@@ -30325,6 +30685,21 @@
 	},
 /turf/environment/space,
 /area/space)
+"uTM" = (
+/obj/machinery/door/airlock/centcom{
+	req_access = list(101)
+	},
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/velocity)
+"uWM" = (
+/obj/item/weapon/present,
+/turf/unsimulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/centcom/holding)
 "vak" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "pod2";
@@ -30332,6 +30707,7 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/unsimulated/floor,
 /area/centcom/evac)
 "vaz" = (
@@ -30361,6 +30737,7 @@
 	name = "Salvage Shuttle Dock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/shuttle/plating,
 /area/centcom/evac)
 "voK" = (
@@ -30373,6 +30750,11 @@
 	icon_state = "neutral"
 	},
 /area/velocity)
+"vrH" = (
+/obj/structure/window/fulltile/reinforced/indestructible,
+/obj/item/decoration/garland,
+/turf/unsimulated/floor,
+/area/centcom/evac)
 "vDJ" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/unsimulated/floor/cult/lava,
@@ -30428,6 +30810,13 @@
 	icon_state = "floorcatwalk"
 	},
 /area/custom/syndicate_mothership/elite_squad)
+"xsb" = (
+/obj/item/decoration/tinsel,
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "wood"
+	},
+/area/centcom/living)
 "xsM" = (
 /turf/simulated/shuttle/floor/vox{
 	icon_state = "floorcatwalk"
@@ -30449,13 +30838,17 @@
 	icon_state = "barber"
 	},
 /area/velocity)
+"xKK" = (
+/obj/item/decoration/snowman,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/evac)
 "xLi" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/obj/machinery/atm{
-	pixel_x = -30
-	},
+/obj/machinery/vending/newyearmate,
 /turf/unsimulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -30473,6 +30866,10 @@
 	icon_state = "floorcatwalk"
 	},
 /area/custom/syndicate_mothership/elite_squad)
+"ycK" = (
+/obj/item/decoration/snowflake,
+/turf/unsimulated/wall,
+/area/custom/syndicate_mothership)
 "yea" = (
 /turf/unsimulated/floor/cult,
 /area/custom/cult)
@@ -33563,7 +33960,7 @@ abg
 arM
 asj
 asJ
-abg
+oFF
 abg
 aDf
 abi
@@ -34586,12 +34983,12 @@ baY
 abl
 abi
 abi
-abg
+oFF
 abg
 arN
 asl
 asK
-abg
+oFF
 abg
 baO
 bbd
@@ -34845,7 +35242,7 @@ bbY
 abi
 abi
 abg
-abg
+oFF
 aDz
 abg
 abg
@@ -35873,7 +36270,7 @@ abi
 abi
 abg
 abg
-abg
+oFF
 aDz
 abg
 abg
@@ -36128,14 +36525,14 @@ abi
 bbd
 abg
 abg
-abg
+oFF
 aCI
 aDh
 bbG
 aEg
 bbp
 abg
-abg
+oFF
 abg
 abk
 abi
@@ -36639,7 +37036,7 @@ abi
 abi
 abi
 bbf
-abg
+oFF
 aBT
 ahM
 aaY
@@ -36908,7 +37305,7 @@ axd
 aaY
 bdQ
 nXb
-abg
+oFF
 abg
 abg
 abg
@@ -37412,7 +37809,7 @@ abi
 abg
 abj
 bba
-abg
+oFF
 akh
 aqE
 aDl
@@ -37926,7 +38323,7 @@ abi
 abg
 abo
 abo
-abg
+oFF
 alZ
 aqG
 aDl
@@ -37934,7 +38331,7 @@ aGq
 aDa
 axr
 azM
-abg
+oFF
 aBh
 aFe
 aDa
@@ -38191,7 +38588,7 @@ bax
 aDa
 axs
 abg
-abg
+oFF
 abg
 abg
 aBw
@@ -38695,7 +39092,7 @@ abl
 abi
 abh
 abi
-abg
+oFF
 abs
 awB
 aaY
@@ -39470,11 +39867,11 @@ abi
 abh
 abi
 abg
-abg
+oFF
 abg
 aDz
 abg
-abg
+oFF
 abg
 abi
 abi
@@ -40502,7 +40899,7 @@ abg
 abg
 aDz
 abg
-abg
+oFF
 abi
 abi
 abl
@@ -40755,7 +41152,7 @@ abi
 abi
 abi
 abg
-abg
+oFF
 asb
 arP
 atd
@@ -48420,13 +48817,13 @@ akE
 aaM
 aaM
 aaM
-abn
+vrH
 pab
 hxb
 ifb
 hNb
 adX
-abn
+vrH
 aaM
 aaM
 aaM
@@ -48677,13 +49074,13 @@ akG
 alf
 aaM
 aaM
-abn
+vrH
 pbb
 hyb
 aIy
 hOb
 afQ
-abn
+vrH
 aaM
 aaM
 aaM
@@ -48934,13 +49331,13 @@ awA
 akZ
 qbb
 aaM
-abn
+vrH
 peb
 hzb
 hIb
 hPb
 adX
-abn
+vrH
 aaM
 aaM
 aaM
@@ -49707,9 +50104,9 @@ omb
 aaM
 aaM
 aaM
-abn
+vrH
 aIy
-abn
+vrH
 aaM
 aaM
 aaM
@@ -49964,9 +50361,9 @@ aaM
 aaM
 aaM
 aaM
-abn
+vrH
 aJe
-abn
+vrH
 aaM
 aaM
 aaM
@@ -50202,7 +50599,7 @@ aaM
 aNs
 aOt
 aOv
-aNs
+lmj
 aQy
 aNs
 aRk
@@ -50221,9 +50618,9 @@ aaM
 aaM
 aaM
 aaM
-abn
+vrH
 aIy
-abn
+vrH
 aaM
 aaM
 aaM
@@ -50456,7 +50853,7 @@ aaM
 aaM
 aaM
 aaM
-aNs
+lmj
 aOu
 aOv
 aOv
@@ -50477,10 +50874,10 @@ aHv
 aHv
 aHv
 aHv
-abn
-abn
+vrH
+vrH
 pdb
-abn
+vrH
 aaM
 aaM
 aaM
@@ -50737,7 +51134,7 @@ hGb
 hGb
 hGb
 hRb
-abn
+vrH
 aaM
 phb
 plb
@@ -50948,7 +51345,7 @@ hyb
 aIy
 hOb
 hSb
-aIy
+gSJ
 hZb
 hyb
 aIy
@@ -50973,10 +51370,10 @@ aaM
 aNs
 aNs
 aPT
+lmj
 aNs
 aNs
-aNs
-aNs
+lmj
 aNs
 aaM
 aaM
@@ -51998,14 +52395,14 @@ aaM
 aaM
 aaM
 aaM
-aNs
+lmj
 klb
 aOF
 aOF
 aOF
 aOF
 lob
-aNs
+lmj
 aaM
 aaM
 aaM
@@ -52251,7 +52648,7 @@ aHv
 aHv
 aHv
 aHv
-aHv
+okm
 aHv
 aHv
 aHv
@@ -52748,13 +53145,13 @@ aID
 aID
 aHv
 aHv
-aHv
+okm
 abn
 aFf
 abn
+okm
 aHv
-aHv
-aHv
+okm
 abn
 bNb
 abn
@@ -52776,7 +53173,7 @@ kIb
 aOG
 aOF
 aRx
-aNs
+lmj
 aaM
 ags
 agA
@@ -53026,7 +53423,7 @@ aII
 aII
 aNl
 aII
-aHv
+okm
 aOB
 aOB
 kIb
@@ -53260,7 +53657,7 @@ aaM
 aaM
 aaM
 aaM
-aHv
+okm
 hWb
 aIc
 aIB
@@ -53279,7 +53676,7 @@ iLb
 aHv
 aHv
 aHv
-aHv
+okm
 aHv
 aHv
 aNK
@@ -53293,12 +53690,12 @@ aRx
 aNs
 aJu
 aJu
+dvN
+aJu
+dvN
 aJu
 aJu
-aJu
-aJu
-aJu
-aJu
+dvN
 aJu
 aaM
 aaM
@@ -53307,7 +53704,7 @@ aaM
 aHv
 hgb
 hRb
-aHv
+qMZ
 aaM
 aaM
 aaM
@@ -53315,17 +53712,17 @@ aaM
 aaM
 aaM
 aaM
-abn
+vrH
 aem
 aem
-abn
+vrH
 aem
 aem
-abn
+vrH
 aaM
-abn
+vrH
 pCb
-abn
+vrH
 osb
 pWb
 aaM
@@ -53518,20 +53915,20 @@ aaM
 aaM
 aaM
 aHv
+okm
 aHv
-aHv
-aHv
+okm
 iib
 aFf
 iib
-aHv
+okm
 iib
 aFf
 iib
+okm
 aHv
 aHv
-aHv
-aHv
+okm
 aIy
 aMb
 aNo
@@ -53540,14 +53937,14 @@ jlb
 aci
 aMb
 jLb
-aHv
+okm
 kmb
 lXb
 aPR
 aOF
 aOF
 aOF
-aNs
+lmj
 lFb
 aeb
 lOb
@@ -53556,33 +53953,33 @@ mab
 meb
 aSD
 aJP
-aJu
+dvN
 aHv
 aHv
 aHv
 aHv
-aHv
+okm
 pgb
 adJ
 aHv
+okm
 aHv
 aHv
-aHv
 aaM
 aaM
 aaM
 aaM
-abn
+vrH
 akd
 amc
-abn
+vrH
 amc
 apL
-abn
+vrH
 aaM
-abn
+vrH
 apL
-abn
+vrH
 aaM
 aaM
 aaM
@@ -53814,7 +54211,7 @@ aKp
 mlb
 aJP
 aVu
-aVK
+kcs
 aWb
 aVK
 aVK
@@ -53824,20 +54221,20 @@ hRb
 aVK
 aVK
 aRt
-aHv
-abn
-abn
-abn
-abn
+okm
+vrH
+vrH
+vrH
+vrH
 aaX
 aFf
 aFf
 aaX
 aFf
 aFf
-abn
+vrH
 aaX
-abn
+vrH
 pCb
 aaX
 aaM
@@ -54071,7 +54468,7 @@ mgb
 jgb
 aJP
 iyb
-mub
+oNZ
 hGb
 hGb
 hGb
@@ -54092,11 +54489,11 @@ adI
 apG
 aVR
 apM
-hGb
+rMu
 hGb
 hGb
 akF
-abn
+vrH
 aaM
 aaM
 aaM
@@ -54288,7 +54685,7 @@ bwb
 aBp
 aBp
 aaM
-aHv
+okm
 hWb
 aIc
 aIy
@@ -54328,7 +54725,7 @@ mob
 jgb
 aJP
 aKX
-ndb
+qbF
 aIO
 aIO
 aIO
@@ -54349,11 +54746,11 @@ aIO
 aIO
 aIO
 ndb
-aIO
+rtd
 aIO
 aIO
 ndb
-abn
+vrH
 aaM
 aaM
 aaM
@@ -54585,7 +54982,7 @@ aKp
 mmb
 aJP
 aVv
-aSc
+lPq
 aWc
 aSc
 aSc
@@ -54595,7 +54992,7 @@ aSC
 aSc
 aSc
 aRt
-aHv
+okm
 aSc
 aSc
 aZB
@@ -54603,14 +55000,14 @@ aaV
 aSc
 aSc
 aSc
-aSc
+xKK
 aSc
 aSc
 oQb
 oXb
 aSc
 aSc
-abn
+vrH
 aaM
 aaM
 aaM
@@ -54805,18 +55202,18 @@ aaM
 aHv
 aHv
 aHv
-aHv
+okm
+iib
+aFf
+iib
+okm
 iib
 aFf
 iib
 aHv
-iib
-aFf
-iib
+okm
 aHv
-aHv
-aHv
-aHv
+okm
 aIy
 aMc
 aNw
@@ -54832,7 +55229,7 @@ aRx
 aOG
 aOF
 aRy
-aNs
+lmj
 lHb
 aee
 lRb
@@ -54842,32 +55239,32 @@ mhb
 aSE
 avw
 aJu
+okm
 aHv
 aHv
+okm
 aHv
 aHv
+okm
+aHv
+okm
 aHv
 aHv
+vrH
+vrH
+vrH
+okm
+crf
+crf
+crf
+crf
+crf
+crf
 aHv
-aHv
-aHv
-aHv
-aHv
-abn
-abn
-abn
-aHv
-aIc
-aIc
-aIc
-aIc
-aIc
-aIc
-aHv
-abn
-abn
-abn
-abn
+vrH
+vrH
+vrH
+vrH
 aaM
 aaM
 aaM
@@ -55059,7 +55456,7 @@ byb
 bzb
 aBp
 aaM
-aHv
+okm
 hWb
 aIc
 aIC
@@ -55075,14 +55472,14 @@ aIc
 hWb
 aHv
 aHv
+okm
 aHv
 aHv
 aHv
 aHv
+okm
 aHv
-aHv
-aHv
-aHv
+okm
 aOG
 aOF
 aRx
@@ -55092,10 +55489,10 @@ aRx
 aNs
 oab
 aJu
+dvN
 aJu
 aJu
-aJu
-aJu
+dvN
 aJu
 obb
 aJu
@@ -55346,16 +55743,16 @@ aOF
 aOF
 kvb
 aRz
-aNs
+lmj
 aSd
 adK
 aSd
 afl
 aSd
 aSd
-aJu
+dvN
 afe
-aJu
+dvN
 aaM
 aaM
 aaM
@@ -55574,19 +55971,19 @@ aLv
 aBp
 aBp
 aHv
-aHv
-aHv
-abn
-aFf
-abn
-aHv
-aHv
+okm
 aHv
 abn
 aFf
 abn
 aHv
+okm
 aHv
+abn
+aFf
+abn
+okm
+okm
 aHv
 aaM
 aaM
@@ -55596,7 +55993,7 @@ aaM
 aKu
 aaM
 aaM
-aaU
+iOj
 aOG
 aOF
 aOF
@@ -55853,7 +56250,7 @@ aaM
 aKu
 aaM
 aaM
-aaU
+iOj
 aOG
 aOF
 aRx
@@ -55869,7 +56266,7 @@ aTF
 aTF
 aTF
 aUz
-aJu
+dvN
 aaM
 aaM
 aaM
@@ -56110,7 +56507,7 @@ aaM
 aKu
 aaM
 aaM
-aaU
+iOj
 aOG
 kvb
 aRx
@@ -56119,12 +56516,12 @@ adY
 aec
 aNs
 aJu
+dvN
+aJu
+dvN
 aJu
 aJu
-aJu
-aJu
-aJu
-aJu
+dvN
 aJu
 aJu
 aaM
@@ -56367,7 +56764,7 @@ aaM
 aKu
 aaM
 aaM
-aaU
+iOj
 aOG
 aOF
 aRx
@@ -56631,7 +57028,7 @@ aOF
 aOF
 adR
 aef
-aNs
+lmj
 aaM
 aaM
 aaM
@@ -56881,8 +57278,8 @@ aaM
 aKu
 ahJ
 ahJ
-aNs
-aNs
+lmj
+lmj
 kwb
 kJb
 kJb
@@ -57144,7 +57541,7 @@ aNs
 aPU
 aPU
 aNs
-aNs
+lmj
 aJu
 aaM
 aaM
@@ -57397,10 +57794,10 @@ aaM
 aaM
 aaM
 aaM
-aNs
+lmj
 lXb
 lXb
-aNs
+lmj
 aaM
 aaM
 aaM
@@ -57654,7 +58051,7 @@ aaM
 aaM
 aaM
 aaM
-aNs
+lmj
 aOF
 aQE
 aNs
@@ -57914,7 +58311,7 @@ aaM
 aNs
 aPn
 aPn
-aNs
+lmj
 aaM
 aaM
 aaM
@@ -58168,7 +58565,7 @@ aaM
 aaM
 aaM
 aNs
-aNs
+lmj
 aPW
 aPW
 aNs
@@ -58680,18 +59077,18 @@ aaM
 aKu
 aaM
 aNs
-aNs
+lmj
 aOK
 kyb
 kKb
 kUb
 lcb
 aRA
-aNs
+lmj
 aNs
 aSF
 aSF
-aaU
+iOj
 aaM
 aaM
 aaM
@@ -58948,7 +59345,7 @@ lub
 aSi
 aSF
 aSF
-aaU
+iOj
 aaM
 aaM
 aaM
@@ -59193,19 +59590,19 @@ aAm
 aaM
 aKu
 ahJ
-aNs
+lmj
 jQb
-aNs
+lmj
 aNs
 aQa
 aPy
 ldb
 aOF
-lqb
-aNs
+hHi
+lmj
 aSF
 aSF
-aaU
+iOj
 aaM
 aaM
 aaM
@@ -59462,7 +59859,7 @@ lvb
 aNs
 aSF
 aSF
-aaU
+iOj
 aaM
 aaM
 aaM
@@ -59716,7 +60113,7 @@ kWb
 lcb
 lpb
 lwb
-aNs
+lmj
 aNs
 aNs
 aNs
@@ -59964,7 +60361,7 @@ aaT
 aaM
 aKu
 aaM
-aaU
+iOj
 jTb
 jRb
 jRb
@@ -59973,7 +60370,7 @@ kWb
 lcb
 lqb
 lzb
-aaU
+iOj
 aaM
 eYb
 aKu
@@ -60221,7 +60618,7 @@ aaT
 aaM
 aKu
 aaM
-aaU
+iOj
 jUb
 jRb
 jRb
@@ -60230,7 +60627,7 @@ kWb
 ldb
 lqb
 nBb
-aaU
+iOj
 aaM
 lSb
 aKu
@@ -60470,7 +60867,7 @@ aJL
 aJf
 aJf
 aJf
-aJL
+mAB
 iNb
 iTb
 jcb
@@ -60478,7 +60875,7 @@ aaT
 aaM
 aKu
 aaM
-aaU
+iOj
 jUb
 jRb
 jRb
@@ -60487,7 +60884,7 @@ kWb
 leb
 lqb
 nBb
-aaU
+iOj
 aaM
 lTb
 aKu
@@ -60727,7 +61124,7 @@ aJq
 aJq
 aJq
 aJq
-aJf
+xsb
 iNb
 iTb
 jcb
@@ -60735,7 +61132,7 @@ aaT
 aaM
 aKu
 ahJ
-aaU
+iOj
 jVb
 jRb
 jRb
@@ -60744,7 +61141,7 @@ kWb
 lcb
 lqb
 mnb
-aaU
+iOj
 aaM
 aqK
 aKu
@@ -60984,7 +61381,7 @@ aKx
 aJf
 aJf
 aJf
-aJf
+xsb
 iNb
 iNb
 iNb
@@ -61001,7 +61398,7 @@ kWb
 lcb
 lrb
 lAb
-aNs
+lmj
 aaM
 apy
 aKu
@@ -61249,10 +61646,10 @@ job
 aAm
 aKu
 aaM
-aNs
+lmj
 jRb
 kob
-aNs
+lmj
 aNs
 aPy
 ldb
@@ -61508,14 +61905,14 @@ aKu
 aaM
 aNs
 jQb
-aNs
+lmj
 aNs
 aQg
 aPz
 leb
 aOF
 lqb
-aNs
+lmj
 aaM
 app
 aKu
@@ -62020,7 +62417,7 @@ aJu
 aJu
 aKu
 aaM
-aaU
+iOj
 jXb
 aON
 kyb
@@ -62029,9 +62426,9 @@ kVb
 lcb
 aON
 lqb
-aaU
+iOj
 aaM
-eYb
+fLy
 aKu
 aaM
 aSj
@@ -62264,20 +62661,20 @@ aaM
 aJu
 aJP
 aKd
-aJP
+jWB
 itb
 iwb
 iwb
 iEb
 iIb
 aJP
-aJP
+jWB
 aKd
 aJP
 aJu
 aKu
 aaM
-aaU
+iOj
 jYb
 aOO
 kzb
@@ -62286,7 +62683,7 @@ aPy
 lfb
 aOO
 lCb
-aaU
+iOj
 aaM
 eYb
 aKu
@@ -62521,20 +62918,20 @@ aaM
 aaS
 aJP
 aJP
+jWB
 aJP
 aJP
 aJP
 aJP
 aJP
 aJP
+jWB
 aJP
 aJP
-aJP
-aJP
-aaS
+ewk
 aKu
 ahJ
-aNs
+lmj
 jZb
 aOP
 kpb
@@ -62778,20 +63175,20 @@ aaM
 aaS
 aJP
 aKe
-aKo
+hyu
 aKo
 aKo
 iCb
 aKo
 aKo
 aKo
-aKo
+hyu
 jfb
 aJP
-aaS
+ewk
 aKu
 aaM
-aaU
+iOj
 jXb
 aON
 kyb
@@ -62800,7 +63197,7 @@ kUb
 lcb
 aON
 lDb
-aSj
+doQ
 aSj
 aSj
 aSj
@@ -63045,10 +63442,10 @@ aJu
 aJu
 jgb
 aJP
-aaS
+ewk
 aKu
 aaM
-aaU
+iOj
 jYb
 aOO
 kAb
@@ -63562,11 +63959,11 @@ jqb
 aJu
 aJu
 aJu
-aNs
+lmj
 jZb
 aOF
 kpb
-aPz
+gYJ
 aPz
 leb
 aOF
@@ -63821,10 +64218,10 @@ jGb
 iPb
 aNs
 kab
-kpb
-aPy
-aPy
-aPy
+uWM
+tQg
+tBw
+tQg
 aPy
 leb
 aRV
@@ -64079,10 +64476,10 @@ iPb
 aNL
 kab
 kqb
-kqb
-kqb
-kqb
-kqb
+ciz
+ciz
+ciz
+ciz
 kqb
 aRU
 aUH
@@ -64336,9 +64733,9 @@ iPb
 aNs
 kab
 krb
-aPz
-aPz
-aPz
+gYJ
+gYJ
+gYJ
 aPz
 ldb
 aRV
@@ -64590,7 +64987,7 @@ jtb
 aJu
 aJu
 aJu
-aNs
+lmj
 jXb
 aOF
 krb
@@ -65083,7 +65480,7 @@ aFW
 aFW
 aFW
 aHx
-aaR
+fMW
 aaM
 aaM
 aaM
@@ -65094,14 +65491,14 @@ aKf
 aKp
 aKp
 aKp
-aLg
+qpz
 aKp
 aKp
 aJu
 aJu
 jgb
 aJP
-aaS
+ewk
 aaM
 aaM
 aNs
@@ -65113,7 +65510,7 @@ kUb
 lcb
 aOF
 lqb
-aSj
+doQ
 aSG
 aSH
 aRH
@@ -65340,29 +65737,29 @@ aFW
 aFW
 aFW
 aHy
-aaR
+fMW
 aaM
 aaM
 aaM
 aaM
-aaS
+ewk
 aJP
 iqb
-isb
+jUr
 isb
 isb
 iCb
 isb
 isb
 isb
-isb
+jUr
 jhb
 aJP
-aaS
+ewk
 aaM
 aaM
 aNs
-aNs
+lmj
 aOT
 kyb
 kLb
@@ -65597,25 +65994,25 @@ aFW
 aFW
 aFW
 aHz
-aaR
+fMW
 aaM
 aaM
 aaM
 aaM
-aaS
+ewk
+aJP
+aJP
+jWB
 aJP
 aJP
 aJP
 aJP
 aJP
 aJP
+jWB
 aJP
 aJP
-aJP
-aJP
-aJP
-aJP
-aaS
+ewk
 aaM
 aaM
 aaM
@@ -65625,7 +66022,7 @@ kBb
 aPy
 aPy
 lhb
-aNs
+lmj
 aNs
 aaM
 aaM
@@ -65862,14 +66259,14 @@ aaM
 aJu
 aJP
 aKh
-aJP
+jWB
 iub
 ixb
 ixb
 iFb
 iJb
 aJP
-aJP
+jWB
 aKh
 aJP
 aJu
@@ -65878,10 +66275,10 @@ aaM
 aaM
 aaM
 aNs
-aNs
+lmj
 aPX
 aPX
-aNs
+lmj
 aNs
 aaM
 aaM
@@ -66870,7 +67267,7 @@ aaM
 aaM
 aaM
 aaM
-aaR
+fMW
 aCV
 aCV
 aBp
@@ -67127,7 +67524,7 @@ aaM
 aaM
 aaM
 aaM
-aaR
+fMW
 aDQ
 aCV
 aBp
@@ -67384,7 +67781,7 @@ aaM
 aaM
 aaM
 aaM
-aaR
+fMW
 aCV
 aCV
 aBp
@@ -68155,7 +68552,7 @@ aaM
 aaM
 aaM
 aaM
-aaR
+fMW
 aCV
 aCV
 aBp
@@ -68412,7 +68809,7 @@ aaM
 aaM
 aaM
 aaM
-aaR
+fMW
 aDQ
 aCV
 gub
@@ -68454,7 +68851,7 @@ aAm
 lkb
 aBK
 aRW
-aPB
+goT
 aJf
 aJf
 aJf
@@ -68669,7 +69066,7 @@ aaM
 aaM
 aaM
 aaM
-aaR
+fMW
 aCV
 aCV
 bxb
@@ -71538,7 +71935,7 @@ aAm
 lkb
 aBK
 aRW
-aPB
+goT
 aJf
 aJf
 aJf
@@ -73271,8 +73668,8 @@ acr
 acD
 acD
 adn
-aaP
-aaP
+lLW
+lLW
 aoo
 aoo
 aaM
@@ -73785,7 +74182,7 @@ act
 acF
 acJ
 ado
-aaP
+lLW
 eCb
 arZ
 aoo
@@ -74042,7 +74439,7 @@ agl
 acG
 agU
 adq
-aaP
+lLW
 eCb
 axV
 ayb
@@ -74299,7 +74696,7 @@ agj
 acG
 agI
 adp
-aaP
+lLW
 eCb
 arZ
 aoo
@@ -74556,7 +74953,7 @@ acy
 acG
 acO
 ads
-aaP
+lLW
 eCb
 arZ
 aoo
@@ -74813,13 +75210,13 @@ agm
 acG
 akm
 adr
-aaP
+lLW
 eCb
 arZ
 ayc
-aaP
-aaP
-aaP
+lLW
+lLW
+lLW
 aoo
 aaM
 aaM
@@ -75070,7 +75467,7 @@ agH
 acG
 ako
 aeZ
-aaP
+lLW
 eCb
 arZ
 aoo
@@ -75327,7 +75724,7 @@ acz
 acF
 acP
 adt
-aaP
+lLW
 eCb
 arZ
 aoo
@@ -75841,7 +76238,7 @@ acB
 acD
 acD
 afb
-aaP
+lLW
 eCb
 arZ
 aoo
@@ -76098,14 +76495,14 @@ acC
 acH
 acU
 adu
-aaP
+lLW
 eCb
 arZ
 aoo
 voK
 arZ
 giW
-asE
+mrh
 asE
 vir
 aoo
@@ -76349,12 +76746,12 @@ aaM
 aaM
 aoo
 aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+lLW
+lLW
+lLW
+lLW
+lLW
+lLW
 aoo
 aux
 aux
@@ -76607,8 +77004,8 @@ aoo
 aoo
 aaP
 aaP
-aaP
-aaP
+lLW
+lLW
 awG
 aaP
 aaP
@@ -76616,9 +77013,9 @@ aaQ
 auy
 auy
 aoo
-aaP
+lLW
 qsx
-aaP
+lLW
 aoo
 aeG
 kbS
@@ -77393,7 +77790,7 @@ arZ
 ayq
 atq
 atq
-aaP
+lLW
 aaM
 azb
 azv
@@ -77650,7 +78047,7 @@ arZ
 ayr
 atq
 asB
-aaP
+lLW
 aaM
 eUb
 azw
@@ -77907,7 +78304,7 @@ arZ
 ayq
 atq
 atq
-aaP
+lLW
 aaM
 eVb
 fbb
@@ -78943,8 +79340,8 @@ ayA
 aAc
 aAc
 aAc
-aao
-eNb
+uTM
+cWy
 aqx
 aqx
 aqx
@@ -79201,7 +79598,7 @@ aar
 aas
 aar
 fFb
-eNb
+cWy
 aqx
 aqx
 aqx
@@ -80196,7 +80593,7 @@ cTb
 cGb
 cGb
 cGb
-aao
+uTM
 arZ
 arZ
 dyb
@@ -87591,16 +87988,16 @@ ahJ
 ahF
 ahF
 aie
-aaN
+oJt
 aie
-aaN
-aaN
-aaN
-aaN
-aaN
-aaN
+oJt
+oJt
+oJt
+oJt
+oJt
+oJt
 atb
-aaN
+oJt
 ahJ
 aaM
 ahJ
@@ -87847,17 +88244,17 @@ ahF
 ahF
 ahF
 aie
-aie
+ycK
 aKz
-aie
+ycK
 ajy
 aki
 aki
 aki
 alz
-aaN
+oJt
 aii
-aaN
+oJt
 ahJ
 ahJ
 ahF
@@ -88114,8 +88511,8 @@ aIK
 aIK
 aaN
 alI
-aaN
-aie
+oJt
+ycK
 ahF
 ahF
 ahF
@@ -88628,8 +89025,8 @@ akv
 akQ
 amm
 aIb
-aHF
-aie
+amJ
+ycK
 ahF
 ahF
 ahF
@@ -88873,9 +89270,9 @@ ahF
 ahF
 ahF
 aie
+ycK
 aie
-aie
-aie
+ycK
 aie
 aie
 alB
@@ -89142,7 +89539,7 @@ akj
 akQ
 amm
 aIb
-aHF
+amJ
 aie
 ahF
 ahF
@@ -89911,7 +90308,7 @@ aIb
 aIb
 acW
 aly
-aly
+tKy
 aly
 aly
 aly
@@ -90167,7 +90564,7 @@ akb
 amH
 alY
 adH
-aly
+tKy
 amo
 bab
 bab
@@ -90415,11 +90812,11 @@ ahF
 ahF
 ahF
 aie
+ycK
 aie
 aie
 aie
-aie
-aie
+ycK
 aix
 aix
 akz
@@ -91960,7 +92357,7 @@ aie
 aie
 aie
 aie
-aie
+ycK
 aie
 aie
 aix
@@ -91970,7 +92367,7 @@ aly
 aly
 aly
 aly
-aly
+tKy
 aly
 aly
 aly
@@ -92213,13 +92610,13 @@ ahF
 ahF
 ahF
 aie
-aie
+ycK
 aSb
 aSb
 ajJ
 aSb
 akL
-aie
+ycK
 alO
 aIb
 alk
@@ -93000,7 +93397,7 @@ ayM
 aKZ
 aLf
 agg
-aie
+ycK
 ahF
 ahF
 ahF
@@ -93241,13 +93638,13 @@ ahF
 ahF
 ahF
 aie
-aie
+ycK
 adl
 adl
 aik
 adl
 akS
-aie
+ycK
 aje
 aIb
 aln
@@ -93507,7 +93904,7 @@ aie
 aie
 aie
 alc
-aie
+ycK
 aie
 aie
 aIa
@@ -93769,7 +94166,7 @@ ame
 aie
 aie
 aIl
-aie
+ycK
 aie
 aie
 ahF
@@ -94023,7 +94420,7 @@ alU
 amB
 alo
 anE
-aie
+ycK
 aHf
 aIt
 aIT

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -20907,11 +20907,11 @@
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "dVF" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/decal/turf_decal/blue{
 	dir = 8;
 	icon_state = "siding_line"
 	},
+/obj/machinery/vending/newyearmate,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -41420,6 +41420,7 @@
 /area/station/security/brig)
 "ikZ" = (
 /obj/item/decoration/tinsel,
+/obj/machinery/vending/newyearmate,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -61559,6 +61560,12 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/medbay)
+"muu" = (
+/obj/machinery/vending/newyearmate,
+/turf/simulated/floor{
+	icon_state = "blackchoco"
+	},
+/area/station/civilian/dormitories/service_bedrooms)
 "muv" = (
 /obj/machinery/optable,
 /obj/machinery/status_display{
@@ -70948,6 +70955,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "ovi" = (
@@ -152547,7 +152555,7 @@ jGh
 iga
 dXT
 jGh
-bll
+muu
 rXS
 gBW
 bll

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -223,6 +223,7 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "aat" = (
@@ -323,6 +324,7 @@
 "aaB" = (
 /obj/structure/table,
 /obj/item/weapon/poster/legit,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -559,6 +561,7 @@
 	name = "Prison Lockdown";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "aaX" = (
@@ -663,6 +666,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -725,6 +729,7 @@
 	dir = 4;
 	name = "Library"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -754,6 +759,7 @@
 	dir = 4;
 	name = "Library"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -791,6 +797,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -808,6 +815,7 @@
 	name = "Hydroponics Pasture";
 	req_access = list(28)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -871,6 +879,7 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -889,6 +898,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -952,6 +962,7 @@
 	locked = 1;
 	req_access = list(53)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -1097,6 +1108,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -1262,6 +1274,7 @@
 	c_tag = "Chapel South";
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -1514,6 +1527,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -1629,6 +1643,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -1898,6 +1913,8 @@
 	},
 /obj/item/clothing/head/fedora/white,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/item/weapon/present,
+/obj/item/weapon/present,
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "ada" = (
@@ -2026,6 +2043,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -2085,6 +2103,7 @@
 	name = "AI Chamber";
 	req_access = list(16)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2159,6 +2178,7 @@
 	dir = 4;
 	name = "Locker Room"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -2336,6 +2356,7 @@
 	id_tag = "Toilet_Med";
 	name = "Bathroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -2358,6 +2379,7 @@
 	name = "Shooting Range";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2368,6 +2390,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "afh" = (
@@ -2388,6 +2411,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -2419,6 +2443,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -2666,6 +2691,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/pie,
 /obj/machinery/light/small,
+/obj/item/weapon/present,
 /turf/simulated/floor{
 	icon_state = "redbluefull"
 	},
@@ -2733,6 +2759,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -2968,6 +2995,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -3053,6 +3081,7 @@
 /area/station/medical/cmo)
 "alc" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -3184,6 +3213,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "amy" = (
@@ -3195,6 +3225,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"amB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/primary)
 "amM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3377,6 +3411,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "anX" = (
@@ -3387,6 +3422,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "aog" = (
@@ -3515,6 +3551,7 @@
 	pixel_x = 32;
 	pixel_y = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -3658,6 +3695,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aqy" = (
@@ -3691,6 +3729,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "aqF" = (
@@ -3715,6 +3754,7 @@
 	name = "Supermatter Construction Area";
 	req_access = list(24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -3783,6 +3823,7 @@
 	name = "Genetic Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -3983,6 +4024,10 @@
 	},
 /turf/simulated/wall,
 /area/station/civilian/gym)
+"atE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/hop_office)
 "atL" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -4066,6 +4111,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "auq" = (
@@ -4137,6 +4183,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/cargo)
 "avV" = (
@@ -4224,6 +4271,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "awS" = (
@@ -4234,6 +4282,7 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "awU" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -4304,6 +4353,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
 "axK" = (
@@ -4337,6 +4387,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -4511,6 +4562,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -4595,6 +4647,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/rnd/xenobiology)
+"aAV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/vacantoffice)
 "aAZ" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hooded/wintercoat/science{
@@ -4672,6 +4728,7 @@
 	name = "Chemistry Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "aBG" = (
@@ -4700,6 +4757,7 @@
 /area/station/medical/virology)
 "aBP" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -4777,6 +4835,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "aDk" = (
@@ -4852,6 +4911,7 @@
 	name = "Blueshield Office Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/blueshield)
 "aEs" = (
@@ -4993,6 +5053,7 @@
 /obj/structure/reagent_dispensers/cleaner{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitebluecorner"
@@ -5081,6 +5142,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/atmos_office)
 "aGi" = (
@@ -5577,6 +5639,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Courtroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/dormitories/courtroom)
 "aLg" = (
@@ -5616,6 +5679,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "aMd" = (
@@ -5678,6 +5742,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "aMC" = (
@@ -5687,6 +5752,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/chamber)
 "aMD" = (
@@ -5842,6 +5908,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/sleeper)
 "aOo" = (
@@ -5864,6 +5931,7 @@
 /obj/machinery/door/airlock{
 	name = "Courtroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -6226,6 +6294,7 @@
 	icon_state = "gr_window"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "aSt" = (
@@ -6526,6 +6595,7 @@
 	name = "Bridge Access";
 	req_access = list(19)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -6593,6 +6663,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"aWH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/barbershop)
 "aWR" = (
 /obj/structure/stool/bed/chair/metal/green{
 	dir = 8
@@ -6709,6 +6783,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -6777,6 +6852,11 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"aZy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "aZz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6950,6 +7030,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "bbg" = (
@@ -6994,6 +7075,7 @@
 /area/station/maintenance/medbay)
 "bbt" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "purplecorner"
@@ -7129,6 +7211,7 @@
 	dir = 4;
 	name = "Chapel"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -7265,6 +7348,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -7429,6 +7513,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -7559,6 +7644,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -7608,6 +7694,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -7685,6 +7772,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -7751,6 +7839,7 @@
 	locked = 1;
 	name = "Escape Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "biT" = (
@@ -7815,6 +7904,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "bjt" = (
@@ -7963,6 +8053,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -8201,6 +8292,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "bmD" = (
@@ -8243,6 +8335,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "bmU" = (
@@ -8254,6 +8347,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -8277,6 +8371,7 @@
 	id = "CE_private";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "bni" = (
@@ -8287,6 +8382,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "bnp" = (
@@ -8383,6 +8479,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
 "bou" = (
@@ -8423,6 +8520,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/hallway/primary/starboard)
+"bpb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories/courtroom)
 "bpi" = (
 /obj/structure/fireplace,
 /turf/simulated/floor{
@@ -8669,6 +8770,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "bsh" = (
@@ -9078,6 +9180,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bwn" = (
@@ -9111,6 +9214,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
+/obj/item/decoration/snowflake,
 /turf/simulated/wall,
 /area/station/hallway/primary/central)
 "bwC" = (
@@ -9205,6 +9309,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot_old"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowpatch_inv"
 	},
@@ -9223,6 +9328,10 @@
 	icon_state = "whitechoco"
 	},
 /area/station/engineering/engine)
+"bxG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/primary/central)
 "bxO" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -9241,6 +9350,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"bya" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/auxsolarstarboard)
 "bye" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -9333,6 +9446,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "byU" = (
@@ -9581,6 +9695,7 @@
 /area/station/hallway/secondary/exit)
 "bAS" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -9598,6 +9713,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
 "bBe" = (
@@ -9855,6 +9971,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "bDu" = (
@@ -9914,6 +10031,7 @@
 	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/iaa_office)
 "bDU" = (
@@ -9938,6 +10056,7 @@
 	name = "Chapel Storage";
 	req_access = list(22)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -9962,6 +10081,7 @@
 	name = "Crematorium";
 	req_access = list(27)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10012,6 +10132,7 @@
 	name = "Security Post - Science";
 	req_access = list(2)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -10209,6 +10330,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "greenchoco"
 	},
@@ -10486,6 +10608,10 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
+"bJa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/hallway)
 "bJb" = (
 /obj/machinery/turretid/stun{
 	control_area = "AI Upload Chamber";
@@ -10564,6 +10690,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -10577,6 +10704,7 @@
 	req_access = list(22)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "bJs" = (
@@ -10705,6 +10833,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "bKv" = (
@@ -10907,6 +11036,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11268,6 +11398,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "bRd" = (
@@ -11302,11 +11433,13 @@
 	name = "Morgue";
 	req_access = list(5,6)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
 /area/station/medical/morgue)
 "bRA" = (
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -11333,11 +11466,16 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"bRS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/ai_monitored/storage_secure)
 "bRX" = (
 /turf/simulated/wall,
 /area/station/civilian/theatre)
 "bRY" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -11371,6 +11509,7 @@
 	name = "Robotist Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "bSq" = (
@@ -11459,6 +11598,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -11491,6 +11631,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/armoury)
 "bUp" = (
@@ -11761,6 +11902,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -11881,6 +12023,7 @@
 	name = "Research Division Access";
 	req_one_access = list(2,47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -11944,6 +12087,7 @@
 	dir = 4;
 	name = "Washroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "bYl" = (
@@ -12377,6 +12521,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"ccN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/security/main)
 "ccP" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -12547,6 +12706,10 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/starboard)
+"ceD" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/atmos/atmos_office)
 "ceI" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway South";
@@ -12595,6 +12758,7 @@
 	req_access = list(19)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -12621,6 +12785,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"cfE" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "cfF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -12840,6 +13008,10 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"chE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/meeting_room)
 "chU" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -13124,6 +13296,7 @@
 	name = "Corporate Lounge";
 	req_one_access = list(19,38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -13141,6 +13314,7 @@
 	pixel_x = 32;
 	pixel_y = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -13337,6 +13511,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/service_bedrooms)
 "cmX" = (
@@ -13452,6 +13627,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "coi" = (
@@ -13653,6 +13829,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "crz" = (
@@ -13857,6 +14034,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/bridge/captain_quarters)
 "cvc" = (
@@ -13953,6 +14131,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
 "cvO" = (
@@ -14074,6 +14253,17 @@
 	icon_state = "blackchoco"
 	},
 /area/station/aisat/teleport)
+"cwF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "cwM" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -14162,6 +14352,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/storage/tech)
+"cye" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/miningoffice)
 "cyh" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14321,6 +14515,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "czh" = (
@@ -14476,6 +14671,7 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -14491,6 +14687,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "cAF" = (
@@ -14710,6 +14907,7 @@
 	req_access = list(1)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -14757,6 +14955,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
 "cEz" = (
@@ -15278,6 +15477,10 @@
 	icon_state = "black"
 	},
 /area/station/civilian/chapel/mass_driver)
+"cJi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/bridge/teleporter)
 "cJr" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/firealarm{
@@ -15315,6 +15518,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot_old"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -15402,6 +15606,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"cLj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "cLm" = (
 /turf/simulated/wall,
 /area/station/maintenance/incinerator)
@@ -15476,6 +15684,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "cMd" = (
@@ -15486,6 +15695,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig/storage)
 "cMg" = (
@@ -15506,6 +15716,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -15844,6 +16055,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -16306,6 +16518,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "cUm" = (
@@ -16596,6 +16809,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "cYg" = (
@@ -16679,6 +16893,7 @@
 	req_access = list(35)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "cZS" = (
@@ -17066,6 +17281,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -17448,6 +17664,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "diq" = (
@@ -17682,6 +17899,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
 "dkc" = (
@@ -17894,6 +18112,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -18027,6 +18246,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -18172,6 +18392,7 @@
 	name = "Psychiatric Office";
 	req_access = list(64)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -18281,6 +18502,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "drY" = (
@@ -18473,6 +18695,17 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"dtU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/civilian/gym)
 "dtY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -18611,12 +18844,17 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/bar)
+"dvA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/chargebay)
 "dvH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "dvU" = (
@@ -18815,6 +19053,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -18852,6 +19091,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
+"dxP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/cmo)
 "dxR" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -18949,6 +19192,19 @@
 	icon_state = "neutral"
 	},
 /area/station/medical/chemistry)
+"dzk" = (
+/obj/structure/table,
+/obj/item/weapon/kitchen/utensil/fork{
+	pixel_x = 4
+	},
+/obj/item/weapon/kitchen/utensil/spoon{
+	pixel_x = -5
+	},
+/obj/item/weapon/present,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
+/area/station/hallway/primary/fore)
 "dzl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -18998,6 +19254,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "dAh" = (
@@ -19178,6 +19435,7 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "darkblue"
@@ -19329,6 +19587,10 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"dFk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/interrogation)
 "dFp" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -19351,6 +19613,7 @@
 	dir = 4;
 	name = "Dormitory"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -19459,6 +19722,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "dGH" = (
@@ -19486,6 +19750,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories/courtroom)
 "dHc" = (
@@ -19773,6 +20038,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
 "dKw" = (
@@ -19790,8 +20056,13 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/atmos_office)
+"dKJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint/escape)
 "dKL" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-5"
@@ -19813,6 +20084,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "evacbar_shutters"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "dKV" = (
@@ -20175,6 +20447,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/rnd/chargebay)
+"dQs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "dQz" = (
 /obj/random/scrap/safe_even,
 /turf/simulated/floor/plating,
@@ -20238,6 +20514,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "dRX" = (
@@ -20252,6 +20529,24 @@
 	icon_state = "blackchoco"
 	},
 /area/station/aisat/antechamber_interior)
+"dSi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "bar_reva_shuttes";
+	name = "Bar Shutters";
+	opacity = 0
+	},
+/obj/item/weapon/present,
+/turf/simulated/floor{
+	icon_state = "blackchoco"
+	},
+/area/station/hallway/primary/fore)
 "dSt" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/stool,
@@ -20444,6 +20739,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "dUa" = (
@@ -20457,6 +20753,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "dUn" = (
@@ -20863,6 +21160,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/rnd/hor)
+"dYz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/escape)
 "dYB" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/wood,
@@ -20881,6 +21182,7 @@
 	dir = 4;
 	dock_tag = "pod3"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "dYR" = (
@@ -21789,6 +22091,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -22328,6 +22631,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -22381,6 +22685,7 @@
 "epk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -22471,6 +22776,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "erG" = (
@@ -22629,6 +22935,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "eto" = (
@@ -22671,6 +22978,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Escape Hall"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -22813,6 +23121,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -22830,6 +23139,7 @@
 	name = "AI Upload Access";
 	req_access = list(16)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -22848,6 +23158,7 @@
 	name = "Warden's Office";
 	req_access = list(3)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -23067,6 +23378,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "exA" = (
@@ -23075,6 +23387,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "exB" = (
@@ -23133,6 +23446,7 @@
 /area/station/cargo/office)
 "exM" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -23158,11 +23472,9 @@
 	},
 /area/station/engineering/break_room)
 "eyj" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/green,
-/area/station/hallway/primary/fore)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/nuke_storage)
 "eyp" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Teleporter";
@@ -23342,6 +23654,18 @@
 /obj/item/weapon/bell,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
+"eAs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemistry Reception";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/chapel)
 "eAx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -23360,6 +23684,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "eAD" = (
@@ -23460,6 +23785,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -23537,6 +23863,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -23643,10 +23970,17 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
 /area/station/civilian/locker)
+"eEa" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	icon_state = "graychoco"
+	},
+/area/station/hallway/primary/fore)
 "eEq" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -23666,6 +24000,7 @@
 	req_access = list(25)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -23760,6 +24095,7 @@
 /obj/machinery/computer/skills,
 /obj/structure/table/reinforced,
 /obj/machinery/light/small,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkblue"
 	},
@@ -23853,6 +24189,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "eHc" = (
@@ -24369,6 +24706,7 @@
 	name = "Brig Maintenance";
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "eMn" = (
@@ -24390,6 +24728,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "eMv" = (
@@ -24779,6 +25118,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blackcorner"
@@ -24855,6 +25195,7 @@
 	dir = 4;
 	name = "Library"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -24927,6 +25268,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
 "eSi" = (
@@ -25078,6 +25420,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "eTL" = (
@@ -25170,6 +25513,7 @@
 	name = "Psychiatric Office";
 	req_access = list(64)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -25283,6 +25627,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
+"eWW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint/cargo)
 "eXa" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/belt/utility,
@@ -25294,6 +25642,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/chamber)
 "eXp" = (
@@ -25340,6 +25689,7 @@
 	pixel_x = 26;
 	pixel_y = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit"
 	},
@@ -25546,6 +25896,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -25565,6 +25916,7 @@
 	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -25729,6 +26081,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -25910,6 +26263,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "fcZ" = (
@@ -25949,6 +26303,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "fdw" = (
@@ -26058,6 +26413,7 @@
 	name = "Science Lab Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "fez" = (
@@ -26303,6 +26659,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "fgA" = (
@@ -26495,9 +26852,9 @@
 /turf/simulated/wall,
 /area/station/hallway/primary/central)
 "fjB" = (
-/obj/structure/stool/bar,
-/turf/simulated/floor/carpet/green,
-/area/station/hallway/primary/fore)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/sleeper)
 "fjF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -26576,6 +26933,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -26707,6 +27065,7 @@
 	name = "Brig Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig/equipment)
 "flv" = (
@@ -26914,6 +27273,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot_old"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -26948,12 +27308,13 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "fpT" = (
-/obj/structure/table/woodentable/poker,
-/obj/item/toy/cards,
-/turf/simulated/floor/carpet/green,
+/obj/item/device/flashlight/lamp/fir/special,
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
 /area/station/hallway/primary/fore)
 "fqg" = (
 /obj/item/weapon/table_parts/wood/fancy,
@@ -27233,6 +27594,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "fsv" = (
@@ -27255,6 +27617,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -27469,6 +27832,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
+"ftV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge)
 "ftZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/machinery/door/firedoor,
@@ -27501,6 +27868,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/teleporter)
 "fuu" = (
@@ -27772,6 +28140,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/hos)
 "fxb" = (
@@ -27803,6 +28172,7 @@
 	name = "Security Office";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
@@ -27824,6 +28194,13 @@
 	icon_state = "greencorner"
 	},
 /area/station/civilian/hydroponics)
+"fxx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/gym)
 "fxH" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -27845,6 +28222,10 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"fye" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/library)
 "fym" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -27969,6 +28350,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/sleeper)
 "fzz" = (
@@ -28002,6 +28384,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/atmos_office)
 "fzV" = (
@@ -28291,6 +28674,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "fDA" = (
@@ -28310,6 +28694,7 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "fDB" = (
@@ -28331,6 +28716,10 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"fDI" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/lab)
 "fDL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28584,6 +28973,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/rnd/hor)
+"fHk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint/escape_custom_desk)
 "fHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -28731,6 +29124,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/server)
 "fJg" = (
@@ -28826,6 +29220,7 @@
 	name = "Supply Dock Airlock";
 	req_access = list(31)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "fJR" = (
@@ -28929,6 +29324,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"fKQ" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall,
+/area/station/cargo/office)
 "fKS" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
@@ -29504,6 +29903,7 @@
 /area/station/hallway/primary/fore)
 "fSC" = (
 /obj/machinery/vending/theater,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -29580,6 +29980,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -29598,6 +29999,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "fTK" = (
@@ -29700,6 +30102,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "fVI" = (
@@ -29805,6 +30208,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/rnd/mixing)
+"fWr" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/chamber)
 "fWu" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -29820,6 +30227,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "fWz" = (
@@ -29878,6 +30286,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "fXg" = (
@@ -30123,6 +30532,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/atmos_office)
 "fZJ" = (
@@ -30189,6 +30599,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"gaz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/emergency)
 "gaF" = (
 /turf/simulated/floor,
 /area/station/cargo/storage)
@@ -30355,6 +30769,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"gcx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/reception)
 "gcE" = (
 /obj/machinery/atmospherics/components/trinary/filter/m_filter,
 /turf/simulated/floor,
@@ -30427,6 +30845,7 @@
 	name = "MiniSat Antechamber";
 	req_one_access = list(66)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -30454,6 +30873,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "gdV" = (
@@ -30463,6 +30883,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -30874,6 +31295,7 @@
 	name = "MiniSat Antechamber";
 	req_one_access = list(66)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31058,6 +31480,7 @@
 /area/station/rnd/hallway/lobby)
 "gjZ" = (
 /obj/item/weapon/flora/random,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "darkblue"
@@ -31190,6 +31613,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cryo)
 "gld" = (
@@ -31272,6 +31696,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "glD" = (
@@ -31415,6 +31840,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "gmW" = (
@@ -31517,6 +31943,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -31852,8 +32279,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"grV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/storage)
 "grX" = (
 /obj/structure/table/reinforced,
 /obj/item/device/tagger/shop,
@@ -31899,6 +32331,10 @@
 /obj/structure/window/thin/reinforced,
 /turf/environment/space,
 /area/space)
+"gsB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/locker)
 "gsC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=SSW-B";
@@ -31942,6 +32378,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "gte" = (
@@ -32004,6 +32441,7 @@
 	name = "QM Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "gtG" = (
@@ -32374,6 +32812,7 @@
 	name = "Execution Blast";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/execution)
 "gwa" = (
@@ -32565,6 +33004,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "gyi" = (
@@ -32696,6 +33136,7 @@
 	name = "Medical Lobby Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "gyZ" = (
@@ -32735,6 +33176,10 @@
 	},
 /turf/simulated/wall,
 /area/station/cargo/miningoffice)
+"gzq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/tech)
 "gzs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32818,6 +33263,7 @@
 	pixel_x = 6;
 	pixel_y = 12
 	},
+/obj/item/weapon/present,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -32828,6 +33274,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "gAl" = (
@@ -33069,6 +33516,17 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"gDD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/atmos)
 "gDL" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33237,6 +33695,7 @@
 	name = "Research and Development Lab";
 	req_one_access = list(7,29)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -33359,6 +33818,7 @@
 	name = "Privacy Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
 "gHs" = (
@@ -33407,6 +33867,10 @@
 	icon_state = "neutral"
 	},
 /area/station/security/main)
+"gHI" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories)
 "gHT" = (
 /turf/simulated/floor{
 	icon_state = "graychoco"
@@ -33485,6 +33949,7 @@
 	dir = 8;
 	req_access = list(46)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "gIt" = (
@@ -33565,6 +34030,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Barbershop"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -33630,6 +34096,7 @@
 /area/station/maintenance/chapel)
 "gKo" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blackcorner"
@@ -34093,6 +34560,10 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"gQk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/atmos)
 "gQo" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -34281,6 +34752,7 @@
 	pixel_x = 4;
 	pixel_y = 23
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -34305,6 +34777,7 @@
 	name = "Research Director Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/server)
 "gSE" = (
@@ -34333,6 +34806,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "gSP" = (
@@ -34478,6 +34952,7 @@
 	},
 /area/station/medical/cryo)
 "gUf" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -34793,6 +35268,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "gXb" = (
@@ -34902,6 +35378,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "gYu" = (
@@ -35044,6 +35521,7 @@
 	dir = 1;
 	icon_state = "warn_corner"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -35195,6 +35673,7 @@
 "hbE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -35219,6 +35698,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "hbR" = (
@@ -35242,8 +35722,13 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
+"hcb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/blueshield)
 "hcn" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -35700,6 +36185,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
 "hjc" = (
@@ -36196,6 +36682,10 @@
 	icon_state = "caution"
 	},
 /area/station/hallway/primary/port)
+"hon" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/gym)
 "hoM" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -36488,6 +36978,10 @@
 	icon_state = "redchecker"
 	},
 /area/station/civilian/barbershop)
+"hqY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/teleport)
 "hrc" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -36504,6 +36998,7 @@
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -36527,6 +37022,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "hrv" = (
@@ -36552,6 +37048,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "hrO" = (
@@ -36568,6 +37065,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -36687,6 +37185,7 @@
 /obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot_old"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -36720,6 +37219,10 @@
 	icon_state = "blackcorner"
 	},
 /area/station/civilian/chapel)
+"htr" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/brig)
 "htC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36729,6 +37232,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "htD" = (
@@ -36896,10 +37400,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/hos)
 "huB" = (
-/obj/structure/table/woodentable/poker,
-/obj/item/weapon/dice/d20,
-/turf/simulated/floor/carpet/green,
-/area/station/hallway/primary/fore)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/engine)
 "huO" = (
 /obj/structure/closet{
 	name = "evidence closet"
@@ -36993,6 +37496,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -37070,11 +37574,12 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "hwF" = (
-/obj/structure/table/woodentable/poker,
-/turf/simulated/floor/carpet/green,
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
 /area/station/hallway/primary/fore)
 "hwM" = (
 /obj/structure/table/reinforced,
@@ -37206,6 +37711,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "hxU" = (
@@ -37346,6 +37852,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "hzh" = (
@@ -37694,6 +38201,10 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/security/prison)
+"hBq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/tools)
 "hBr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -37760,6 +38271,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"hCm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/lobby)
 "hCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37824,6 +38339,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "hDc" = (
@@ -37918,6 +38434,7 @@
 	name = "Brig Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "hDN" = (
@@ -37941,6 +38458,7 @@
 	dir = 2;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -38444,6 +38962,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/detectives_office)
 "hJt" = (
@@ -38577,6 +39096,7 @@
 	pixel_x = 15;
 	pixel_y = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/chapel/office)
 "hLk" = (
@@ -38651,6 +39171,7 @@
 	name = "Medical Lobby Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "hMb" = (
@@ -38777,6 +39298,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"hNH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/engineering)
 "hNK" = (
 /turf/simulated/wall,
 /area/station/engineering/atmos/supermatter)
@@ -38885,6 +39410,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
 "hPa" = (
@@ -38969,6 +39495,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape_custom_desk)
 "hPP" = (
@@ -39279,6 +39806,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "hUj" = (
@@ -39539,6 +40067,7 @@
 	dir = 4;
 	name = "Library"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -39668,6 +40197,7 @@
 	name = "Auxiliary Construction Zone";
 	req_one_access = list(23,65,48)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "hXp" = (
@@ -39708,6 +40238,7 @@
 "hXC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -39734,6 +40265,7 @@
 	name = "Bridge Access";
 	req_access = list(19)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -40010,10 +40542,9 @@
 	},
 /area/station/rnd/hor)
 "ibe" = (
-/obj/structure/table/woodentable/poker,
-/obj/item/weapon/storage/pill_bottle/dice,
-/turf/simulated/floor/carpet/green,
-/area/station/hallway/primary/fore)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/gateway)
 "ibg" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/electrical{
@@ -40102,6 +40633,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"ibN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/forensic_office)
 "ibP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40263,6 +40798,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "idQ" = (
@@ -40372,6 +40908,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "ifx" = (
@@ -40882,6 +41419,7 @@
 	},
 /area/station/security/brig)
 "ikZ" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -40907,6 +41445,7 @@
 	name = "Detectives Lockdown";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/forensic_office)
 "ilj" = (
@@ -40993,6 +41532,7 @@
 /obj/item/weapon/storage/box/flashbangs{
 	pixel_x = 20
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -41080,6 +41620,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitehall"
@@ -41113,6 +41654,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/rnd/mixing)
+"imG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/chapel)
 "imK" = (
 /turf/simulated/floor{
 	icon_state = "blackchoco"
@@ -41717,6 +42262,7 @@
 	name = "Brig Restroom"
 	},
 /obj/effect/decal/turf_decal/set_burned,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
 "iup" = (
@@ -41845,6 +42391,7 @@
 	dir = 8
 	},
 /obj/structure/window/thin/reinforced,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "ivD" = (
@@ -41897,6 +42444,7 @@
 	dir = 6;
 	network = list("SS13","Research")
 	},
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -42113,6 +42661,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "iyJ" = (
@@ -42121,6 +42670,10 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor,
 /area/station/storage/primary)
+"iyP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/chiefs_office)
 "iyV" = (
 /obj/structure/window/thin,
 /obj/effect/decal/turf_decal{
@@ -42378,6 +42931,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -42463,6 +43017,7 @@
 	name = "Chapel Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "iCW" = (
@@ -42601,6 +43156,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitechoco"
 	},
@@ -42829,6 +43385,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "iGy" = (
@@ -43062,6 +43619,7 @@
 	dir = 2;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -43101,6 +43659,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories/service_bedrooms)
 "iJj" = (
@@ -43659,6 +44218,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"iPT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/hallway/lobby)
 "iPV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -43773,6 +44336,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -43799,6 +44363,7 @@
 	name = "Medbay right APC";
 	pixel_x = 27
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluecorner"
 	},
@@ -43916,6 +44481,7 @@
 	name = "Bridge Access";
 	req_access = list(19)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -44128,6 +44694,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "iUS" = (
@@ -44310,6 +44877,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/aisat/teleport)
+"iWz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/psych)
 "iWC" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -44326,6 +44897,7 @@
 	name = "Security Transferring Center";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -44450,6 +45022,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -44481,6 +45054,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -44806,6 +45380,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "jcC" = (
@@ -44836,6 +45411,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"jcM" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/server)
 "jcN" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway North";
@@ -44874,6 +45453,13 @@
 	icon_state = "dark"
 	},
 /area/station/security/blueshield)
+"jdb" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "jde" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -44915,6 +45501,10 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"jdN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/warden)
 "jdS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -45290,6 +45880,12 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"jhD" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "blackchoco"
+	},
+/area/station/civilian/dormitories/service_bedrooms)
 "jhH" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/simulated/floor/bluegrid{
@@ -45476,6 +46072,10 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"jjF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/virology)
 "jjN" = (
 /obj/decal/boxingrope,
 /obj/structure/window/thin,
@@ -45670,6 +46270,7 @@
 /area/station/medical/cmo)
 "jlH" = (
 /obj/machinery/door/airlock/multi_tile/glass,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -45902,6 +46503,7 @@
 	name = "Robotics Lab";
 	req_access = list(29)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -45921,6 +46523,7 @@
 	dir = 4;
 	icon_state = "siding_wood_corner"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "jps" = (
@@ -46016,6 +46619,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -46059,6 +46663,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/hos)
 "jqQ" = (
@@ -46069,6 +46674,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "jra" = (
@@ -46193,6 +46799,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -46419,6 +47026,7 @@
 	req_access = list(45)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -46480,6 +47088,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitechoco"
 	},
@@ -46574,6 +47183,10 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/security/prison)
+"jvr" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/storage/emergency2)
 "jvv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46629,6 +47242,12 @@
 /obj/item/weapon/circuitboard/oven,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"jwi" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "jwn" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
@@ -46861,6 +47480,10 @@
 	icon_state = "bluechecker"
 	},
 /area/station/medical/storage)
+"jxJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/cold_room)
 "jxP" = (
 /obj/machinery/vending/barbervend,
 /turf/simulated/floor/wood,
@@ -46880,6 +47503,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "jyc" = (
@@ -47016,6 +47640,7 @@
 	name = "Chapel Office";
 	req_access = list(22)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -47245,6 +47870,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -47563,10 +48189,15 @@
 	name = "MiniSat Access";
 	req_access = list(66)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluechoco"
 	},
 /area/station/engineering/minisat_secure_area)
+"jGh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories/service_bedrooms)
 "jGn" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/cups,
@@ -47576,6 +48207,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -47646,6 +48278,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "jHw" = (
@@ -47673,6 +48306,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Primary Tool Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -47960,6 +48594,10 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"jJO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/telesci)
 "jKp" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -48327,6 +48965,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "jNt" = (
@@ -48340,6 +48979,7 @@
 	dir = 4;
 	name = "Cryogenic Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -48418,6 +49058,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -48570,6 +49211,7 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -48676,6 +49318,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "jQh" = (
@@ -48771,6 +49414,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "jQT" = (
@@ -48952,6 +49596,7 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "jUj" = (
@@ -49289,6 +49934,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -49411,6 +50057,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "jYp" = (
@@ -49507,6 +50154,7 @@
 	name = "QM Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "jZh" = (
@@ -49531,6 +50179,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -49568,6 +50217,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -49711,7 +50361,7 @@
 	},
 /area/station/civilian/locker)
 "kco" = (
-/obj/item/weapon/flora/random,
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "neutral"
@@ -50015,6 +50665,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -50133,6 +50784,7 @@
 	name = "Corporate Lounge Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "kfZ" = (
@@ -50278,6 +50930,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -50371,6 +51024,7 @@
 	name = "Research Director Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "kiP" = (
@@ -50380,6 +51034,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blackcorner"
@@ -50737,6 +51392,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "kmK" = (
@@ -50771,6 +51427,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -50836,6 +51493,7 @@
 	name = "Vacant Office";
 	pixel_x = -26
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowcorner"
@@ -50850,6 +51508,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -50933,6 +51592,7 @@
 	name = "Telecomms Server Room";
 	req_access = list(61)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -51246,6 +51906,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "krR" = (
@@ -51342,6 +52003,7 @@
 	name = "Meeting Room Window Shields";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "ksG" = (
@@ -51496,7 +52158,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "kuo" = (
-/obj/item/weapon/flora/random,
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "neutral"
@@ -51533,6 +52195,7 @@
 /obj/effect/decal/turf_decal/dark_red{
 	icon_state = "box_corners_white"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -51872,6 +52535,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -51994,6 +52658,7 @@
 	dir = 8;
 	icon_state = "warn_corner"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -52358,6 +53023,10 @@
 /obj/machinery/life_assist/artificial_ventilation,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"kEK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/engineering)
 "kET" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -52399,6 +53068,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "kFq" = (
@@ -52484,6 +53154,22 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard)
+"kGd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "kitchen_shuttes";
+	name = "KitchenShutters";
+	opacity = 0
+	},
+/obj/item/weapon/present,
+/turf/simulated/floor/plating,
+/area/station/civilian/kitchen)
 "kGh" = (
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/engineering/atmos/supermatter)
@@ -52600,6 +53286,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -53008,6 +53695,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kKi" = (
@@ -53072,6 +53760,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/chapel/office)
 "kKJ" = (
@@ -53179,6 +53868,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -53232,6 +53922,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage_secure)
+"kMg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "kMi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -53270,6 +53969,7 @@
 	name = "Arrival Airlock";
 	req_one_access = list(65,48)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kMw" = (
@@ -53417,6 +54117,7 @@
 	name = "Genetic Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "kOe" = (
@@ -53460,6 +54161,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "kOR" = (
@@ -53507,6 +54209,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"kPK" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/wood,
+/area/station/civilian/library)
 "kQf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -53576,6 +54282,7 @@
 /area/station/rnd/robotics)
 "kRo" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -53592,6 +54299,7 @@
 	name = "Atmospherics Maintenance";
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "kRI" = (
@@ -53735,6 +54443,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "kSE" = (
@@ -53749,6 +54458,7 @@
 	req_access = list(25)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "kSI" = (
@@ -53784,6 +54494,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -53910,6 +54621,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -53919,6 +54631,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"kUi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/fore)
 "kUm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53945,6 +54661,7 @@
 	name = "Drone Bay";
 	req_one_access = list(31,48)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -54187,6 +54904,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -54323,6 +55041,7 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -54397,6 +55116,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -54735,6 +55455,7 @@
 	pixel_x = -32;
 	pixel_y = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -54812,6 +55533,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/engineering/atmos)
+"lei" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/genetics)
 "les" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -54907,6 +55632,7 @@
 	dir = 4;
 	name = "Service Bedrooms"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -55046,6 +55772,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/security/brig)
+"lic" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/medbreak)
 "lij" = (
 /obj/structure/cable,
 /obj/effect/decal/turf_decal/wood/dark{
@@ -55569,6 +56299,10 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"lnu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/crematorium)
 "lnK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55658,6 +56392,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"loY" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/civilian/gym)
 "lpw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -55872,6 +56615,7 @@
 	name = "Infirmary"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -55996,6 +56740,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "lsw" = (
@@ -56055,6 +56800,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
 "lsP" = (
@@ -56131,6 +56877,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
 "ltP" = (
@@ -56151,6 +56898,10 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"lue" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/cryo)
 "lum" = (
 /obj/structure/stool/bed,
 /obj/structure/cable{
@@ -56401,6 +57152,7 @@
 	name = "Medbay Storage";
 	req_access = list(72)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -56464,6 +57216,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
 "lxv" = (
@@ -56593,6 +57346,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/engineering/chiefs_office)
+"lzq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel)
 "lzr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -56771,6 +57528,7 @@
 	name = "Security Post - Engineering";
 	req_access = list(2)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -56816,6 +57574,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -57104,6 +57863,7 @@
 	name = "Primary Tool Storage";
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
 "lFs" = (
@@ -57111,6 +57871,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "lFG" = (
@@ -57209,6 +57970,7 @@
 	id = "HoP_private";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "lGn" = (
@@ -57338,6 +58100,7 @@
 	name = "Genetic Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "lIf" = (
@@ -57502,6 +58265,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "lJP" = (
@@ -57658,6 +58422,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "lLH" = (
@@ -57736,6 +58501,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "lMA" = (
@@ -57772,6 +58538,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -57912,10 +58679,9 @@
 	},
 /area/station/civilian/gym)
 "lNt" = (
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/structure/table/woodentable/poker,
-/turf/simulated/floor/carpet/green,
-/area/station/hallway/primary/fore)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/ai_upload)
 "lNx" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -58236,6 +59002,7 @@
 	name = "Armoury";
 	req_access = list(3)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -58416,6 +59183,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -58570,6 +59338,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/blueshield)
 "lVc" = (
@@ -58602,6 +59371,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
 "lVA" = (
@@ -58738,6 +59508,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "lXB" = (
@@ -58752,6 +59523,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -58807,6 +59579,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"lYj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/hos)
 "lYm" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -59223,6 +59999,7 @@
 "mdQ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/gun/projectile/grenade_launcher/m79,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -59277,6 +60054,7 @@
 	name = "Surgery Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
 "meW" = (
@@ -59291,6 +60069,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
 "mfa" = (
@@ -59553,6 +60332,7 @@
 	req_one_access = list(12,22)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "mhX" = (
@@ -60042,6 +60822,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "mmV" = (
@@ -60069,6 +60850,24 @@
 "mne" = (
 /turf/simulated/wall,
 /area/station/medical/sleeper)
+"mng" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "bar_reva_shuttes";
+	name = "Bar Shutters";
+	opacity = 0
+	},
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	icon_state = "blackchoco"
+	},
+/area/station/hallway/primary/fore)
 "mnm" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
@@ -60388,6 +61187,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/service_bedrooms)
 "mqL" = (
@@ -60435,6 +61235,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -60523,6 +61324,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "mso" = (
@@ -60541,6 +61343,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
 "msK" = (
@@ -60657,6 +61460,10 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"mtB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/break_room)
 "mtD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60680,6 +61487,7 @@
 	name = "AI Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/aisat/ai_chamber)
 "mtH" = (
@@ -60702,6 +61510,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "mtI" = (
@@ -61109,8 +61918,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"myK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/office)
 "myX" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -61134,6 +61948,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/engineering/engine)
+"mzc" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/drone_fabrication)
 "mzd" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -61168,6 +61986,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/weapon/present,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -61197,6 +62016,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "mzT" = (
@@ -61451,6 +62271,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "mBA" = (
@@ -61496,6 +62317,7 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "mBF" = (
@@ -61558,6 +62380,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "mBV" = (
@@ -61709,6 +62532,7 @@
 "mEq" = (
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table/woodentable,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -61856,6 +62680,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/locker)
 "mGd" = (
@@ -62003,6 +62828,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "mIZ" = (
@@ -62040,6 +62866,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "mJs" = (
@@ -62346,6 +63173,10 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"mNN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/aisat)
 "mNU" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -62395,6 +63226,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "mOt" = (
@@ -62559,10 +63391,15 @@
 "mQh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"mQj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/drone_fabrication)
 "mQk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -62738,6 +63575,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"mRs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/surgeryobs)
 "mRu" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -62858,6 +63699,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "evacbar_shutters"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "mSq" = (
@@ -62989,6 +63831,7 @@
 	name = "QM Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "mTN" = (
@@ -63058,6 +63901,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -63128,6 +63972,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
 "mVg" = (
@@ -63196,6 +64041,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -63358,6 +64204,7 @@
 	dir = 4;
 	req_access = list(6)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluechoco"
 	},
@@ -63385,6 +64232,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"mXB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/brig)
 "mXC" = (
 /turf/simulated/wall,
 /area/station/cargo/lobby)
@@ -63580,6 +64431,10 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"mZS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/minisat_secure_area)
 "mZU" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -63645,6 +64500,7 @@
 	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -63676,6 +64532,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/tech)
+"naE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/checkpoint/medbay)
 "naF" = (
 /obj/structure/sign/poster/official/build{
 	pixel_y = 32
@@ -63687,6 +64547,7 @@
 /obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot_old"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -63878,6 +64739,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitebluecorner"
@@ -63900,6 +64762,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
 "neh" = (
@@ -64009,6 +64872,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -64533,6 +65397,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "nlV" = (
@@ -64753,6 +65618,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "noq" = (
@@ -65163,6 +66029,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -65224,6 +66091,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "nsr" = (
@@ -66014,6 +66882,10 @@
 	icon_state = "greencorner"
 	},
 /area/station/civilian/hydroponics)
+"nBx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycleroffice)
 "nBB" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -66075,6 +66947,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/rnd/xenobiology)
+"nCq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/atmos)
 "nCD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66113,6 +66989,10 @@
 	},
 /turf/simulated/floor,
 /area/station/security/range)
+"nCM" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/detectives_office)
 "nCP" = (
 /obj/machinery/door/window/brigdoor/northright{
 	req_access = list(20)
@@ -66422,6 +67302,7 @@
 	name = "Surgery Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
 "nFZ" = (
@@ -66555,6 +67436,7 @@
 	name = "Corporate Lounge Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/corp_lounge)
 "nHj" = (
@@ -66565,6 +67447,7 @@
 	dir = 4;
 	name = "Recreation Room"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/gym)
 "nHp" = (
@@ -66830,6 +67713,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/gym)
 "nKi" = (
@@ -66848,6 +67732,18 @@
 /obj/item/stack/medical/bruise_pack/rags/not_old,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"nKG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/port)
 "nKH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67020,6 +67916,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "nNm" = (
@@ -67059,6 +67956,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "nNX" = (
@@ -67067,6 +67965,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
 "nOh" = (
@@ -67238,6 +68137,7 @@
 	icon_state = "gr_window"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
 "nQd" = (
@@ -67447,6 +68347,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "nRs" = (
@@ -67694,6 +68595,10 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"nTE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/misc_lab)
 "nTN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -67745,6 +68650,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "nUj" = (
@@ -67855,6 +68761,7 @@
 	name = "Bridge Access";
 	req_access = list(19)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -67876,6 +68783,7 @@
 	dir = 4;
 	name = "Primary Tool Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -67917,6 +68825,17 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"nWo" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "nWy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -67978,6 +68897,7 @@
 	name = "Chief Medical Officer";
 	req_access = list(40)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -68070,6 +68990,7 @@
 	name = "Engine Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "nXD" = (
@@ -68243,6 +69164,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape_custom_desk)
 "nYQ" = (
@@ -68288,6 +69210,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -68327,6 +69250,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
+"nZK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/kitchen)
 "nZW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -68403,6 +69330,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "oaG" = (
@@ -68416,6 +69344,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/engineering/atmos/supermatter)
+"oaO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/hydroponics)
 "oaP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -68596,6 +69528,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -68634,6 +69567,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "odu" = (
@@ -68954,6 +69888,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -69065,6 +70000,10 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"oih" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall,
+/area/station/maintenance/atmos)
 "oii" = (
 /obj/structure/closet/secure_closet,
 /obj/random/misc/storage,
@@ -69387,6 +70326,10 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
+"omU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/prison)
 "omV" = (
 /turf/simulated/wall,
 /area/station/security/checkpoint)
@@ -69442,6 +70385,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"oon" = (
+/obj/item/weapon/flora/random,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "graychoco"
+	},
+/area/station/civilian/chapel)
 "oos" = (
 /obj/structure/particle_accelerator/power_box{
 	dir = 8
@@ -69504,6 +70454,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/civilian/chapel)
+"opF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/starboard)
 "opJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69527,6 +70481,7 @@
 /obj/effect/decal/turf_decal/dark_red{
 	icon_state = "siding_line"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/hos)
 "oqc" = (
@@ -69536,6 +70491,7 @@
 	req_access = list(62)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -69691,6 +70647,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -69749,6 +70706,7 @@
 	name = "Medical Lobby Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "otd" = (
@@ -69980,6 +70938,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "ouZ" = (
@@ -70062,6 +71021,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/engineering/break_room)
+"ows" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall,
+/area/station/maintenance/cargo)
 "owz" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -70171,6 +71134,7 @@
 	dir = 2;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -70193,6 +71157,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"oyI" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint)
+"oyT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/qm)
 "ozc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70210,6 +71182,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "ozn" = (
@@ -70385,6 +71358,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot_old"
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -70570,6 +71544,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -70606,6 +71581,7 @@
 	dir = 2;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -70734,6 +71710,7 @@
 /obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_corner"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "oFq" = (
@@ -71100,6 +72077,7 @@
 	name = "Prison Wing";
 	req_access = list(2)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -71158,7 +72136,7 @@
 	},
 /area/station/security/prison)
 "oJP" = (
-/obj/item/weapon/flora/random,
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "neutral"
@@ -71218,6 +72196,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -71314,6 +72293,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
 "oLD" = (
@@ -71455,6 +72435,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -71535,6 +72516,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"oNc" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/exit)
 "oNn" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -71818,6 +72803,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Escape Hall"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "oQd" = (
@@ -72117,6 +73103,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -72508,6 +73495,7 @@
 /area/station/rnd/robotics)
 "oZh" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbrownchoco"
 	},
@@ -72557,6 +73545,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "oZK" = (
@@ -72716,6 +73705,7 @@
 	dir = 4;
 	name = "Chapel Mass Driver"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -72850,6 +73840,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "pea" = (
@@ -73048,6 +74039,7 @@
 	name = "Brig Maintenance";
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -73067,6 +74059,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "pfR" = (
@@ -73085,6 +74078,7 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -73103,6 +74097,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"pgq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos)
 "pgt" = (
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
 	pixel_x = 3
@@ -73612,6 +74610,7 @@
 /obj/structure/sign/poster/official/love_ian{
 	pixel_x = 32
 	},
+/obj/item/weapon/present,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "pmc" = (
@@ -73669,6 +74668,7 @@
 	name = "Robotist Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -73821,6 +74821,7 @@
 	dir = 4;
 	name = "Chapel"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -74273,6 +75274,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "ptj" = (
@@ -74401,6 +75403,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -74514,6 +75517,7 @@
 	id = "CE_private";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "pws" = (
@@ -74570,6 +75574,7 @@
 "pwE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donkpockets,
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -74936,6 +75941,7 @@
 	name = "Engineering External Access";
 	req_one_access = list(10,11,13,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "pzD" = (
@@ -75076,6 +76082,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -75144,6 +76151,7 @@
 	name = "Detectives Lockdown";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "pBC" = (
@@ -75352,6 +76360,7 @@
 	req_access = list(2)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -75367,6 +76376,7 @@
 	name = "Primary Tool Storage"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -75489,6 +76499,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "pFf" = (
@@ -75533,6 +76544,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -75619,6 +76631,7 @@
 	req_one_access = list(2,5)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -75642,6 +76655,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "pGN" = (
@@ -75673,6 +76687,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
 "pHc" = (
@@ -75709,6 +76724,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -75880,6 +76896,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -75968,6 +76985,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/structure/transit_tube,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "pLw" = (
@@ -76028,6 +77046,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -76302,6 +77321,7 @@
 	name = "Brig Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig/storage)
 "pPp" = (
@@ -76525,6 +77545,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -76831,6 +77852,7 @@
 	id = "CE_private";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "pUK" = (
@@ -76897,6 +77919,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
+/obj/item/weapon/present,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -77179,6 +78202,7 @@
 	name = "Locker Room Showers"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
 "pZb" = (
@@ -77352,6 +78376,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -77408,6 +78433,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
 "qbu" = (
@@ -77460,6 +78486,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "qbB" = (
@@ -77580,6 +78607,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -77646,6 +78674,7 @@
 	name = "Prison Lockdown";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "qec" = (
@@ -77690,6 +78719,7 @@
 	dir = 4;
 	name = "Reading Bay"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -77764,6 +78794,7 @@
 	name = "Brig Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "qfJ" = (
@@ -77786,6 +78817,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -78058,6 +79090,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -78254,6 +79287,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "qkU" = (
@@ -78267,6 +79301,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qlj" = (
@@ -78386,6 +79421,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -78404,6 +79440,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -78514,6 +79551,10 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/engineering)
+"qnJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/chemistry)
 "qnN" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -78806,6 +79847,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "qrj" = (
@@ -78869,6 +79911,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
 "qsh" = (
@@ -78992,6 +80035,7 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "qsX" = (
@@ -79264,6 +80308,7 @@
 	dir = 4;
 	name = "Holodeck Door"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -79276,6 +80321,7 @@
 	pixel_x = 5;
 	pixel_y = 28
 	},
+/obj/item/weapon/present,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -79304,6 +80350,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/storage)
+"qwN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/cargo)
 "qwP" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -79333,6 +80383,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "qxh" = (
@@ -79345,6 +80396,7 @@
 	id = "Visit Shutters";
 	name = "Visit Shutters"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "qxl" = (
@@ -79635,6 +80687,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "qBW" = (
@@ -79738,11 +80791,13 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "qDi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -79774,6 +80829,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/medical/cryo)
+"qDr" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/storage)
 "qDw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79834,6 +80893,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -79964,6 +81024,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -80037,6 +81098,7 @@
 	name = "CMO Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "qGc" = (
@@ -80066,6 +81128,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -80308,6 +81371,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "qIQ" = (
@@ -80429,6 +81493,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -80603,6 +81668,7 @@
 	name = "Corporate Lounge Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "qLO" = (
@@ -80715,6 +81781,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -80762,6 +81829,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
 	},
@@ -81000,6 +82068,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -81026,6 +82095,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -81199,6 +82269,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/toy/figure/dsquad,
+/obj/item/weapon/present,
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "qSZ" = (
@@ -81214,6 +82285,7 @@
 	name = "QM Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "qTl" = (
@@ -81372,6 +82444,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/rnd/scibreak)
+"qUB" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "qUN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/turf_decal{
@@ -81550,6 +82629,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "qXu" = (
@@ -81970,6 +83050,7 @@
 	name = "Brig Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "rbY" = (
@@ -82071,6 +83152,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/server)
 "rdK" = (
@@ -82395,6 +83477,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "rhK" = (
@@ -82434,6 +83517,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "riq" = (
@@ -82502,6 +83586,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "rjn" = (
@@ -82646,6 +83731,7 @@
 	name = "QM Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "rlC" = (
@@ -82823,6 +83909,7 @@
 	name = "Engineering External Access";
 	req_one_access = list(13,45,1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "rot" = (
@@ -83028,6 +84115,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "rqA" = (
@@ -83102,8 +84190,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"rrx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/primary/port)
 "rry" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -83268,6 +84361,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
 "rtt" = (
@@ -83546,6 +84640,7 @@
 	dir = 4;
 	name = "Dormitory"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -83671,8 +84766,13 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
+"rwY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/brig/equipment)
 "rxj" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/disk/nuclear,
@@ -83883,6 +84983,7 @@
 	req_access = list(25)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84066,6 +85167,7 @@
 	name = "MiniSat Antechamber";
 	req_one_access = list(66)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84132,6 +85234,7 @@
 	layer = 2.8;
 	name = "doorway barricade"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "rAU" = (
@@ -84152,6 +85255,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -84444,6 +85548,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -84694,6 +85799,7 @@
 	name = "Chemistry Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "rHZ" = (
@@ -84714,6 +85820,7 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -84817,6 +85924,7 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "rIx" = (
@@ -84826,6 +85934,7 @@
 	c_tag = "Security Escape Checkpoint";
 	dir = 9
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -85054,6 +86163,7 @@
 	name = "doorway barricade"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "rKp" = (
@@ -85064,6 +86174,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -85090,6 +86201,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "rKw" = (
@@ -85124,6 +86236,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "rKF" = (
@@ -85154,6 +86267,7 @@
 	name = "MiniSat Transit Tube Access";
 	req_access = list(66)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluechoco"
 	},
@@ -85299,6 +86413,7 @@
 	name = "Medical Lobby Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "rMP" = (
@@ -85382,6 +86497,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "rNL" = (
@@ -85432,6 +86548,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "rNY" = (
@@ -85536,6 +86653,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgeryobs)
+"rPv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/theatre)
 "rPA" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "1,2"
@@ -85554,6 +86675,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "rPH" = (
@@ -85570,6 +86692,10 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"rPI" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/mass_driver)
 "rPP" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=NW-B";
@@ -85610,6 +86736,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "rQp" = (
@@ -85713,6 +86840,7 @@
 /obj/machinery/recharger,
 /obj/structure/table/woodentable,
 /obj/machinery/light/smart,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "rRv" = (
@@ -85756,6 +86884,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -85828,6 +86957,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -86073,6 +87203,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"rVP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/central)
 "rVS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -86087,6 +87221,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "rWn" = (
@@ -86131,6 +87266,14 @@
 	icon_state = "graychoco"
 	},
 /area/station/security/brig)
+"rWx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hor)
+"rWH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/telesci)
 "rWJ" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall/r_wall,
@@ -86190,6 +87333,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -86324,6 +87468,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/scibreak)
 "rZe" = (
@@ -86473,6 +87618,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "sbg" = (
@@ -86515,6 +87661,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "sbN" = (
@@ -86533,6 +87680,10 @@
 	icon_state = "redbluefull"
 	},
 /area/station/medical/medbreak)
+"sbS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/port)
 "sbT" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -86548,6 +87699,14 @@
 	icon_state = "blackchoco"
 	},
 /area/station/security/interrogation)
+"sce" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/storage/tech)
+"scf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/computer)
 "sck" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/fancy/donut_box{
@@ -86578,6 +87737,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "scw" = (
@@ -86669,6 +87829,10 @@
 	icon_state = "white"
 	},
 /area/station/rnd/xenobiology)
+"sdG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/science)
 "sdL" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -86707,6 +87871,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/lobby)
 "seu" = (
@@ -86715,6 +87880,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -86948,7 +88114,7 @@
 	},
 /area/station/security/lobby)
 "sgt" = (
-/obj/item/weapon/flora/random,
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "neutral"
@@ -87150,6 +88316,7 @@
 /area/station/security/blueshield)
 "siU" = (
 /obj/item/weapon/flora/random,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -87387,6 +88554,7 @@
 	name = "Medbay Treatment Center";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -87624,6 +88792,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/bridge)
+"sng" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "snp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87651,6 +88823,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/rnd/misc_lab)
+"snC" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall,
+/area/station/civilian/hydroponics)
 "snG" = (
 /obj/effect/decal/turf_decal/white{
 	dir = 4;
@@ -87995,6 +89171,10 @@
 	icon_state = "graychoco"
 	},
 /area/station/rnd/xenobiology)
+"srJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/storage)
 "srP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
@@ -88041,6 +89221,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "sse" = (
@@ -88084,6 +89265,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -88129,6 +89311,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
 "stz" = (
@@ -88204,6 +89387,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"sub" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/starboard)
 "sud" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -88219,6 +89408,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "suB" = (
@@ -88311,6 +89501,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"svH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/prison/toilet)
 "svI" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -88378,6 +89572,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "sws" = (
@@ -88428,6 +89623,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -88468,6 +89664,7 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/storage/box/r4046/EMP,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -88561,6 +89758,7 @@
 	name = "Science Lab Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "syX" = (
@@ -88600,6 +89798,7 @@
 	name = "Supermatter Construction Area";
 	req_access = list(24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -88787,6 +89986,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -88926,6 +90126,7 @@
 	dir = 4;
 	dock_tag = "pod2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "sDs" = (
@@ -88942,6 +90143,7 @@
 /area/station/rnd/robotics)
 "sDu" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackcorner"
 	},
@@ -88987,6 +90189,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "sDX" = (
@@ -89021,6 +90224,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories/courtroom)
 "sEu" = (
@@ -89108,6 +90312,7 @@
 	dir = 1
 	},
 /obj/item/weapon/reagent_containers/food/snacks/baguette,
+/obj/item/weapon/present,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "sEZ" = (
@@ -89125,6 +90330,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -89294,6 +90500,7 @@
 	name = "Corporate Lounge";
 	req_one_access = list(19,38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -89382,6 +90589,10 @@
 	icon_state = "grimy"
 	},
 /area/station/aisat/antechamber_interior)
+"sIv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/bridge)
 "sIx" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
@@ -89390,6 +90601,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -90007,6 +91219,7 @@
 	id = "CE_private";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "sQd" = (
@@ -90032,6 +91245,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "sQv" = (
@@ -90214,6 +91428,7 @@
 	req_one_access = list(2,31,48)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowfull"
 	},
@@ -90401,6 +91616,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/snowflake,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "sUZ" = (
@@ -90444,6 +91660,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -90671,6 +91888,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "sYC" = (
@@ -90766,6 +91984,7 @@
 	name = "Prison Lockdown";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "sZV" = (
@@ -90837,6 +92056,16 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
+"taB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "taF" = (
 /obj/effect/landmark/start/geneticist,
 /obj/effect/decal/turf_decal/white{
@@ -91123,6 +92352,7 @@
 	pixel_y = -5
 	},
 /obj/item/weapon/camera_assembly,
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"
@@ -91319,6 +92549,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/locker)
 "tgM" = (
@@ -91409,6 +92640,10 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"tio" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/checkpoint/engi)
 "tit" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91426,6 +92661,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "tiI" = (
@@ -91784,6 +93020,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkyellowfull"
 	},
@@ -92003,6 +93240,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "tpB" = (
@@ -92075,12 +93313,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
 /area/station/security/prison)
 "tqF" = (
 /obj/structure/window/thin/reinforced,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "tqK" = (
@@ -92093,6 +93333,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "tqX" = (
@@ -92168,6 +93409,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -92192,6 +93434,7 @@
 /obj/item/weapon/storage/box/teargas{
 	pixel_x = -3
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -92519,6 +93762,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -92608,6 +93852,7 @@
 	name = "Telecomms Server Room";
 	req_access = list(61)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -92667,6 +93912,10 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"txB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry)
 "txJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -92707,6 +93956,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
 "tya" = (
@@ -93050,6 +94300,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "tBy" = (
@@ -93209,6 +94460,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "tDm" = (
@@ -93321,6 +94573,14 @@
 	icon_state = "graychoco"
 	},
 /area/station/civilian/janitor)
+"tEp" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/scibreak)
+"tEw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/robotics)
 "tED" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93358,6 +94618,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "tEJ" = (
@@ -93633,6 +94894,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "tIa" = (
@@ -93710,6 +94972,7 @@
 	name = "Brig Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "tJj" = (
@@ -93786,6 +95049,7 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -93814,6 +95078,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -93850,6 +95115,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/book/manual/wiki/possible_threats,
 /obj/item/weapon/paper/cmf_manual,
+/obj/item/weapon/present,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "tKY" = (
@@ -93894,6 +95160,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "tLS" = (
@@ -93918,6 +95185,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -94104,6 +95372,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -94161,6 +95430,7 @@
 	dir = 8;
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -94282,6 +95552,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
 "tRh" = (
@@ -94483,6 +95754,10 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"tTi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/toilet)
 "tTk" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -95072,6 +96347,7 @@
 	name = "Coworking";
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "ual" = (
@@ -95098,6 +96374,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
+"uaJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/armoury)
 "uaL" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
@@ -95171,6 +96451,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -95181,6 +96462,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
+"ubZ" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "ucd" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -95273,6 +96561,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -95381,6 +96670,7 @@
 	req_access = list(63)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "uei" = (
@@ -95422,6 +96712,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -95481,6 +96772,7 @@
 	name = "Security Post - Cargo";
 	req_access = list(2)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -95582,6 +96874,7 @@
 	name = "Brig Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "ugI" = (
@@ -95590,6 +96883,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway/lobby)
 "ugS" = (
@@ -95862,6 +97156,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
 "ujH" = (
@@ -95907,6 +97202,10 @@
 	icon_state = "caution"
 	},
 /area/station/storage/emergency)
+"ukb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/range)
 "ukc" = (
 /obj/structure/table,
 /obj/machinery/light/smart{
@@ -95974,6 +97273,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "ukD" = (
@@ -96023,6 +97323,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -96158,6 +97459,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "umc" = (
@@ -96186,6 +97488,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -96209,6 +97512,7 @@
 /area/station/engineering/atmos)
 "umq" = (
 /obj/item/weapon/flora/random,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -96437,6 +97741,10 @@
 	icon_state = "yellow"
 	},
 /area/station/rnd/hallway)
+"uoA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/auxsolarport)
 "uoF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -96480,6 +97788,10 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"upa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/brig/solitary_confinement)
 "upb" = (
 /mob/living/simple_animal/cow{
 	name = "Betsy"
@@ -96641,6 +97953,7 @@
 /area/station/hallway/primary/port)
 "urv" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blackcorner"
@@ -96851,6 +98164,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -96903,6 +98217,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/engineering/minisat_secure_area)
+"uut" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/ai_monitored/eva)
 "uuy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -97010,6 +98328,7 @@
 	name = "Prison Wing";
 	req_access = list(2)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -97156,6 +98475,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/armoury)
+"uxi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/bar)
 "uxx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -97176,6 +98499,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "uym" = (
@@ -97332,6 +98656,7 @@
 	name = "Robotist Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "uBc" = (
@@ -97610,6 +98935,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "uED" = (
@@ -97842,6 +99168,7 @@
 	name = "MiniSat Antechamber";
 	req_one_access = list(66)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -97942,6 +99269,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/cargo)
 "uKa" = (
@@ -97977,6 +99305,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "uKh" = (
@@ -98051,6 +99380,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"uLq" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/peppermill,
+/obj/item/weapon/present,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
+/area/station/hallway/primary/fore)
 "uLr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -98075,6 +99415,7 @@
 	name = "Corporate Lounge Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/corp_lounge)
 "uLv" = (
@@ -98085,6 +99426,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "uLI" = (
@@ -98307,6 +99649,7 @@
 	name = "Brig";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -98491,6 +99834,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
+/obj/item/weapon/present,
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
 	},
@@ -98562,6 +99906,10 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"uRj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/brig/storage)
 "uRx" = (
 /obj/structure/morgue{
 	dir = 8
@@ -98614,6 +99962,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "uSc" = (
@@ -98670,7 +100019,6 @@
 	},
 /area/station/bridge/captain_quarters)
 "uSZ" = (
-/obj/structure/stool/bar,
 /obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor/carpet/green,
 /area/station/hallway/primary/fore)
@@ -98814,6 +100162,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "uUM" = (
@@ -98830,6 +100179,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redchoco"
@@ -98891,6 +100241,7 @@
 	dir = 8;
 	icon_state = "box_corners_white"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -98967,6 +100318,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "uWh" = (
@@ -99159,6 +100511,7 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -99171,6 +100524,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "uYM" = (
@@ -99199,6 +100553,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -99301,6 +100656,7 @@
 	name = "Execution Blast";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/execution)
 "vac" = (
@@ -99410,6 +100766,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -99758,6 +101115,7 @@
 	name = "Brig";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -99789,6 +101147,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -100046,6 +101405,7 @@
 "vjq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -100255,6 +101615,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"vlV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/morgue)
 "vlW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/turf_decal/dark_red{
@@ -100655,6 +102019,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "vqB" = (
@@ -100783,6 +102148,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -100875,6 +102241,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowchoco"
 	},
@@ -100942,6 +102309,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -101011,6 +102379,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
+"vuf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/iaa_office)
 "vuj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -101530,6 +102902,7 @@
 	id = "HoP_private";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "vAP" = (
@@ -101578,6 +102951,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "vBA" = (
@@ -101688,6 +103062,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/atmos_office)
 "vDb" = (
@@ -101704,6 +103079,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -101952,6 +103328,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "vGh" = (
@@ -102286,6 +103663,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitechoco"
 	},
@@ -102322,6 +103700,7 @@
 /obj/structure/sign/directions/medical{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -102506,6 +103885,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -102654,6 +104034,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -102928,6 +104309,7 @@
 	name = "Escape Airlock";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
 "vTD" = (
@@ -103329,6 +104711,7 @@
 	req_access = list(17)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -103492,6 +104875,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "vYN" = (
@@ -103641,6 +105025,7 @@
 	c_tag = "Starboard Escape Entry";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -103746,6 +105131,7 @@
 	name = "Medbay";
 	req_one_access = list(2,5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -104018,6 +105404,7 @@
 	name = "Escape Airlock";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
 "wfH" = (
@@ -104203,6 +105590,7 @@
 	dir = 4;
 	name = "Cryogenic Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralchoco"
 	},
@@ -104504,6 +105892,7 @@
 	dir = 6;
 	icon_state = "siding_line"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/hos)
 "wln" = (
@@ -104538,6 +105927,12 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"wlt" = (
+/obj/item/weapon/present,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/storage)
 "wlv" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -104640,6 +106035,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "wmz" = (
@@ -104971,6 +106367,7 @@
 	c_tag = "Librarian Workspace";
 	dir = 6
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -105170,6 +106567,7 @@
 	name = "Hydroponics";
 	req_access = list(35)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "greenblue"
 	},
@@ -105389,6 +106787,7 @@
 /area/station/engineering/atmos)
 "wwR" = (
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -105440,6 +106839,7 @@
 	dir = 4;
 	name = "Holodeck Door"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -105628,6 +107028,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -105704,6 +107105,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "wAA" = (
@@ -106030,6 +107432,10 @@
 /obj/item/clothing/mask/surgical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"wDf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hallway)
 "wDh" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -106078,6 +107484,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "wDB" = (
@@ -106092,6 +107499,7 @@
 	name = "Hydroponics";
 	req_access = list(35)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenblue"
@@ -106112,6 +107520,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/gateway)
 "wDG" = (
@@ -106260,6 +107669,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brownchoco"
@@ -106282,6 +107692,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "wGd" = (
@@ -106303,6 +107714,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -106333,6 +107745,13 @@
 	icon_state = "2,3"
 	},
 /area/shuttle/supply/station)
+"wGV" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "wGW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -106457,6 +107876,7 @@
 	id = "xenobiosouth";
 	name = "Containment Blast Doors"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "wIo" = (
@@ -106570,6 +107990,10 @@
 	icon_state = "blackchecker"
 	},
 /area/station/civilian/hydroponics)
+"wJv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/xenobiology)
 "wJy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -106700,6 +108124,7 @@
 /area/station/security/checkpoint/escape_custom_desk)
 "wLD" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -106741,6 +108166,10 @@
 	icon_state = "grimy"
 	},
 /area/station/aisat/antechamber_interior)
+"wLM" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall,
+/area/station/civilian/kitchen)
 "wLR" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -106796,6 +108225,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"wMQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/scibreak)
 "wMZ" = (
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -106856,6 +108289,10 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"wNO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/captain_quarters)
 "wNU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -106911,6 +108348,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -107056,6 +108494,7 @@
 	name = "Robotics Lab";
 	req_access = list(29)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -107087,6 +108526,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "wQM" = (
@@ -107133,6 +108573,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "wRs" = (
@@ -107481,6 +108922,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "wVw" = (
@@ -107604,6 +109046,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway/lobby)
 "wXp" = (
@@ -107670,6 +109113,7 @@
 	name = "Prison Lockdown";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "wYl" = (
@@ -107836,6 +109280,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -107894,6 +109339,7 @@
 /area/station/medical/storage)
 "xao" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blackcorner"
@@ -107919,6 +109365,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -107987,6 +109434,7 @@
 	dir = 4;
 	name = "Holodeck Door"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -108108,6 +109556,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "xdd" = (
@@ -108199,6 +109648,7 @@
 /area/station/civilian/cold_room)
 "xef" = (
 /obj/machinery/door/airlock/multi_tile/glass,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -108222,6 +109672,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "xer" = (
@@ -108407,6 +109858,7 @@
 	dir = 4;
 	name = "Courtroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/dormitories/courtroom)
 "xgp" = (
@@ -108516,6 +109968,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "xhL" = (
@@ -108749,6 +110202,13 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"xkK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/gym)
 "xlj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -108827,6 +110287,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -108901,6 +110362,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -108962,6 +110424,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -109215,6 +110678,10 @@
 	icon_state = "black"
 	},
 /area/station/civilian/gym)
+"xpv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/office)
 "xpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
@@ -109255,6 +110722,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -109295,6 +110763,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"xqz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "xqB" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/manual/hydroponics_beekeeping,
@@ -109312,6 +110784,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "xqN" = (
@@ -109426,6 +110899,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "xrE" = (
@@ -109452,6 +110926,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkorangechoco"
 	},
@@ -109593,6 +111068,7 @@
 	req_one_access = list(13,45,1)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "xsW" = (
@@ -109628,6 +111104,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -109658,6 +111135,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -110022,6 +111500,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "xxv" = (
@@ -110169,6 +111648,7 @@
 	req_access = list(67)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -110194,6 +111674,7 @@
 	name = "QM Lockdown Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "xzh" = (
@@ -110226,6 +111707,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -110299,6 +111781,14 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"xAd" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/hallway)
+"xAg" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/brig)
 "xAi" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -110310,6 +111800,7 @@
 	name = "Brig";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -110331,6 +111822,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "xAq" = (
@@ -110352,6 +111844,7 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/chapel/office)
 "xAJ" = (
@@ -110536,6 +112029,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -110633,6 +112127,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
+"xCV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/portsolar)
 "xCW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -110751,6 +112249,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/snowflake,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "xEL" = (
@@ -111265,6 +112764,7 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "xLe" = (
@@ -111321,6 +112821,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -111494,6 +112995,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"xNt" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/corp_lounge)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -111768,6 +113273,7 @@
 	dir = 4;
 	name = "Chapel Mass Driver"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -111857,6 +113363,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -111913,6 +113420,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -112122,6 +113630,7 @@
 	c_tag = "Dormitories South-East";
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -112275,6 +113784,7 @@
 	name = "Science Lab Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "xVT" = (
@@ -112432,6 +113942,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -112452,6 +113963,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "xXy" = (
@@ -112471,6 +113983,7 @@
 	name = "Robotist Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -112604,6 +114117,10 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
+"xYS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/prison)
 "xZa" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -112670,6 +114187,7 @@
 	req_one_access = list(1,5,11,18,24)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -112693,6 +114211,10 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/gym)
+"xZY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/janitor)
 "yam" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor{
@@ -112798,6 +114320,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"ybz" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "ybG" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -112871,6 +114402,7 @@
 	name = "Gear Room";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -112891,6 +114423,15 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"ycp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central)
 "ycu" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the medbay foyer.";
@@ -113049,6 +114590,7 @@
 	name = "Genetics Lab";
 	req_access = list(9,47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -113271,6 +114813,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/photo_album,
 /obj/item/device/camera,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "yhi" = (
@@ -113357,6 +114900,7 @@
 	dir = 4;
 	name = "Holodeck Door"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -113591,6 +115135,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "yll" = (
@@ -119433,14 +120978,14 @@ coL
 vQd
 qLu
 gyO
+bRS
 gbY
-gbY
-gbY
+bRS
 gbY
 giP
 gbY
 rWJ
-gbY
+bRS
 lbh
 jOq
 tTd
@@ -119938,7 +121483,7 @@ gqK
 xlX
 kHi
 kHi
-sVa
+sng
 xlX
 kHi
 kHi
@@ -119948,7 +121493,7 @@ kHi
 xlX
 kHi
 plf
-gbY
+bRS
 xXB
 kMb
 vtY
@@ -120453,7 +121998,7 @@ kHU
 kHU
 sVa
 sVa
-sVa
+sng
 sVa
 sVa
 sVa
@@ -120474,7 +122019,7 @@ xlX
 kHi
 kHi
 xlX
-oer
+lNt
 kHi
 xlX
 cwB
@@ -120718,18 +122263,18 @@ sVa
 jKJ
 fQR
 tGO
-sVa
+sng
 gbY
 nfy
 jod
 qYF
 mBf
 ibg
-gbY
+bRS
 oer
 oer
 oer
-oer
+lNt
 oer
 oer
 kHU
@@ -120965,7 +122510,7 @@ iOl
 vYy
 kHU
 sVa
-sVa
+sng
 eXX
 hFh
 xay
@@ -120978,7 +122523,7 @@ aBc
 eXX
 gbY
 ftb
-gbY
+bRS
 gdx
 gbY
 gbY
@@ -121247,7 +122792,7 @@ xLs
 uTC
 evW
 oer
-oer
+lNt
 xzf
 iOl
 dAY
@@ -121496,7 +123041,7 @@ lnX
 hfx
 hPY
 jWu
-oer
+lNt
 iJx
 jFo
 qyc
@@ -121990,7 +123535,7 @@ xzf
 aAA
 nyl
 pJp
-sVa
+sng
 sVa
 jdA
 nCV
@@ -122507,7 +124052,7 @@ fGI
 rrT
 gti
 gti
-gti
+aZy
 ijp
 sZC
 aBc
@@ -122789,7 +124334,7 @@ eKH
 iup
 lvz
 oer
-oer
+lNt
 xzf
 iOl
 hjl
@@ -123032,14 +124577,14 @@ hkz
 lNx
 aBc
 eXX
-pGn
+hqY
 fBB
 pGn
 uHN
 pGn
 pGn
 oer
-oer
+lNt
 aec
 nvv
 nnI
@@ -123279,7 +124824,7 @@ tTd
 plf
 sVa
 sVa
-sVa
+sng
 hTa
 tXy
 sVa
@@ -123288,7 +124833,7 @@ sVa
 wlr
 irC
 vrt
-sVa
+sng
 pGn
 vKF
 bOy
@@ -123298,7 +124843,7 @@ ehd
 pGn
 oer
 oer
-oer
+lNt
 oer
 oer
 oer
@@ -123558,7 +125103,7 @@ vQd
 coL
 coL
 vQd
-oer
+lNt
 coL
 vQd
 gsz
@@ -124050,7 +125595,7 @@ rIJ
 vQd
 coL
 coL
-sVa
+sng
 vQd
 coL
 coL
@@ -124060,7 +125605,7 @@ coL
 vQd
 coL
 plf
-pGn
+hqY
 xuC
 cwC
 fJV
@@ -124575,11 +126120,11 @@ wxV
 nEC
 pGn
 pGn
-pGn
+hqY
 pGn
 rAm
 pGn
-pGn
+hqY
 pGn
 lbh
 jOq
@@ -125343,7 +126888,7 @@ plf
 kHU
 kHU
 plf
-uZG
+mNN
 dGB
 uZG
 uZG
@@ -125860,7 +127405,7 @@ kHU
 iMj
 aCJ
 uZG
-uZG
+mNN
 xow
 awc
 lKi
@@ -131808,7 +133353,7 @@ cjx
 gMM
 cjx
 cjx
-cjx
+sdG
 gMM
 cjx
 meE
@@ -132061,7 +133606,7 @@ plf
 vee
 xRM
 cjx
-cjx
+sdG
 fRJ
 gVo
 fRJ
@@ -132276,7 +133821,7 @@ pka
 kHU
 kHU
 kHU
-tvt
+mZS
 xXN
 rOC
 xkv
@@ -132317,7 +133862,7 @@ nHd
 nHd
 vee
 lUT
-cjx
+sdG
 fRJ
 fRJ
 fRJ
@@ -132541,7 +134086,7 @@ tvt
 btY
 mQa
 jUl
-tvt
+mZS
 vct
 cTi
 dgY
@@ -132789,7 +134334,7 @@ lgc
 lgc
 kHU
 kHU
-tvt
+mZS
 xxJ
 tbx
 jAI
@@ -132803,7 +134348,7 @@ lYm
 swv
 oFq
 ktv
-tvt
+mZS
 kHU
 plf
 kHU
@@ -132839,7 +134384,7 @@ fRJ
 fRJ
 fRJ
 llw
-cjx
+sdG
 lUT
 gPj
 lwe
@@ -133089,7 +134634,7 @@ nrB
 wDo
 nLr
 cjx
-gVW
+wJv
 tZY
 fRJ
 fRJ
@@ -133308,7 +134853,7 @@ jcC
 njz
 fPC
 pGR
-tvt
+mZS
 qVq
 ksR
 sjd
@@ -133570,7 +135115,7 @@ tvt
 tvt
 tvt
 tvt
-tvt
+mZS
 tvt
 tvt
 tvt
@@ -133610,7 +135155,7 @@ bnp
 cRA
 jYs
 hXe
-gVW
+wJv
 yhZ
 cfJ
 cjx
@@ -133831,7 +135376,7 @@ roV
 jIF
 bUY
 vKa
-tvt
+mZS
 gRp
 vVi
 mKw
@@ -133870,7 +135415,7 @@ pFJ
 dbo
 udu
 nSI
-cjx
+sdG
 mpi
 gfJ
 gZk
@@ -134078,7 +135623,7 @@ tvt
 pYQ
 jiU
 kpo
-tvt
+mZS
 jYE
 hHS
 xaA
@@ -134112,7 +135657,7 @@ abE
 acO
 jwI
 hRb
-cjx
+sdG
 rud
 mVg
 yda
@@ -134372,7 +135917,7 @@ jUW
 cjx
 wCA
 oAI
-gVW
+wJv
 uhT
 frn
 aAZ
@@ -134638,7 +136183,7 @@ nnf
 anG
 gVW
 gVW
-gVW
+wJv
 wBr
 gVW
 cjx
@@ -134859,7 +136404,7 @@ uur
 vqO
 gph
 lqF
-tvt
+mZS
 fzd
 tiI
 kHU
@@ -135113,7 +136658,7 @@ tvt
 tvt
 tvt
 ouX
-tvt
+mZS
 ouX
 tvt
 tvt
@@ -135141,7 +136686,7 @@ xwj
 jwI
 ara
 crH
-jwI
+kEK
 fGG
 kfd
 fGG
@@ -135412,7 +136957,7 @@ cUf
 qkA
 fRJ
 kVW
-cjx
+sdG
 aJp
 uvO
 pwX
@@ -135578,9 +137123,9 @@ rkx
 rkx
 rkx
 rkx
+mQj
 rkx
-rkx
-vPk
+pgq
 aBv
 sVH
 aIO
@@ -135615,14 +137160,14 @@ aaj
 npo
 rcA
 vPk
-wjb
+mtB
 wjb
 wjb
 vrC
 wjb
 wjb
 ehA
-ehA
+iyP
 ehA
 bmZ
 ehA
@@ -135825,13 +137370,13 @@ aab
 aad
 plf
 oyu
-uja
-uja
-uja
+cwF
+cwF
+cwF
+uoA
 kAl
 kAl
-kAl
-kAl
+uoA
 aAr
 rDL
 atL
@@ -135878,7 +137423,7 @@ rat
 owf
 aVC
 pwz
-ehA
+iyP
 lXj
 ifb
 wJN
@@ -135887,7 +137432,7 @@ xzy
 gRG
 pZo
 tJP
-ehA
+iyP
 gRp
 kip
 plf
@@ -136169,7 +137714,7 @@ vyR
 jwI
 cmB
 gPy
-jwI
+kEK
 nGM
 fRJ
 vpb
@@ -136426,7 +137971,7 @@ ilb
 jwI
 rkr
 gPy
-jwI
+kEK
 huv
 nCm
 saj
@@ -136440,7 +137985,7 @@ qxf
 bur
 nCm
 nyM
-cjx
+sdG
 qOn
 fbF
 uCJ
@@ -136855,7 +138400,7 @@ kHU
 lgc
 kHU
 kHU
-kAl
+uoA
 iOL
 grm
 eQM
@@ -136865,7 +138410,7 @@ ohU
 kCA
 vwv
 sWI
-vPk
+pgq
 jFr
 cbS
 emc
@@ -136954,7 +138499,7 @@ uWb
 qkA
 fRJ
 kVW
-cjx
+sdG
 lsw
 juy
 jTm
@@ -137117,7 +138662,7 @@ cha
 kAl
 kAl
 kAl
-jbr
+mzc
 jbr
 jbr
 jbr
@@ -137128,7 +138673,7 @@ vPk
 aYm
 vPk
 aqK
-vPk
+pgq
 vPk
 vPk
 cbA
@@ -137420,7 +138965,7 @@ qlj
 qrc
 vsI
 qlj
-ehA
+iyP
 sPV
 bgu
 sPV
@@ -137429,7 +138974,7 @@ dAf
 kHq
 dAf
 ehA
-ehA
+iyP
 nsa
 tLA
 nsa
@@ -137437,7 +138982,7 @@ ccL
 get
 gvH
 vkK
-nsa
+huB
 diQ
 vWf
 oos
@@ -137454,7 +138999,7 @@ nsa
 nsa
 jwI
 cMM
-jwI
+kEK
 fRJ
 ctb
 fRJ
@@ -137910,7 +139455,7 @@ xrz
 itq
 itq
 itq
-itq
+ceD
 aGb
 itq
 aGb
@@ -137969,10 +139514,10 @@ aaZ
 jwI
 lDb
 jwI
-jwI
+kEK
 gVW
 wBr
-gVW
+wJv
 pdk
 fRJ
 wgr
@@ -137980,7 +139525,7 @@ fRJ
 ddl
 gVW
 wBr
-gVW
+wJv
 cjx
 cjx
 laZ
@@ -138159,7 +139704,7 @@ cxI
 sFM
 xTO
 tlM
-vPk
+pgq
 cfD
 bTG
 hZG
@@ -138495,7 +140040,7 @@ wXp
 oHG
 fGy
 wcV
-cjx
+sdG
 ubj
 ubt
 jQp
@@ -138673,7 +140218,7 @@ pLy
 jnQ
 klu
 amM
-vPk
+pgq
 cfD
 aWD
 mJM
@@ -138693,7 +140238,7 @@ fOY
 pWS
 fsi
 kxq
-vPk
+pgq
 tLi
 kFO
 eya
@@ -138736,11 +140281,11 @@ hCG
 vej
 eWb
 gQo
-nsa
+huB
 ijY
 buY
 ldN
-jwI
+kEK
 hVD
 mAQ
 ooG
@@ -139007,7 +140552,7 @@ cJr
 nlY
 eRn
 cjx
-cjx
+sdG
 cjx
 cjx
 fUZ
@@ -139192,7 +140737,7 @@ gAr
 ivG
 ula
 bmj
-itq
+ceD
 stm
 uND
 fjH
@@ -139253,7 +140798,7 @@ jVn
 nsa
 lud
 agc
-jwI
+kEK
 nUw
 vCS
 xOr
@@ -139262,7 +140807,7 @@ bfh
 qiE
 cjx
 cjx
-cjx
+sdG
 cjx
 jqH
 sqh
@@ -139452,7 +140997,7 @@ rHG
 tEF
 tEF
 tEF
-tEF
+nCq
 tEF
 wRk
 bQW
@@ -139507,7 +141052,7 @@ iWj
 eui
 hAd
 qbF
-nsa
+huB
 evL
 pek
 esN
@@ -139703,7 +141248,7 @@ cxI
 rVK
 vPk
 vPk
-vPk
+pgq
 jcs
 vPk
 tEF
@@ -139774,7 +141319,7 @@ ivl
 cIK
 bfh
 uGd
-cjx
+sdG
 fVu
 qLc
 qGO
@@ -140021,13 +141566,13 @@ qiQ
 jNg
 aCh
 lkw
-nsa
+huB
 pPD
 lTI
 jwI
 jwI
 jwI
-jwI
+kEK
 nlp
 nuX
 gNg
@@ -140251,7 +141796,7 @@ oUf
 wjb
 uSc
 abg
-uSc
+tio
 uSc
 ttW
 xyb
@@ -140264,13 +141809,13 @@ bQa
 xFH
 ico
 aeU
-nsa
+huB
 rym
 cXU
 yep
 inM
 qgD
-nsa
+huB
 yid
 sUm
 dQD
@@ -140518,7 +142063,7 @@ iGx
 acF
 sYu
 qBN
-nsa
+huB
 nsa
 nsa
 nsa
@@ -141035,7 +142580,7 @@ gun
 nsa
 qVy
 bUt
-nsa
+huB
 kej
 kej
 aaU
@@ -141049,7 +142594,7 @@ jBe
 oYw
 sPU
 aij
-nsa
+huB
 ksn
 ijY
 ijY
@@ -141279,7 +142824,7 @@ ksv
 ktK
 uSc
 uib
-uSc
+tio
 uSc
 aGp
 kVA
@@ -141289,7 +142834,7 @@ aEj
 myY
 rCg
 bSR
-nsa
+huB
 lYU
 lvF
 nsa
@@ -141299,10 +142844,10 @@ wwd
 gLD
 gLD
 nsa
+huB
 nsa
 nsa
-nsa
-nsa
+huB
 nsa
 nsa
 nsa
@@ -141318,7 +142863,7 @@ kYb
 oRy
 tJr
 tJr
-tJr
+jcM
 tJr
 uLI
 tJr
@@ -141530,20 +143075,20 @@ uck
 sqb
 hQQ
 czK
-qTx
+rrx
 bUU
 iky
 gUo
-qTx
+rrx
 abU
 abU
 uSc
 uSc
 uSc
 uSc
-uSc
+tio
 jwI
-jwI
+kEK
 jwI
 jwI
 jwI
@@ -141551,10 +143096,10 @@ wtC
 wBQ
 typ
 typ
+jvr
 typ
 typ
-typ
-typ
+jvr
 typ
 pla
 cdy
@@ -141621,7 +143166,7 @@ ifo
 loK
 acw
 hGd
-ifo
+xCV
 kHU
 pka
 pka
@@ -141791,7 +143336,7 @@ dqR
 xmJ
 ksv
 doE
-doE
+qUB
 doE
 doE
 lgU
@@ -141826,7 +143371,7 @@ sgS
 wtC
 uRb
 waU
-wtC
+hNH
 mTr
 ncb
 xyp
@@ -142048,7 +143593,7 @@ aAP
 aAP
 uhz
 env
-env
+nKG
 env
 env
 env
@@ -142069,7 +143614,7 @@ cZC
 mcl
 rtt
 qKd
-typ
+jvr
 pEB
 wtC
 ppJ
@@ -142095,13 +143640,13 @@ avo
 lOt
 tJr
 dNy
-dNy
+nTE
 jSj
 dNy
 dNy
 dNy
 dNy
-dNy
+nTE
 dNy
 dNy
 juy
@@ -142131,7 +143676,7 @@ tIo
 tIo
 tIo
 kHU
-ifo
+xCV
 xuU
 eii
 iOB
@@ -142305,7 +143850,7 @@ bzt
 bzt
 rxP
 bzt
-bzt
+ubZ
 txw
 oyb
 bzt
@@ -142315,12 +143860,12 @@ bvv
 tYK
 wtC
 wtC
-wtC
+hNH
 wtC
 wtC
 hBT
 lud
-typ
+jvr
 oBJ
 dAX
 mcl
@@ -142345,7 +143890,7 @@ aTn
 iGZ
 oqY
 tJr
-tJr
+jcM
 gSy
 tJr
 gSy
@@ -142553,17 +144098,17 @@ fgy
 wwi
 kGI
 kGI
+sbS
 kGI
-kGI
-ocs
+gzq
 ocs
 ocs
 dGn
-ocs
+gzq
 ocs
 ocs
 sHI
-ocs
+gzq
 ocs
 bqr
 nSF
@@ -142594,7 +144139,7 @@ qAA
 wtC
 lTI
 hBT
-wtC
+hNH
 wtC
 wmS
 wtC
@@ -142839,7 +144384,7 @@ typ
 fbL
 jzd
 typ
-typ
+jvr
 typ
 lud
 wtC
@@ -142854,11 +144399,11 @@ jyh
 wtC
 mkc
 apA
-wtC
+hNH
 aTn
 pYO
 tAX
-agq
+rWx
 fHa
 pKm
 hbw
@@ -143064,11 +144609,11 @@ xLR
 irO
 wwi
 gzO
-wwi
+gQk
 kHU
 aiN
 aiN
-aiN
+sce
 aiN
 hdU
 ffL
@@ -143083,7 +144628,7 @@ ocs
 bzt
 rcq
 gKG
-wtC
+hNH
 mAv
 elz
 tUr
@@ -143364,7 +144909,7 @@ ylt
 ylt
 omz
 vil
-lhp
+jJO
 gwj
 ldt
 fmH
@@ -143384,7 +144929,7 @@ dNy
 dNy
 mQn
 dNy
-dNy
+nTE
 dNy
 dNy
 dNy
@@ -143548,7 +145093,7 @@ wwi
 mcm
 wwi
 wwi
-wwi
+gQk
 qTX
 aee
 uKn
@@ -143580,7 +145125,7 @@ liK
 kWH
 qlc
 kHU
-aiN
+sce
 wCv
 cxU
 wGe
@@ -143602,7 +145147,7 @@ iSb
 yfw
 aqd
 qnC
-wtC
+hNH
 ijY
 ksn
 wtC
@@ -143803,7 +145348,7 @@ cLm
 viT
 wwi
 wwi
-wwi
+gQk
 duo
 kGW
 kGW
@@ -143811,25 +145356,25 @@ vPL
 xaF
 nBv
 bIi
-qTX
+oaO
 qTX
 qTX
 srt
-srt
+nZK
 srt
 gzS
 srt
 srt
 srt
+nZK
+wLM
 srt
 srt
-srt
-srt
-srt
+nZK
 srt
 kIU
 kIU
-kIU
+jxJ
 kIU
 pug
 bZz
@@ -143868,7 +145413,7 @@ hBT
 hxU
 oZa
 srY
-oZa
+tEw
 oZa
 oZa
 oZa
@@ -143893,7 +145438,7 @@ vaP
 wwp
 vqc
 rMn
-agq
+rWx
 wKJ
 jVk
 jdg
@@ -144069,13 +145614,13 @@ ipt
 xJC
 jne
 faA
-qTX
+snC
 qTX
 hMx
 cVr
 heK
 uFN
-srt
+nZK
 rwG
 ttK
 sCp
@@ -144095,9 +145640,9 @@ ciW
 wwi
 kHU
 aiN
+sce
 aiN
-aiN
-aiN
+sce
 qnj
 kYA
 oNZ
@@ -144159,7 +145704,7 @@ jVk
 jVk
 qhJ
 hwC
-dNy
+nTE
 due
 uDL
 jIj
@@ -144315,7 +145860,7 @@ cLm
 cLm
 cLm
 qDI
-wwi
+gQk
 cEA
 fxw
 xaF
@@ -144327,7 +145872,7 @@ xDe
 xaF
 jne
 bLF
-qTX
+oaO
 iNc
 kMx
 xrO
@@ -144340,14 +145885,14 @@ aSY
 aSY
 uum
 lVS
-srt
+nZK
 wHb
 xdV
 gTB
 kst
 buQ
 nja
-wwi
+gQk
 lzr
 wwi
 plf
@@ -144364,7 +145909,7 @@ vKI
 qBd
 tRz
 fcz
-ocs
+gzq
 eJQ
 ksv
 gKG
@@ -144372,12 +145917,12 @@ wtC
 agb
 aqF
 waU
-uJi
+dvA
 uJi
 uJi
 lsB
 uJi
-uJi
+dvA
 xgp
 eay
 iax
@@ -144385,7 +145930,7 @@ jBv
 voM
 gLB
 cVA
-oZa
+tEw
 odI
 sgS
 ijY
@@ -144543,16 +146088,16 @@ kHU
 kHU
 kHU
 kHU
-yaE
+kMg
 tyE
-yaE
+kMg
 kHU
 plf
 plf
 kHU
-yaE
+kMg
 tyE
-yaE
+kMg
 kHU
 kHU
 kHU
@@ -144613,11 +146158,11 @@ wwi
 wwi
 aiN
 aiN
+sce
 aiN
 aiN
 aiN
-aiN
-aiN
+sce
 aiN
 aiN
 aiN
@@ -144628,7 +146173,7 @@ idK
 pbn
 pbn
 pbn
-pbn
+aWH
 uJi
 moc
 iUy
@@ -144669,7 +146214,7 @@ dNy
 nNa
 biZ
 nNa
-dNy
+nTE
 cOy
 cOy
 cOy
@@ -144800,27 +146345,27 @@ plf
 plf
 kHU
 plf
-yaE
+kMg
 qYg
-yaE
-bjt
-bjt
-bjt
-bjt
-yaE
+kMg
+nWo
+nWo
+nWo
+nWo
+kMg
 qYg
-yaE
+kMg
 plf
 kHU
 plf
 plf
 plf
 ffS
-bjt
-bjt
-bjt
+nWo
+nWo
+nWo
 wwi
-gdp
+gDD
 wwi
 maK
 aHs
@@ -144882,7 +146427,7 @@ kRw
 qEZ
 nWG
 gib
-pbn
+aWH
 eRU
 hML
 gZh
@@ -144901,7 +146446,7 @@ sbp
 bpx
 gmg
 dtQ
-oZa
+tEw
 oZa
 oZa
 daK
@@ -145052,27 +146597,27 @@ ffS
 ffS
 ffS
 ffS
-ffS
-bjt
-bjt
+txB
+nWo
+nWo
 ffS
 rcM
-yaE
+kMg
 xKv
-yaE
+kMg
 aqg
 aqg
 aqg
 cmk
-yaE
+kMg
 xKv
-yaE
+kMg
 vvv
 ffS
-bjt
-bjt
-bjt
-ffS
+nWo
+nWo
+nWo
+txB
 hkD
 hkD
 mkT
@@ -145098,7 +146643,7 @@ wrF
 nIT
 xaF
 arC
-qTX
+oaO
 wKd
 hjY
 jOY
@@ -145130,10 +146675,10 @@ aVs
 aVs
 aVs
 aVs
+amB
 aVs
 aVs
-aVs
-aVs
+amB
 aVs
 aVs
 nEU
@@ -145161,13 +146706,13 @@ aqC
 qXN
 qqu
 oZa
-jwI
+kEK
 hCP
 lhp
 iXE
 iXE
 iXE
-iQn
+rWH
 wnJ
 bzw
 wJj
@@ -145343,7 +146888,7 @@ wwi
 wwi
 izp
 uMS
-wwi
+gQk
 nIT
 xaF
 lwz
@@ -145373,7 +146918,7 @@ esZ
 kIU
 jVV
 ekm
-kIU
+jxJ
 vYk
 bpv
 vXd
@@ -145590,7 +147135,7 @@ alc
 gHT
 rsE
 ldJ
-wwi
+gQk
 fTi
 buR
 ban
@@ -145623,11 +147168,11 @@ bgs
 ybJ
 coI
 nLd
+kGd
 rtx
-rtx
-srt
+nZK
 lMD
-kIU
+jxJ
 kIU
 kIU
 kIU
@@ -145920,7 +147465,7 @@ xQR
 oHA
 xQR
 pHt
-uJi
+dvA
 qIL
 pQt
 kTN
@@ -145950,7 +147495,7 @@ vCH
 apt
 sSE
 fVY
-oRy
+bJa
 wST
 daS
 xYg
@@ -146081,24 +147626,24 @@ ffS
 ffS
 ffS
 ffS
-bjt
-bjt
+nWo
+nWo
 ffS
 vvv
-yaE
+kMg
 xKv
-yaE
+kMg
 cmk
 nhe
 nnd
 cmk
 ffS
-ffS
-bjt
+txB
+nWo
 rcM
 ffS
-bjt
-bjt
+nWo
+nWo
 ffS
 fAi
 lNi
@@ -146142,7 +147687,7 @@ xCL
 xCL
 qqF
 lwv
-wwi
+oih
 lKH
 idQ
 kIN
@@ -146171,7 +147716,7 @@ pHa
 jxP
 hOL
 dRd
-uJi
+dvA
 ohp
 qoI
 fnr
@@ -146196,10 +147741,10 @@ mGu
 lhp
 lhp
 lhp
+wDf
 vCH
 vCH
-vCH
-vCH
+wDf
 vCH
 vCH
 vCH
@@ -146342,13 +147887,13 @@ plf
 plf
 kHU
 plf
-yaE
+kMg
 qYg
-yaE
-bjt
+kMg
+nWo
 ffS
 ffS
-ffS
+txB
 uEm
 mTn
 mTn
@@ -146390,16 +147935,16 @@ abo
 tJq
 ajJ
 dkf
-kUa
+uLq
 niP
-dkf
+dzk
 jsI
 pTB
-dkf
+dzk
 kUa
 ano
 bYQ
-wwi
+gQk
 wUJ
 vau
 hho
@@ -146411,7 +147956,7 @@ jwp
 dIV
 uac
 oBd
-aVs
+amB
 aEc
 hpd
 eUS
@@ -146424,7 +147969,7 @@ jHQ
 oqH
 fVi
 kIB
-pbn
+aWH
 iYY
 tMV
 rwI
@@ -146599,9 +148144,9 @@ kHU
 kHU
 kHU
 kHU
-yaE
+kMg
 tyE
-yaE
+kMg
 kHU
 plf
 plf
@@ -146631,7 +148176,7 @@ xAM
 pHV
 biE
 wwi
-wwi
+gQk
 vYh
 udW
 uTw
@@ -146876,7 +148421,7 @@ hBl
 fYS
 dEP
 wwi
-wwi
+gQk
 wwi
 wwi
 wwi
@@ -147182,7 +148727,7 @@ iCW
 qlO
 eza
 kUz
-aVs
+amB
 cPa
 vEZ
 daq
@@ -147198,7 +148743,7 @@ buL
 pbn
 wRM
 hqT
-pbn
+aWH
 uJi
 mcr
 mcr
@@ -147241,7 +148786,7 @@ cmw
 oWE
 dNy
 cOy
-cOy
+grV
 cOy
 cOy
 cOy
@@ -147401,7 +148946,7 @@ xMV
 lOa
 mzT
 mvD
-tJq
+kUi
 tGH
 eIm
 eIm
@@ -147436,10 +148981,10 @@ jxa
 egV
 aaz
 eza
-eza
+aAV
 eza
 urf
-aVs
+amB
 aVs
 lxj
 lxj
@@ -147465,7 +149010,7 @@ qLv
 bwA
 vUh
 eKK
-oZa
+tEw
 oZa
 oZa
 oZa
@@ -147734,13 +149279,13 @@ xei
 bFh
 vpT
 tSI
-vIl
+iPT
 olx
 frM
 mQE
 qPO
 ofJ
-ofJ
+fDI
 ofJ
 ofJ
 ofJ
@@ -147750,7 +149295,7 @@ qDG
 cAb
 hHB
 vCH
-dNy
+nTE
 dNy
 dNy
 dNy
@@ -148284,7 +149829,7 @@ wDZ
 wDZ
 wDZ
 wDZ
-wDZ
+jjF
 wDZ
 wDZ
 wDZ
@@ -148448,7 +149993,7 @@ oJP
 twi
 iRO
 jGM
-eIm
+eEa
 rLk
 iRb
 smH
@@ -148472,14 +150017,14 @@ hXM
 iRZ
 bpW
 oIM
-oIM
+chE
 ksB
 ksB
 ksB
 oIM
 mmd
 mmd
-mmd
+atE
 mmd
 mmd
 mmd
@@ -148493,14 +150038,14 @@ vAJ
 fZK
 xzz
 xau
-aVg
+uut
 aVg
 aVg
 aVg
 dAb
 aVg
 aVg
-aVg
+uut
 aVg
 jOJ
 ogP
@@ -148532,12 +150077,12 @@ nza
 pku
 aaY
 hXu
-wDZ
+jjF
 wDZ
 wDZ
 lIf
 wDZ
-wDZ
+jjF
 dxH
 sEV
 mZM
@@ -148715,7 +150260,7 @@ mvE
 mvE
 otw
 ctm
-tJq
+kUi
 fIn
 ogP
 kXR
@@ -148734,7 +150279,7 @@ yku
 vgf
 abl
 dUZ
-mmd
+atE
 tGX
 dAL
 uLr
@@ -148758,7 +150303,7 @@ gxv
 kuF
 qfb
 mNo
-aVg
+uut
 jOJ
 ogP
 vpT
@@ -148777,13 +150322,13 @@ fes
 cyt
 iGZ
 wYl
-kFd
+tEp
 kFd
 kFd
 qQL
 kFd
 gqV
-gqV
+wMQ
 gqV
 wBR
 wBR
@@ -148932,12 +150477,12 @@ aaD
 fYS
 mZi
 ffS
-bjt
-bjt
-bjt
-bjt
-bjt
-bjt
+nWo
+nWo
+nWo
+nWo
+nWo
+nWo
 ffS
 eQO
 fDL
@@ -148945,7 +150490,7 @@ wAW
 wts
 qQo
 wts
-wts
+xZY
 wts
 tGc
 rrl
@@ -149169,9 +150714,9 @@ kHU
 kHU
 kHU
 kHU
-yaE
+kMg
 hGn
-yaE
+kMg
 kHU
 plf
 plf
@@ -149188,14 +150733,14 @@ msk
 rCP
 fYS
 rEz
-yaE
+kMg
 kHU
 plf
 plf
 plf
 plf
 kHU
-yaE
+kMg
 hkD
 hss
 ctc
@@ -149213,8 +150758,8 @@ cRp
 gpG
 qSx
 uSZ
-fjB
-fjB
+qSx
+qSx
 qSx
 dtr
 czE
@@ -149296,13 +150841,13 @@ gVz
 gZd
 ogL
 nAF
-wBR
+dxP
 dGk
 vES
 jwM
 jTP
 ttZ
-wBR
+dxP
 cHN
 oeh
 oeh
@@ -149315,7 +150860,7 @@ wcN
 nVA
 wDZ
 wDZ
-wDZ
+jjF
 wDZ
 hVK
 guR
@@ -149426,13 +150971,13 @@ plf
 plf
 kHU
 plf
-yaE
+kMg
 qYg
-yaE
-bjt
+kMg
+nWo
 ffS
 ffS
-ffS
+txB
 uEm
 mTn
 mTn
@@ -149445,14 +150990,14 @@ ffS
 nBB
 fYS
 rEz
-yaE
+kMg
 kHU
 kHU
 plf
 plf
 kHU
 kHU
-yaE
+kMg
 hkD
 fYS
 pKn
@@ -149464,15 +151009,15 @@ wts
 dUy
 hTg
 bll
-xVN
+jGh
 sdL
 jvg
 uSN
-fjB
-ibe
+qSx
+hwF
 fpT
-huB
-fjB
+hwF
+qSx
 uSN
 uhY
 dmy
@@ -149538,7 +151083,7 @@ tjS
 eLM
 cKQ
 iAp
-ofJ
+fDI
 nAv
 mdn
 ngP
@@ -149565,7 +151110,7 @@ oeh
 bRg
 kfZ
 pto
-wDZ
+jjF
 vFa
 sBf
 pDN
@@ -149676,40 +151221,40 @@ plf
 ffS
 ffS
 ffS
+txB
 ffS
 ffS
-ffS
-bjt
-bjt
+nWo
+nWo
 ffS
 rcM
-yaE
+kMg
 qgt
-yaE
+kMg
 ygh
 cPq
 bix
 cmk
 ffS
-ffS
-bjt
+txB
+nWo
 vvv
 ffS
-bjt
-bjt
+nWo
+nWo
 ffS
 fAi
 coT
 kuh
 hne
-yaE
+kMg
 plf
 kHU
 kHU
 kHU
 kHU
 plf
-yaE
+kMg
 wtr
 rsE
 jhc
@@ -149725,11 +151270,11 @@ xVN
 qNO
 bKT
 uSN
-fjB
+qSx
 hwF
-eyj
-lNt
-fjB
+hwF
+hwF
+qSx
 uSN
 mpN
 uQg
@@ -149751,7 +151296,7 @@ hBZ
 kHU
 kHU
 kHU
-lYH
+ftV
 nJF
 txp
 tvj
@@ -149762,7 +151307,7 @@ dVA
 ntw
 atk
 dhb
-mmd
+atE
 tFU
 nAN
 iuu
@@ -149805,7 +151350,7 @@ fes
 gLF
 som
 gWl
-rSa
+naE
 hOR
 hOR
 rSa
@@ -149816,7 +151361,7 @@ gWR
 iBy
 rKA
 wBR
-wBR
+dxP
 axc
 oeh
 oeh
@@ -149932,7 +151477,7 @@ jtw
 bsV
 qrH
 ggs
-yaE
+kMg
 iYf
 fff
 sUt
@@ -149959,14 +151504,14 @@ eAW
 iMs
 vJG
 dat
-yaE
+kMg
 plf
 kHU
 kHU
 kHU
 kHU
 plf
-yaE
+kMg
 vDr
 fYS
 jEs
@@ -149990,7 +151535,7 @@ qSx
 uSN
 aam
 bqI
-tJq
+kUi
 bRX
 rbL
 hXZ
@@ -149999,7 +151544,7 @@ rdT
 cRm
 cgg
 gNT
-bRX
+rPv
 bRX
 vlD
 ogP
@@ -150068,7 +151613,7 @@ qnq
 cEh
 pnu
 rBp
-wBR
+dxP
 iPX
 qIQ
 bBR
@@ -150079,7 +151624,7 @@ wUe
 jin
 fLu
 aVy
-wDZ
+jjF
 eKO
 xpa
 fPI
@@ -150216,14 +151761,14 @@ alc
 gHT
 fYS
 lTw
-yaE
+kMg
 kHU
 kHU
 plf
 plf
 kHU
 kHU
-yaE
+kMg
 csG
 fYS
 sdy
@@ -150266,7 +151811,7 @@ plf
 kHU
 plf
 lYH
-apX
+sIv
 iQw
 wtl
 ham
@@ -150342,7 +151887,7 @@ wRh
 ftg
 orf
 wDZ
-wDZ
+jjF
 wDZ
 wDZ
 chv
@@ -150446,9 +151991,9 @@ ryD
 qDf
 wLR
 wMj
-yaE
+kMg
 lae
-yaE
+kMg
 ljH
 eyw
 eyw
@@ -150473,14 +152018,14 @@ alc
 gHT
 fYS
 lTw
-yaE
+kMg
 kHU
 plf
 plf
 plf
 plf
 kHU
-yaE
+kMg
 csG
 fYS
 kBW
@@ -150497,9 +152042,9 @@ xVN
 tJq
 qup
 quV
-bnx
+mng
 rSY
-bnx
+dSi
 mye
 bnx
 tJq
@@ -150546,7 +152091,7 @@ tMh
 gGp
 plZ
 mUn
-mmd
+atE
 nyW
 mKJ
 aVg
@@ -150706,50 +152251,50 @@ ffS
 ffS
 ffS
 ffS
-ffS
-bjt
-bjt
+txB
+nWo
+nWo
 ffS
 vvv
-yaE
+kMg
 qgt
-yaE
+kMg
 cmk
 iOK
 dOC
 uSg
-yaE
+kMg
 qgt
-yaE
+kMg
 rcM
 ffS
-bjt
-bjt
-ffS
+nWo
+nWo
+txB
 ffS
 upq
 fYS
 wjU
 ffS
-bjt
-bjt
-bjt
-bjt
-bjt
-bjt
+nWo
+nWo
+nWo
+nWo
+nWo
+nWo
 ffS
 wii
 fYS
 iLV
 wts
-wts
+xZY
 wts
 wts
 wfP
 eOt
 uio
 bll
-bll
+jhD
 xPY
 mUa
 pZq
@@ -150794,15 +152339,15 @@ mmd
 mmd
 mmd
 mmd
+atE
+mmd
+atE
 mmd
 mmd
 mmd
 mmd
 mmd
-mmd
-mmd
-mmd
-mmd
+atE
 mmd
 vRM
 psf
@@ -150810,7 +152355,7 @@ aVg
 grX
 dSE
 oRh
-aVg
+uut
 bVQ
 kkG
 oFJ
@@ -150837,7 +152382,7 @@ rSa
 eUW
 lWZ
 rSa
-rSa
+naE
 rSa
 wBR
 wjL
@@ -150968,16 +152513,16 @@ plf
 plf
 plf
 plf
-yaE
+kMg
 qYg
-yaE
-bjt
-bjt
-bjt
-bjt
-yaE
+kMg
+nWo
+nWo
+nWo
+nWo
+kMg
 qYg
-yaE
+kMg
 plf
 plf
 plf
@@ -150998,15 +152543,15 @@ ffS
 uAC
 fYS
 wtr
-xVN
+jGh
 iga
 dXT
-xVN
+jGh
 bll
 rXS
 gBW
 bll
-bll
+jhD
 mdE
 tJq
 miU
@@ -151018,7 +152563,7 @@ ieG
 eao
 jhy
 vIX
-tJq
+kUi
 ohV
 hNp
 bHC
@@ -151026,7 +152571,7 @@ bRX
 aag
 iqM
 ljP
-bRX
+rPv
 hZs
 srs
 nvi
@@ -151046,7 +152591,7 @@ oIM
 tCX
 lCz
 oKx
-oIM
+chE
 sXp
 oYQ
 geq
@@ -151086,7 +152631,7 @@ xxm
 ttD
 uSH
 tEY
-xxm
+xAd
 rpZ
 sjU
 sOk
@@ -151101,7 +152646,7 @@ jlG
 xGp
 cfF
 vRp
-wBR
+dxP
 bbk
 cco
 cEJ
@@ -151227,20 +152772,20 @@ xjr
 kHU
 dhU
 hGn
-yaE
+kMg
 kHU
 plf
 plf
 kHU
-yaE
+kMg
 hGn
-yaE
+kMg
 plf
 plf
 kHU
 kHU
 kHU
-yaE
+kMg
 csG
 fYS
 nln
@@ -151266,20 +152811,20 @@ oZA
 xVN
 xVN
 tJq
-tJq
+kUi
 noq
 sRL
 fSx
 ulH
 kvu
 ucP
-kvu
+uxi
 kvu
 kvu
 nHp
 tAg
 ahQ
-bRX
+rPv
 sEY
 kSI
 acy
@@ -151299,9 +152844,9 @@ vOQ
 tvj
 nxF
 uqv
+scf
 lZx
-lZx
-lZx
+scf
 lZx
 lZx
 pQD
@@ -151333,7 +152878,7 @@ nvi
 ogP
 tGK
 oXw
-bZk
+lei
 bZk
 bZk
 bZk
@@ -151353,7 +152898,7 @@ hpE
 rSa
 bGq
 nTU
-wBR
+dxP
 wZn
 mWS
 bFo
@@ -151364,14 +152909,14 @@ pPK
 iUF
 wDZ
 wDZ
-wDZ
+jjF
 wDZ
 iUF
 bGi
 tJV
+jjF
 wDZ
-wDZ
-wDZ
+jjF
 wDZ
 pku
 gIJ
@@ -151496,8 +153041,8 @@ plf
 plf
 plf
 kHU
-yaE
-yaE
+kMg
+kMg
 csG
 fYS
 dUJ
@@ -151520,14 +153065,14 @@ bll
 nEE
 kET
 pPd
-xVN
+jGh
 fYg
 gqd
 srs
 srs
-srs
+ows
 kvu
-kvu
+uxi
 kvu
 eHx
 unt
@@ -151792,14 +153337,14 @@ sCO
 kvu
 bRX
 bRX
-bRX
+rPv
 bRX
 bRX
 bRX
 bRX
 bRX
 xIQ
-srs
+qwN
 wVZ
 itF
 vAu
@@ -151828,7 +153373,7 @@ geq
 kMR
 gIC
 kxd
-pQD
+fWr
 pQD
 pQD
 pQD
@@ -151853,11 +153398,11 @@ vdj
 bTd
 pUP
 xot
-xxm
+xAd
 qPa
 kmW
 rKS
-xxm
+xAd
 rtq
 rSa
 elV
@@ -152009,9 +153554,9 @@ plf
 plf
 plf
 plf
-bjt
-bjt
-bjt
+nWo
+nWo
+nWo
 csG
 fYS
 iMr
@@ -152120,7 +153665,7 @@ rSa
 axJ
 bWo
 stv
-rSa
+naE
 rSa
 uqj
 xqf
@@ -152283,11 +153828,11 @@ xao
 csG
 fYS
 sEX
-srs
+qwN
 rzN
 hSq
 vRu
-srs
+qwN
 bDf
 bll
 oTt
@@ -152345,10 +153890,10 @@ eXe
 eXe
 hfS
 pDU
-pQD
+fWr
 wVZ
 mKJ
-mMA
+xNt
 vEH
 kSv
 rOO
@@ -152398,7 +153943,7 @@ beJ
 beJ
 beJ
 bRy
-beJ
+vlV
 beJ
 beJ
 roF
@@ -152523,8 +154068,8 @@ plf
 plf
 plf
 plf
-bjt
-bjt
+nWo
+nWo
 glx
 oDk
 fYS
@@ -152630,7 +154175,7 @@ sQd
 qDS
 qDS
 iIq
-cAq
+jwi
 qDS
 mmN
 jMv
@@ -152638,7 +154183,7 @@ iQV
 qDS
 sRN
 lkn
-jMv
+jdb
 pxa
 cAq
 qDS
@@ -152793,11 +154338,11 @@ cbP
 cbP
 xbG
 omV
-omV
+oyI
 csG
 kuh
 jQo
-srs
+qwN
 uHj
 fYG
 jfo
@@ -152893,13 +154438,13 @@ fsv
 fzx
 mne
 vTJ
-sBD
+srJ
 aMR
 bni
 sBD
 sBD
 bni
-sBD
+srJ
 sBD
 sXj
 mPo
@@ -152914,7 +154459,7 @@ fNA
 lKf
 gyl
 fNA
-beJ
+vlV
 lOY
 ewZ
 vVj
@@ -153038,8 +154583,8 @@ plf
 plf
 plf
 kHU
-yaE
-yaE
+kMg
+kMg
 nsh
 fYS
 vDr
@@ -153076,9 +154621,9 @@ sht
 sht
 edA
 sht
+xpv
 sht
-sht
-mXC
+hCm
 mXC
 cSn
 mXC
@@ -153088,7 +154633,7 @@ xdk
 bzv
 lMB
 wDN
-hBZ
+rVP
 kHU
 shk
 vgF
@@ -153181,7 +154726,7 @@ plL
 plL
 hGQ
 dQz
-hqd
+dYz
 xhL
 qTU
 sug
@@ -153283,20 +154828,20 @@ xjr
 kHU
 dhU
 hGn
-yaE
+kMg
 kHU
 plf
 plf
 kHU
-yaE
+kMg
 hGn
-yaE
+kMg
 plf
 plf
 kHU
 kHU
 kHU
-yaE
+kMg
 dtY
 sTt
 vDr
@@ -153328,7 +154873,7 @@ gux
 srs
 xse
 nyv
-sht
+xpv
 nie
 izS
 aRr
@@ -153398,7 +154943,7 @@ eOj
 sew
 kXd
 afh
-mne
+fjB
 rIl
 xfO
 qly
@@ -153422,7 +154967,7 @@ cdS
 lnd
 pdC
 hlU
-beJ
+vlV
 kwC
 gea
 odg
@@ -153538,16 +155083,16 @@ xjr
 xjr
 xjr
 plf
-yaE
+kMg
 ruV
-yaE
-bjt
-bjt
-bjt
-bjt
-yaE
+kMg
+nWo
+nWo
+nWo
+nWo
+kMg
 ruV
-yaE
+kMg
 plf
 plf
 plf
@@ -153557,7 +155102,7 @@ ffS
 jUI
 fYS
 vDr
-omV
+oyI
 ouq
 lcf
 nig
@@ -153579,10 +155124,10 @@ bWV
 dVi
 sht
 sht
+fKQ
+xpv
 sht
-sht
-sht
-sht
+xpv
 isG
 sht
 sht
@@ -153627,7 +155172,7 @@ kxd
 jhH
 iMQ
 kxd
-pQD
+fWr
 plf
 plf
 oXw
@@ -153651,7 +155196,7 @@ krJ
 sew
 fWT
 nYh
-sew
+qnJ
 sew
 eQU
 phG
@@ -153690,9 +155235,9 @@ rmY
 rmY
 rmY
 aaG
+oNc
 rmY
-rmY
-rmY
+oNc
 aaI
 rmY
 rxC
@@ -153702,13 +155247,13 @@ gJZ
 gJZ
 vhu
 sKR
-rmY
+oNc
 foK
 xfW
 kKm
 oBw
 tlK
-tlK
+dKJ
 kHU
 plf
 plf
@@ -153792,24 +155337,24 @@ kHU
 ffS
 bjt
 glU
-bjt
+nWo
 ffS
 rcM
-yaE
+kMg
 qgt
-yaE
+kMg
 aqg
 aqg
 aqg
 cmk
-yaE
+kMg
 qgt
-yaE
+kMg
 vvv
 ffS
-bjt
-bjt
-ffS
+nWo
+nWo
+txB
 cmm
 nsh
 fYS
@@ -153869,9 +155414,9 @@ vOQ
 tvj
 nxF
 uqv
+scf
 lZx
-lZx
-lZx
+scf
 lZx
 lZx
 pQD
@@ -153931,7 +155476,7 @@ fgs
 sbr
 hdN
 sbk
-kpr
+mRs
 wcD
 xFi
 xFi
@@ -153942,7 +155487,7 @@ wDh
 pfr
 jMG
 abd
-beJ
+vlV
 eAS
 eHc
 aQL
@@ -154216,7 +155761,7 @@ mRu
 mRu
 ier
 rXN
-rmY
+oNc
 pfW
 vfW
 hrU
@@ -154303,7 +155848,7 @@ plf
 lgc
 kHU
 kHU
-ffS
+txB
 rrR
 oaP
 fYS
@@ -154333,7 +155878,7 @@ whM
 jmd
 hef
 eFK
-omV
+oyI
 reb
 mcL
 nyv
@@ -154348,7 +155893,7 @@ fGm
 iqq
 cRg
 tIH
-sht
+xpv
 ltP
 ybe
 vex
@@ -154391,20 +155936,20 @@ iaL
 iaL
 iaL
 iaL
-iaL
+wNO
 iaL
 iaL
 iaL
 hEr
 hEr
-hEr
+xqz
 hEr
 hEr
 hEr
 hEr
 wMM
 bfG
-rZn
+ibe
 bwZ
 try
 xKJ
@@ -154412,7 +155957,7 @@ xLZ
 ktc
 wqS
 gfs
-rZn
+ibe
 wVZ
 xag
 vof
@@ -154560,7 +156105,7 @@ plf
 kHU
 plf
 plf
-yaE
+kMg
 jKS
 fcd
 wAG
@@ -154639,7 +156184,7 @@ gpg
 llT
 tvj
 jEM
-iaL
+wNO
 cqG
 ltn
 hZU
@@ -154647,12 +156192,12 @@ hZU
 xzc
 wtR
 aNO
-iaL
+wNO
 pwQ
 rxj
 wwU
 kPq
-hEr
+xqz
 gUX
 gUX
 gnJ
@@ -154699,7 +156244,7 @@ mbK
 vVA
 szQ
 bOW
-sBD
+srJ
 pxa
 xZn
 kpr
@@ -154713,7 +156258,7 @@ vEK
 njw
 mnO
 iVK
-beJ
+vlV
 iiQ
 nGt
 vmo
@@ -154820,7 +156365,7 @@ kHU
 uEm
 ffS
 lgb
-lgb
+dQs
 lgb
 lgb
 lgb
@@ -154835,16 +156380,16 @@ uUD
 kma
 mZg
 cmk
-ffS
+txB
+srs
+srs
+srs
+qwN
 srs
 srs
 srs
 srs
-srs
-srs
-srs
-srs
-srs
+qwN
 srs
 srs
 srs
@@ -154855,20 +156400,20 @@ niH
 nyv
 cpR
 cpR
+qDr
 cpR
 cpR
 cpR
 cpR
-cpR
-cpR
+qDr
 bas
 bas
 bas
+eWW
 bas
 bas
 bas
-bas
-bas
+eWW
 bas
 bas
 pbb
@@ -154949,7 +156494,7 @@ eQI
 dTh
 gqx
 yiz
-sBD
+srJ
 dfS
 vBg
 aKs
@@ -154962,14 +156507,14 @@ rYC
 kpr
 kpr
 kpr
+mRs
 kpr
-kpr
 beJ
 beJ
-beJ
+vlV
 beJ
 mWZ
-beJ
+vlV
 beJ
 rmY
 xXS
@@ -154987,13 +156532,13 @@ fCj
 phn
 ier
 rUL
-rmY
+oNc
 tlK
 uei
 bSM
 vfW
 abP
-tlK
+dKJ
 plf
 pka
 plf
@@ -155148,7 +156693,7 @@ rPX
 plf
 kHU
 plf
-lYH
+ftV
 mfJ
 jYO
 iQv
@@ -155210,7 +156755,7 @@ kdH
 kdH
 kdH
 kdH
-kdH
+lue
 qxl
 qxl
 vUq
@@ -155224,7 +156769,7 @@ asm
 jfS
 vrA
 qtV
-npd
+lic
 syl
 tmK
 unB
@@ -155349,7 +156894,7 @@ tRY
 tRY
 aex
 pwd
-lgb
+dQs
 tZU
 oOP
 nyv
@@ -155432,7 +156977,7 @@ gWn
 jJs
 kYE
 dwJ
-rZn
+ibe
 vVL
 ajk
 kUm
@@ -155456,7 +157001,7 @@ igW
 gwH
 nPb
 nPb
-nPb
+gcx
 xRs
 rJg
 jJo
@@ -155469,7 +157014,7 @@ tfX
 twB
 kdH
 eOx
-qxl
+iWz
 qxl
 cVX
 qRh
@@ -155590,13 +157135,13 @@ kHU
 plf
 plf
 kHU
-lgb
+dQs
 wYB
 kXg
 rpj
 mHC
 vGp
-lgb
+dQs
 vhM
 cQi
 oLp
@@ -155647,7 +157192,7 @@ dMI
 xYD
 isE
 ogl
-sht
+xpv
 jqQ
 nQy
 jqQ
@@ -155682,7 +157227,7 @@ uqH
 smi
 iaL
 tls
-oCZ
+cJi
 tXB
 wRR
 gWn
@@ -155881,7 +157426,7 @@ srs
 nyv
 pnq
 nyv
-cpR
+qDr
 uuH
 qbm
 xTi
@@ -155903,7 +157448,7 @@ sht
 osk
 wFU
 sht
-sht
+xpv
 sht
 utf
 dXa
@@ -155929,7 +157474,7 @@ bpi
 gAc
 ebc
 mnK
-iaL
+wNO
 iaL
 iaL
 iaL
@@ -155973,7 +157518,7 @@ eJm
 piz
 svc
 nCD
-nPb
+gcx
 bcF
 ati
 uKL
@@ -155989,7 +157534,7 @@ tfW
 lij
 bIH
 clt
-qxl
+iWz
 npd
 aeO
 npd
@@ -156116,7 +157661,7 @@ uYs
 uYs
 uYs
 uYs
-lgb
+dQs
 uYs
 kKg
 uYs
@@ -156146,7 +157691,7 @@ nJB
 quG
 quG
 dav
-cpR
+qDr
 hVo
 hFG
 hFG
@@ -156187,14 +157732,14 @@ rHq
 rHq
 hZU
 ygS
-iaL
+wNO
 cjq
 nac
 hrj
 pEa
 kMA
 gUC
-iaL
+wNO
 pst
 oCZ
 lQz
@@ -156204,7 +157749,7 @@ fus
 fZz
 oNU
 fuM
-rZn
+ibe
 rWn
 xWS
 npW
@@ -156238,7 +157783,7 @@ sUP
 qDm
 omM
 qDm
-kdH
+lue
 tXl
 bhv
 biC
@@ -156252,11 +157797,11 @@ iDo
 txc
 npd
 npd
-npd
+lic
 tgA
 xQo
 qIx
-rmY
+oNc
 rmY
 tsE
 rmY
@@ -156365,7 +157910,7 @@ kmD
 jKG
 wru
 hue
-tYn
+bya
 plf
 nHd
 uSD
@@ -156377,7 +157922,7 @@ nRr
 ybG
 tvg
 wDO
-lgb
+dQs
 kxe
 oGb
 erK
@@ -156399,7 +157944,7 @@ cpR
 cpR
 dpk
 dpk
-cpR
+qDr
 wPK
 wPK
 cpR
@@ -156438,7 +157983,7 @@ jxu
 pBI
 imK
 hIQ
-iaL
+wNO
 smi
 hZU
 hZU
@@ -156518,7 +158063,7 @@ oYI
 xfr
 glD
 ojS
-efB
+opF
 rmY
 guO
 tnp
@@ -156529,7 +158074,7 @@ rmY
 phn
 ier
 mnw
-rmY
+oNc
 tlK
 tlK
 mTY
@@ -156618,7 +158163,7 @@ plf
 plf
 kHU
 kHU
-tYn
+bya
 rLY
 wBi
 xpt
@@ -156648,7 +158193,7 @@ srs
 nyv
 aUl
 aGL
-aGL
+nBx
 kCL
 aGL
 aGL
@@ -156695,21 +158240,21 @@ mzR
 aVI
 iRZ
 mzR
+wNO
+iaL
+iaL
+wNO
 iaL
 iaL
 iaL
 iaL
+wNO
 iaL
 iaL
+wNO
 iaL
 iaL
-iaL
-iaL
-iaL
-iaL
-iaL
-iaL
-iaL
+wNO
 hEr
 xeH
 hEr
@@ -156717,13 +158262,13 @@ hEr
 xCJ
 pAS
 qEV
-oXw
+bxG
 rZn
 rZn
+ibe
 rZn
 rZn
-rZn
-rZn
+ibe
 rZn
 rZn
 alz
@@ -156738,9 +158283,9 @@ icJ
 nPb
 nPb
 rMM
+gcx
 nPb
-nPb
-nPb
+gcx
 rMM
 rMM
 nPb
@@ -156939,7 +158484,7 @@ pfA
 cpR
 aoi
 cpR
-cpR
+qDr
 rCx
 pMl
 mXl
@@ -157049,7 +158594,7 @@ nMJ
 dLc
 vGt
 abW
-tlK
+dKJ
 plf
 pka
 plf
@@ -157239,7 +158784,7 @@ xSd
 xSd
 xSd
 xSd
-xSd
+ycp
 tcx
 laN
 ogP
@@ -157284,7 +158829,7 @@ kFX
 xUM
 qBt
 kFX
-kFX
+sub
 kFX
 kFX
 nKU
@@ -157300,7 +158845,7 @@ mRu
 mRu
 ier
 cSz
-rmY
+oNc
 bLC
 dpF
 gVK
@@ -157405,7 +158950,7 @@ kMt
 wDO
 erG
 wDO
-lgb
+dQs
 gux
 xsj
 tKs
@@ -157418,7 +158963,7 @@ srs
 jtq
 nyv
 jFh
-aGL
+nBx
 dUL
 wPf
 eLs
@@ -157432,8 +158977,8 @@ xuQ
 ojt
 ojt
 nQN
-ojt
-ojt
+wlt
+wlt
 ojt
 ojt
 fnT
@@ -157446,12 +158991,12 @@ usB
 vEp
 gng
 cpR
-cpR
+qDr
 sQu
 sQu
 sQu
 cpR
-cpR
+qDr
 gtK
 cpR
 pxL
@@ -157496,7 +159041,7 @@ vAu
 vAu
 vAu
 vAu
-qDF
+ybz
 kpD
 vAu
 koY
@@ -157680,7 +159225,7 @@ vIz
 teE
 lnS
 urF
-aGL
+nBx
 xAT
 uOv
 ojt
@@ -157689,7 +159234,7 @@ xuQ
 miA
 ojt
 acZ
-ojt
+wlt
 adc
 seU
 miA
@@ -157715,12 +159260,12 @@ cBp
 lGt
 hBZ
 hBZ
-hBZ
+rVP
 bor
 abz
 bor
 hBZ
-hBZ
+rVP
 hBZ
 cmN
 cmN
@@ -157733,7 +159278,7 @@ uuf
 xsY
 bhH
 jTW
-jTW
+bpb
 jTW
 jTW
 jTW
@@ -157742,7 +159287,7 @@ swO
 sEr
 jTW
 jTW
-jTW
+bpb
 jTW
 jTW
 qfR
@@ -157760,14 +159305,14 @@ kbS
 kbS
 kbS
 kbS
-kbS
+fye
 fpn
 abk
 mFf
 abm
 fpn
 kbS
-kbS
+fye
 aac
 aFa
 uPZ
@@ -157779,7 +159324,7 @@ lez
 lez
 efB
 wOB
-wOB
+hBq
 wOB
 wOB
 fsz
@@ -157804,7 +159349,7 @@ xfr
 xfr
 xfr
 cea
-rmY
+oNc
 sAP
 lMT
 aPX
@@ -157813,12 +159358,12 @@ bJf
 jyz
 nMn
 kKw
+oNc
 rmY
-rmY
 tlK
+dKJ
 tlK
-tlK
-tlK
+dKJ
 tlK
 plf
 plf
@@ -157979,7 +159524,7 @@ lVq
 plf
 kHU
 plf
-cmN
+vuf
 ykD
 iZo
 lkG
@@ -158001,7 +159546,7 @@ pQK
 cpc
 fkW
 mbx
-jTW
+bpb
 mKl
 hqB
 hyh
@@ -158010,10 +159555,10 @@ hBZ
 ulV
 ulV
 hBZ
-hBZ
+rVP
 eiS
 wGg
-kbS
+fye
 jgj
 nsS
 cqJ
@@ -158029,20 +159574,20 @@ kbS
 kbS
 kbS
 kbS
-sfm
+imG
 sfm
 aqx
 sfm
-sfm
+imG
 sfm
 cuH
 wQR
 dcr
 wOB
-wOB
+hBq
 mrl
 wOB
-wOB
+hBq
 qdH
 hPN
 icU
@@ -158063,7 +159608,7 @@ lez
 pyv
 rmY
 rmY
-rmY
+oNc
 rmY
 amx
 amx
@@ -158193,8 +159738,8 @@ aGL
 aGL
 cvE
 aGL
-aGL
-aGL
+nBx
+nBx
 nmH
 uOv
 ojt
@@ -158229,11 +159774,11 @@ kWB
 lGt
 plf
 hpt
-hpt
+eyj
 hpt
 abz
 hpt
-hpt
+eyj
 hpt
 plf
 cmN
@@ -158262,7 +159807,7 @@ dHb
 mKl
 hqB
 hyh
-hBZ
+rVP
 tcX
 uWE
 hTc
@@ -158313,7 +159858,7 @@ bcG
 pnY
 eiH
 eiH
-eiH
+lzq
 hbZ
 hbZ
 hbZ
@@ -158449,7 +159994,7 @@ gux
 aGL
 hVr
 wnv
-aGL
+nBx
 uQb
 aGL
 weQ
@@ -158480,10 +160025,10 @@ yaA
 jWH
 mji
 bxQ
-lGt
+cye
 sTE
 riS
-lGt
+cye
 kHU
 hpt
 swI
@@ -158493,7 +160038,7 @@ swI
 abF
 hpt
 kHU
-cmN
+vuf
 mPw
 xrE
 qJp
@@ -158542,7 +160087,7 @@ qek
 qrk
 wze
 cCI
-kbS
+fye
 fJD
 wYF
 uYM
@@ -158576,7 +160121,7 @@ kYy
 ydP
 kUv
 eiH
-eiH
+lzq
 mUR
 mUR
 plf
@@ -158688,7 +160233,7 @@ nHd
 nHd
 sRk
 lgb
-lgb
+dQs
 lgb
 lgb
 mwa
@@ -158724,13 +160269,13 @@ rZM
 rZM
 xwa
 vke
-twC
+oyT
 xzg
 xzg
 qJX
 xzg
 xzg
-twC
+oyT
 aAF
 iqI
 eHg
@@ -158742,13 +160287,13 @@ sTE
 sTE
 lGt
 plf
-hpt
+eyj
 biT
 hRn
 aNE
 hRn
 abH
-hpt
+eyj
 plf
 cmN
 fjl
@@ -158777,13 +160322,13 @@ pIp
 vBL
 jwD
 hBZ
+rVP
 hBZ
 hBZ
 hBZ
 hBZ
 hBZ
-hBZ
-hBZ
+rVP
 kbS
 cNa
 dNG
@@ -158813,7 +160358,7 @@ ioH
 aKv
 sBl
 vBA
-wOB
+hBq
 fBJ
 rOG
 sYW
@@ -158954,11 +160499,11 @@ srs
 srs
 srs
 srs
+qwN
 srs
 srs
 srs
-srs
-srs
+qwN
 srs
 aGL
 aGL
@@ -159055,7 +160600,7 @@ hGW
 kbS
 kbS
 kbS
-kbS
+fye
 kbS
 kbS
 sfm
@@ -159254,7 +160799,7 @@ wtb
 lGt
 brW
 oLo
-lGt
+cye
 plf
 hpt
 abv
@@ -159269,7 +160814,7 @@ rZe
 vTl
 cmN
 cmN
-cmN
+vuf
 cmN
 mlR
 nPh
@@ -159325,16 +160870,16 @@ gdT
 wOB
 wOB
 wOB
-wOB
+hBq
 wOB
 wOB
 qdH
 nYN
 qdH
 qdH
+fHk
 qdH
-qdH
-qdH
+fHk
 kUv
 mfd
 cUU
@@ -159464,7 +161009,7 @@ plf
 kHU
 plf
 plf
-fTz
+cLj
 uYi
 nSZ
 nSZ
@@ -159493,7 +161038,7 @@ sDU
 cpR
 bDl
 bDl
-cpR
+qDr
 cpR
 twC
 pPS
@@ -159519,7 +161064,7 @@ abx
 abC
 swI
 abL
-hpt
+eyj
 kHU
 gmw
 gmw
@@ -159607,7 +161152,7 @@ mtw
 cUU
 gEm
 huZ
-oJJ
+oon
 mUR
 plf
 plf
@@ -159721,7 +161266,7 @@ pka
 kHU
 plf
 plf
-fTz
+cfE
 jcc
 nSZ
 nSZ
@@ -159765,16 +161310,16 @@ tWv
 lDY
 kKb
 fnU
-lGt
+cye
 nsz
 kHU
 plf
 plf
 hpt
+eyj
 hpt
 hpt
-hpt
-hpt
+eyj
 hpt
 hpt
 plf
@@ -159788,7 +161333,7 @@ gmw
 xWN
 emV
 lVA
-jTW
+bpb
 gjT
 oWH
 cox
@@ -159804,7 +161349,7 @@ jTW
 rRL
 hqB
 lMy
-bYH
+tTi
 tfV
 jIk
 uAq
@@ -159817,11 +161362,11 @@ ftn
 bVz
 lfr
 rNn
-bZx
+kPK
 bmM
 dRW
 bmM
-bZx
+kPK
 kwo
 tNm
 ybY
@@ -159978,7 +161523,7 @@ kxB
 kHU
 kHU
 kHU
-fTz
+cLj
 clc
 nSZ
 nSZ
@@ -160035,7 +161580,7 @@ plf
 kHU
 plf
 plf
-gmw
+ibN
 qbe
 mlK
 xmU
@@ -160091,7 +161636,7 @@ voR
 dLG
 dLG
 dLG
-dLG
+gaz
 dLG
 dLG
 vXL
@@ -160101,7 +161646,7 @@ mDI
 mDI
 mDI
 mDI
-mDI
+myK
 mDI
 mDI
 mDI
@@ -160121,7 +161666,7 @@ mtw
 cUU
 gEm
 huZ
-oJJ
+oon
 mUR
 plf
 plf
@@ -160250,7 +161795,7 @@ oKX
 pjX
 oKX
 pjX
-fTz
+cLj
 kHU
 kHU
 kHU
@@ -160314,7 +161859,7 @@ aiy
 lMq
 xpq
 nsv
-jTW
+bpb
 uCB
 yjY
 dMq
@@ -160324,7 +161869,7 @@ pEx
 gJO
 sGi
 uED
-kbS
+fye
 wqq
 aQj
 gzx
@@ -160362,7 +161907,7 @@ hVZ
 mDI
 dWD
 iAb
-mDI
+myK
 huw
 pwS
 cUU
@@ -160523,7 +162068,7 @@ kHU
 kHU
 kHU
 kHU
-twC
+oyT
 twC
 mmP
 rEs
@@ -160575,7 +162120,7 @@ jTW
 pIp
 hqB
 orJ
-bYH
+tTi
 rox
 lnf
 acv
@@ -160588,11 +162133,11 @@ pji
 lGf
 dNG
 rNn
-bZx
+kPK
 bmM
 xKW
 bmM
-bZx
+kPK
 iMc
 kYI
 fuN
@@ -160816,7 +162361,7 @@ ilc
 xWN
 tTA
 pMC
-jTW
+bpb
 cQU
 sSQ
 fwI
@@ -160828,7 +162373,7 @@ hlq
 riw
 uaL
 kwI
-jTW
+bpb
 pIp
 hqB
 orJ
@@ -160842,7 +162387,7 @@ kbS
 kbS
 tAc
 kbS
-kbS
+fye
 jia
 rNn
 nby
@@ -160869,7 +162414,7 @@ xRL
 bwO
 mDI
 mDI
-mDI
+myK
 aJW
 mDI
 mDI
@@ -161074,13 +162619,13 @@ xWN
 prW
 eqC
 fJg
+hcb
 fJg
 fJg
 fJg
 fJg
 fJg
-fJg
-vst
+htr
 vst
 vst
 vst
@@ -161113,7 +162658,7 @@ nuA
 pht
 xSj
 fez
-kbS
+fye
 bwO
 eZH
 dLG
@@ -161146,7 +162691,7 @@ uiq
 uch
 sEp
 eiH
-eiH
+lzq
 mUR
 mUR
 plf
@@ -161365,9 +162910,9 @@ xlM
 bmM
 xlM
 hGW
+fye
 kbS
-kbS
-kbS
+fye
 kbS
 kbS
 kbS
@@ -161389,15 +162934,15 @@ kKG
 tTM
 mMz
 mDI
+myK
 mDI
-mDI
-eiH
+lzq
 eiH
 xQz
 pbQ
 eiH
 eiH
-eiH
+lzq
 eRX
 eRX
 eRX
@@ -161555,7 +163100,7 @@ twC
 twC
 twC
 twC
-twC
+oyT
 twC
 kHU
 plf
@@ -161576,7 +163121,7 @@ plf
 plf
 plf
 plf
-xyC
+nCM
 cFp
 klH
 lki
@@ -161604,16 +163149,16 @@ bsh
 cWT
 tMl
 fzp
-bYH
+tTi
 cVc
 nMB
 erN
 qhM
-kbS
+fye
 eqG
 nBQ
 vzo
-kbS
+fye
 lgC
 rNn
 iJz
@@ -161634,7 +163179,7 @@ dLG
 dLG
 uPL
 uPL
-dLG
+gaz
 dLG
 iIt
 usP
@@ -161652,7 +163197,7 @@ mQx
 eKY
 eyD
 tkH
-pne
+rPI
 plf
 plf
 plf
@@ -161792,7 +163337,7 @@ nSZ
 nSZ
 nSZ
 nSZ
-fTz
+cLj
 plf
 plf
 kHU
@@ -161855,7 +163400,7 @@ ogy
 jAp
 vst
 vst
-vst
+htr
 oxx
 cAF
 kAb
@@ -161884,7 +163429,7 @@ huT
 twW
 twW
 lSs
-kbS
+fye
 eXa
 voR
 dLG
@@ -161895,14 +163440,14 @@ mxZ
 dLG
 pIG
 qOq
-mDI
+myK
 wKe
 fZD
 iAk
 xAA
 sWL
 fhK
-mDI
+myK
 vZt
 hzG
 bdt
@@ -162110,7 +163655,7 @@ jcX
 fJg
 nPU
 tnt
-vst
+htr
 iyt
 eXY
 smC
@@ -162144,7 +163689,7 @@ xVY
 kbS
 mnp
 voR
-dLG
+gaz
 aUk
 nQd
 gJL
@@ -162154,7 +163699,7 @@ iIt
 sfm
 mDI
 mDI
-mDI
+myK
 mDI
 mDI
 mDI
@@ -162301,10 +163846,10 @@ kxB
 kxB
 fTz
 fTz
+cLj
 fTz
 fTz
-fTz
-fTz
+cLj
 fTz
 kHU
 plf
@@ -162354,7 +163899,7 @@ pgt
 dHR
 pVv
 mjM
-xyC
+nCM
 xWN
 jXs
 dnn
@@ -162364,7 +163909,7 @@ siM
 kzi
 xIe
 uYj
-fJg
+hcb
 wzd
 iBx
 vst
@@ -162379,9 +163924,9 @@ hHN
 dfA
 dfA
 hHN
-sXW
+gsB
 kbS
-kbS
+fye
 kbS
 kbS
 kbS
@@ -162605,7 +164150,7 @@ hwE
 jxX
 adp
 kMq
-xyC
+nCM
 xyC
 xyC
 xyC
@@ -162617,10 +164162,10 @@ jtG
 xAl
 fJg
 fJg
+hcb
 fJg
 fJg
-fJg
-fJg
+hcb
 fJg
 wzd
 kzh
@@ -162642,7 +164187,7 @@ eel
 dGo
 xRq
 kbS
-kbS
+fye
 kbS
 fpn
 eRc
@@ -162665,7 +164210,7 @@ xJv
 bhy
 dLG
 iIt
-pne
+rPI
 kkt
 xJL
 pAL
@@ -162882,7 +164427,7 @@ bLN
 wzd
 pHC
 vst
-sXW
+gsB
 sXW
 ize
 jMU
@@ -162903,16 +164448,16 @@ hgd
 jlH
 hjc
 cAr
-lCq
+wGV
 lCq
 oGh
-kbS
+fye
 rzL
 oAE
 gyi
 tOa
 wun
-kbS
+fye
 mUb
 xRL
 dLG
@@ -162930,7 +164475,7 @@ cvO
 qZH
 tfK
 etS
-pne
+rPI
 pne
 stE
 nJf
@@ -163102,13 +164647,13 @@ plf
 plf
 kHU
 vev
-vev
+dFk
 vev
 vev
 kSo
 poe
 leA
-cHH
+mXB
 adG
 iGB
 rwt
@@ -163138,7 +164683,7 @@ adp
 bRZ
 fGr
 eYX
-vst
+htr
 eXY
 wkR
 smC
@@ -163177,7 +164722,7 @@ eKF
 pYY
 jVJ
 thM
-dLG
+gaz
 iIt
 pne
 eRo
@@ -163195,7 +164740,7 @@ vbw
 egu
 cJd
 dfI
-pne
+rPI
 plf
 plf
 plf
@@ -163350,14 +164895,14 @@ plf
 plf
 plf
 qZx
-qZx
+xYS
 qZx
 qZx
 qZx
 qZx
 wXX
 wXX
-qZx
+xYS
 vev
 nqk
 fzb
@@ -163391,7 +164936,7 @@ hDL
 cyx
 xxb
 bfu
-adp
+xAg
 wtW
 wzd
 vAP
@@ -163417,13 +164962,13 @@ hWA
 mFY
 iXC
 hdR
-xUx
+gHI
 sfm
 oZG
 sfm
 sfm
 sfm
-sfm
+imG
 sfm
 sfm
 sfm
@@ -163449,7 +164994,7 @@ pne
 rsb
 bEf
 rsb
-rsb
+lnu
 qDV
 plp
 iCR
@@ -163606,7 +165151,7 @@ kHU
 suL
 suL
 suL
-qZx
+xYS
 ffK
 yds
 dSL
@@ -163644,7 +165189,7 @@ iGO
 vgk
 qfC
 afo
-adp
+xAg
 adp
 aHv
 sfr
@@ -163661,14 +165206,14 @@ cUm
 rVC
 dAw
 sXW
+gHI
 xUx
 xUx
 xUx
+gHI
 xUx
 xUx
-xUx
-xUx
-xUx
+gHI
 xUx
 xUx
 xUx
@@ -163695,10 +165240,10 @@ bwO
 iIt
 pne
 pne
+rPI
 pne
 pne
-pne
-pne
+rPI
 pne
 nPK
 nPK
@@ -163860,7 +165405,7 @@ kHU
 kHU
 kHU
 kHU
-suL
+upa
 jqK
 nqR
 qZx
@@ -163889,7 +165434,7 @@ bXA
 rfz
 bDv
 gvj
-cHH
+mXB
 pQo
 vFR
 hqk
@@ -163911,7 +165456,7 @@ fGr
 vpp
 vst
 vst
-vst
+htr
 oxx
 pnZ
 jeG
@@ -163928,13 +165473,13 @@ wgL
 wgL
 wgL
 wgL
-xUx
+gHI
 lJP
 iBz
 xUx
 bwO
 pKu
-fHD
+eAs
 jXb
 lOw
 pCr
@@ -164132,7 +165677,7 @@ mhH
 vev
 gzf
 iAc
-vev
+dFk
 pFv
 oHe
 kjL
@@ -164154,7 +165699,7 @@ adp
 mZr
 nRZ
 gIP
-adp
+xAg
 oCT
 jAB
 hWG
@@ -164162,7 +165707,7 @@ adp
 sBe
 rWu
 fQi
-adp
+xAg
 oYL
 wzd
 vpp
@@ -164175,7 +165720,7 @@ hym
 xoq
 tAM
 uQA
-xUx
+gHI
 wtL
 wtL
 wtL
@@ -164216,7 +165761,7 @@ hBA
 sfm
 mlv
 mcG
-sfm
+imG
 hxh
 ual
 glk
@@ -164368,12 +165913,12 @@ plf
 kHU
 kHU
 dBe
-qZx
+xYS
 wXX
 wXX
 wXX
 wXX
-qZx
+xYS
 qZx
 qZx
 fsq
@@ -164398,11 +165943,11 @@ cHH
 aAw
 rbW
 rbW
-cHH
+mXB
 cHH
 rbW
 abI
-cHH
+mXB
 cHH
 xhv
 had
@@ -164690,7 +166235,7 @@ umi
 xUx
 xUx
 xUx
-xUx
+gHI
 xUx
 wiv
 xUx
@@ -164698,7 +166243,7 @@ xUx
 xUx
 jNt
 xUx
-xUx
+gHI
 xUx
 iXC
 hdR
@@ -164956,11 +166501,11 @@ lCq
 byk
 lCq
 wri
-lCq
+wGV
 etv
 hdR
 gTO
-sfm
+imG
 eHV
 bwO
 fkM
@@ -165173,7 +166718,7 @@ lyE
 ntf
 vSz
 mxD
-adp
+xAg
 fqK
 oBN
 fqK
@@ -165190,14 +166735,14 @@ nZW
 kJs
 vSz
 bCI
-cHH
+mXB
 wEJ
 eYX
 iEb
 gYo
 uBW
 iBx
-vst
+htr
 hIf
 kgj
 uNd
@@ -165213,7 +166758,7 @@ sUU
 ccQ
 mti
 tPs
-raM
+taB
 cfY
 pbZ
 ivR
@@ -165407,7 +166952,7 @@ sMd
 hlv
 cTO
 aGz
-hlv
+omU
 rfV
 iVe
 qZx
@@ -165419,22 +166964,22 @@ afw
 afw
 nJt
 afw
-nJt
+ccN
 afw
-nJt
+ccN
 fxe
 ayd
-nJt
+ccN
 afw
 iXe
 iTl
 bkz
-iTl
+ukb
 iTl
 gOs
 iQz
 gOs
-aoj
+jdN
 fDm
 cin
 fDm
@@ -165458,7 +167003,7 @@ vst
 xUx
 xnj
 xUx
-xUx
+gHI
 xUx
 fTt
 xUx
@@ -165652,7 +167197,7 @@ plf
 plf
 pka
 kHU
-qZx
+xYS
 jFZ
 lAC
 hlv
@@ -165711,7 +167256,7 @@ kWX
 vst
 vym
 pHC
-vst
+htr
 xeF
 ptm
 wHa
@@ -165723,11 +167268,11 @@ xUx
 shy
 ptm
 dWK
-xUx
+gHI
 wSl
 ptm
 arm
-xUx
+gHI
 gex
 umE
 xUx
@@ -165912,10 +167457,10 @@ plf
 qZx
 uST
 cLR
-hlv
+omU
 lhk
 eEE
-hlv
+omU
 jIy
 phj
 hlv
@@ -165924,7 +167469,7 @@ sVt
 hlv
 gAl
 phj
-qZx
+xYS
 eND
 jIt
 qZx
@@ -165987,7 +167532,7 @@ gDY
 xUx
 gex
 hdR
-xUx
+gHI
 bwO
 eHV
 jIu
@@ -166169,14 +167714,14 @@ plf
 qZx
 hlv
 axg
-hlv
+omU
 hlv
 pfR
 hlv
 hlv
 eNj
 hlv
-hlv
+omU
 xPZ
 hlv
 hlv
@@ -166184,7 +167729,7 @@ rFp
 qZx
 fDB
 czU
-qZx
+xYS
 afw
 rlC
 hpb
@@ -166219,7 +167764,7 @@ mwW
 qPR
 mGO
 oTu
-onz
+rwY
 hMJ
 hsi
 vst
@@ -166237,7 +167782,7 @@ xUx
 uke
 kHM
 hkQ
-xUx
+gHI
 wpM
 iOb
 crz
@@ -166423,7 +167968,7 @@ plf
 plf
 kHU
 qZx
-qZx
+xYS
 gPN
 xKc
 nGA
@@ -166486,11 +168031,11 @@ kHU
 giN
 wQU
 noh
-xUx
+gHI
 rDT
 gBg
 wNl
-xUx
+gHI
 xzC
 iWu
 rDT
@@ -166758,7 +168303,7 @@ dJL
 dJL
 nKg
 nHj
-dJL
+hon
 sfm
 tBv
 sfm
@@ -166968,11 +168513,11 @@ eZh
 rbY
 luP
 krl
-iTl
+ukb
 qIl
 mRW
 aIf
-iTl
+ukb
 wES
 jfD
 diH
@@ -166996,7 +168541,7 @@ kHU
 plf
 plf
 plf
-dJL
+hon
 keN
 ncp
 peS
@@ -167205,11 +168750,11 @@ wJR
 cgZ
 fOV
 hgU
-hlv
+omU
 nQG
 tif
 tSi
-qZx
+xYS
 vmx
 vhF
 hlv
@@ -167247,13 +168792,13 @@ ouN
 xhl
 mGO
 oTu
-onz
+rwY
 kHU
 kHU
 plf
 kHU
 kHU
-adB
+loY
 ncp
 ncp
 eUo
@@ -167276,7 +168821,7 @@ mWz
 eRS
 lUi
 hMc
-adB
+loY
 kHU
 xsw
 pSP
@@ -167457,7 +169002,7 @@ utL
 lbT
 qbg
 mSW
-wjC
+svH
 ael
 wjC
 cJO
@@ -167470,7 +169015,7 @@ qZx
 tnw
 czU
 qQq
-qZx
+xYS
 plf
 plf
 ugF
@@ -167510,7 +169055,7 @@ kHU
 plf
 kHU
 plf
-adB
+loY
 gDh
 ncp
 ncp
@@ -167533,7 +169078,7 @@ mWz
 lNQ
 mWz
 wNb
-adB
+loY
 plf
 sfm
 unp
@@ -167717,7 +169262,7 @@ akB
 wjC
 wjC
 wjC
-wjC
+svH
 wjC
 hlv
 uwg
@@ -167746,7 +169291,7 @@ rFB
 iXe
 gOs
 pPo
-gOs
+uRj
 uKd
 ils
 dxq
@@ -167767,7 +169312,7 @@ kHU
 plf
 kHU
 plf
-adB
+loY
 ncp
 ncp
 ncp
@@ -167790,7 +169335,7 @@ mWz
 ucd
 mWz
 lCj
-adB
+loY
 kHU
 kHU
 plf
@@ -168004,7 +169549,7 @@ iXe
 kHU
 plf
 kHU
-uKd
+uaJ
 tte
 xCO
 fUB
@@ -168024,7 +169569,7 @@ kHU
 kHU
 lgc
 kHU
-adB
+loY
 ncp
 mpG
 ncp
@@ -168047,7 +169592,7 @@ mWz
 qnB
 mWz
 lCj
-adB
+loY
 kHU
 kHU
 plf
@@ -168251,7 +169796,7 @@ mIU
 fbo
 mIU
 huz
-huz
+lYj
 huz
 iXe
 iXe
@@ -168281,7 +169826,7 @@ plf
 plf
 kHU
 plf
-adB
+loY
 gDh
 ncp
 ncp
@@ -168304,7 +169849,7 @@ mWz
 hPr
 mWz
 nqE
-adB
+loY
 kHU
 kHU
 plf
@@ -168476,7 +170021,7 @@ plf
 kHU
 kHU
 qZx
-qZx
+xYS
 qZx
 qZx
 xLY
@@ -168501,7 +170046,7 @@ sZR
 plf
 kHU
 plf
-huz
+lYj
 iKX
 sDx
 bnu
@@ -168520,12 +170065,12 @@ plf
 kHU
 kHU
 uKd
+uaJ
 uKd
 uKd
 uKd
 uKd
-uKd
-uKd
+uaJ
 uKd
 kHU
 lgc
@@ -168538,7 +170083,7 @@ kHU
 kHU
 lgc
 kHU
-adB
+loY
 ncp
 ncp
 jyc
@@ -168561,7 +170106,7 @@ dAh
 mMt
 sJD
 wlz
-adB
+loY
 kHU
 lgc
 plf
@@ -168751,7 +170296,7 @@ hlv
 xIO
 jps
 xIO
-qZx
+xYS
 wmh
 tbS
 sZR
@@ -168818,7 +170363,7 @@ wud
 oTT
 oTT
 aau
-dJL
+hon
 kHU
 lgc
 kHU
@@ -169052,25 +170597,25 @@ kHU
 kHU
 lgc
 kHU
-dJL
+hon
 kDn
 ncp
 wrs
 dJL
-cym
-cym
+dtU
+dtU
 swr
-cym
-cym
+dtU
+dtU
 wxA
 hyY
 hyY
 wxA
-cym
-cym
+dtU
+dtU
 cAy
-cym
-cym
+dtU
+dtU
 dJL
 mxx
 mTv
@@ -169268,7 +170813,7 @@ hUq
 hUq
 wzo
 qAM
-qZx
+xYS
 kHU
 kHU
 kHU
@@ -169310,15 +170855,15 @@ plf
 lgc
 plf
 dJL
-cym
+dtU
 aLD
 cym
-dJL
+hon
 plf
 kHU
 fMh
 plf
-dJL
+hon
 nRG
 oXA
 oXA
@@ -169328,11 +170873,11 @@ plf
 cdR
 kHU
 plf
-adB
+loY
 hva
 afu
 lWC
-adB
+loY
 kHU
 kHU
 plf
@@ -169574,18 +171119,18 @@ dJL
 kHU
 rbK
 fcL
-cym
-cym
+dtU
+dtU
 qvQ
-cym
-cym
+dtU
+dtU
 qvQ
-cym
-cym
+dtU
+dtU
 auc
 dXZ
 kHU
-adB
+loY
 iGt
 afu
 abM
@@ -169824,10 +171369,10 @@ plf
 kHU
 tcq
 dJL
-cym
+dtU
 sDk
-cym
-dJL
+dtU
+hon
 plf
 htC
 jjS
@@ -169843,10 +171388,10 @@ aEX
 lMz
 plf
 dJL
-cym
-cym
-cym
-dJL
+dtU
+dtU
+dtU
+hon
 kHU
 kHU
 lgc
@@ -170099,7 +171644,7 @@ jjS
 jjS
 lMz
 plf
-adB
+loY
 kHU
 kHU
 kHU
@@ -170307,7 +171852,7 @@ pEn
 beC
 bWZ
 nsl
-huz
+lYj
 plf
 kHU
 lgc
@@ -170337,13 +171882,13 @@ plf
 plf
 lgc
 plf
-adB
+loY
 cVO
 ouU
 pVo
-adB
+loY
 kHU
-kVf
+xkK
 jjS
 jjS
 jjS
@@ -170356,7 +171901,7 @@ jjS
 iNM
 pVE
 kHU
-dJL
+hon
 kHU
 lgc
 lgc
@@ -170598,7 +172143,7 @@ kHU
 guY
 wja
 gHx
-adB
+loY
 plf
 htC
 jjS
@@ -170613,7 +172158,7 @@ jjS
 jjS
 lMz
 plf
-adB
+loY
 kHU
 lgc
 plf
@@ -170815,7 +172360,7 @@ gjS
 plf
 kHU
 plf
-huz
+lYj
 wlk
 woA
 lmF
@@ -170855,7 +172400,7 @@ kHU
 tXo
 axK
 ybX
-adB
+loY
 plf
 htC
 jjS
@@ -170870,7 +172415,7 @@ jjS
 jjS
 lMz
 plf
-adB
+loY
 kHU
 kHU
 plf
@@ -171112,7 +172657,7 @@ kHU
 plf
 plf
 plf
-adB
+loY
 plf
 htC
 jjS
@@ -171127,7 +172672,7 @@ jjS
 jjS
 lMz
 plf
-adB
+loY
 kHU
 lgc
 plf
@@ -171369,7 +172914,7 @@ kHU
 plf
 plf
 plf
-dJL
+hon
 kHU
 kVf
 nkf
@@ -171382,7 +172927,7 @@ jjS
 jjS
 jjS
 jjS
-pVE
+fxx
 kHU
 dJL
 kHU
@@ -171626,7 +173171,7 @@ kHU
 plf
 plf
 plf
-adB
+loY
 plf
 htC
 jjS
@@ -171641,7 +173186,7 @@ jjS
 jjS
 lMz
 plf
-adB
+loY
 kHU
 lgc
 plf
@@ -171883,7 +173428,7 @@ kHU
 kHU
 kHU
 kHU
-adB
+loY
 plf
 htC
 jjS
@@ -171898,7 +173443,7 @@ jjS
 jjS
 lMz
 plf
-adB
+loY
 kHU
 kHU
 kHU
@@ -172140,7 +173685,7 @@ kHU
 kHU
 plf
 kHU
-adB
+loY
 plf
 htC
 jjS
@@ -172155,7 +173700,7 @@ jjS
 jjS
 lMz
 plf
-adB
+loY
 kHU
 lgc
 plf
@@ -172397,22 +173942,22 @@ lgc
 kHU
 plf
 kHU
-adB
+loY
 plf
 iWS
 uxZ
-cym
-cym
+dtU
+dtU
 qvQ
-cym
-cym
+dtU
+dtU
 qvQ
-cym
-cym
+dtU
+dtU
 xxp
 atD
 plf
-adB
+loY
 kHU
 lgc
 plf
@@ -172664,7 +174209,7 @@ xAq
 oXA
 oXA
 nJn
-dJL
+hon
 plf
 cdR
 kHU
@@ -172912,21 +174457,21 @@ plf
 plf
 kHU
 dJL
-cym
-dJL
+dtU
+hon
 odh
 jNo
 anV
 xbd
-cym
-cym
+dtU
+dtU
 yhM
 xAm
 xAm
 dUa
 dJL
-cym
-dJL
+dtU
+hon
 kHU
 kHU
 plf
@@ -173173,7 +174718,7 @@ kHU
 kHU
 kHU
 kHU
-dJL
+hon
 vjZ
 eqo
 rjz
@@ -173692,7 +175237,7 @@ oOj
 qRr
 bqG
 duP
-dJL
+hon
 kHU
 lgc
 plf
@@ -173944,11 +175489,11 @@ plf
 plf
 plf
 kHU
+hon
+loY
 dJL
-adB
 dJL
-dJL
-adB
+loY
 dJL
 kHU
 plf

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -393,6 +393,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/set_burned,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
 "aaI" = (
@@ -480,6 +481,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
 "aaO" = (
@@ -628,6 +630,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -809,6 +812,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "abt" = (
@@ -1028,6 +1032,7 @@
 "abO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/lobby)
 "abP" = (
@@ -1069,6 +1074,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -1241,6 +1247,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/drone_fabrication)
 "acl" = (
@@ -1334,6 +1341,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1730,6 +1738,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2167,6 +2176,7 @@
 	name = "Common Channel";
 	pixel_x = 20
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "adK" = (
@@ -2413,6 +2423,7 @@
 	req_access = list(16);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2568,6 +2579,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/computer)
 "ael" = (
@@ -2892,6 +2904,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "aeT" = (
@@ -3109,6 +3122,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "afq" = (
@@ -3251,6 +3265,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "afB" = (
@@ -3435,12 +3450,14 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating/airless{
 	icon_state = "grimy"
 	},
 /area/space)
 "afQ" = (
 /obj/structure/computerframe,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating/airless{
 	icon_state = "grimy"
 	},
@@ -3758,6 +3775,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "agJ" = (
@@ -4191,6 +4209,7 @@
 	pixel_x = -32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -4609,6 +4628,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/locker)
 "aih" = (
@@ -4632,6 +4652,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -4642,6 +4663,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "aik" = (
@@ -4695,6 +4717,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -4976,6 +4999,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -5037,6 +5061,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -6021,6 +6046,7 @@
 	req_access = list(32);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "ali" = (
@@ -6085,6 +6111,7 @@
 	name = "Librarian"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "alm" = (
@@ -6218,6 +6245,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "alD" = (
@@ -6323,6 +6351,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "alN" = (
@@ -7204,6 +7233,7 @@
 	name = "Chapel"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -7633,6 +7663,7 @@
 	req_access = list(20)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -7666,6 +7697,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "aoF" = (
@@ -7896,6 +7928,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "apc" = (
@@ -8288,6 +8321,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8703,6 +8737,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aqx" = (
@@ -8887,6 +8922,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/computer)
 "aqJ" = (
@@ -9432,6 +9468,7 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "arB" = (
@@ -9734,6 +9771,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "asy" = (
@@ -9819,6 +9857,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "axd" = (
@@ -9881,6 +9920,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "azn" = (
@@ -10043,6 +10083,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"aHA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/outpost_misc_lab)
 "aIc" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -10423,6 +10467,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "aXD" = (
@@ -10578,6 +10623,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
@@ -10689,6 +10735,10 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/central)
+"bki" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/nuke_storage)
 "bkl" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10773,6 +10823,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
 "bop" = (
@@ -10811,6 +10862,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -10940,6 +10992,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bvh" = (
@@ -11165,6 +11218,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -11205,6 +11259,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bGI" = (
@@ -11461,6 +11516,10 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/server)
+"bTC" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/prison)
 "bUn" = (
 /obj/structure/stool,
 /mob/living/simple_animal/mouse,
@@ -11556,6 +11615,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bZK" = (
@@ -11589,11 +11649,10 @@
 	},
 /area/station/hallway/primary/central)
 "ccc" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/stool,
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
+/obj/item/device/flashlight/lamp/fir/special,
+/obj/item/weapon/present,
+/turf/simulated/floor{
+	icon_state = "grass1"
 	},
 /area/station/hallway/secondary/arrival)
 "cck" = (
@@ -11727,6 +11786,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "ciI" = (
@@ -11853,6 +11913,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "cnv" = (
@@ -11898,6 +11959,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -12032,6 +12094,27 @@
 	icon_state = "asteroid"
 	},
 /area/station/hallway/secondary/arrival)
+"cxX" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12);
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
+"cyE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/break_room)
 "cyF" = (
 /obj/machinery/newscaster{
 	pixel_y = 28
@@ -12041,6 +12124,14 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/central)
+"cAr" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "cAJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
 	dir = 8;
@@ -12066,6 +12157,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "cDq" = (
@@ -12285,6 +12377,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "cQe" = (
@@ -12468,6 +12561,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/outpost_misc_lab)
 "cXm" = (
@@ -12489,6 +12583,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "cXY" = (
@@ -12503,6 +12598,10 @@
 	},
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
+"cYq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/hos)
 "cYF" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12);
@@ -12700,6 +12799,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/brflowers,
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
@@ -12807,6 +12907,7 @@
 	name = "Escape Airlock";
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "dqs" = (
@@ -12851,6 +12952,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
 "dtk" = (
@@ -12893,6 +12995,10 @@
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor/engine,
 /area/asteroid/research_outpost/outpost_misc_lab)
+"dtN" = (
+/obj/item/weapon/present,
+/turf/simulated/floor/plating/airless/asteroid,
+/area/asteroid/mine/explored)
 "dtX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -12927,6 +13033,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -12970,6 +13077,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
@@ -12995,6 +13103,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/main)
+"dwV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge)
 "dxg" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -13010,6 +13122,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "dxD" = (
@@ -13108,6 +13221,10 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"dAs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint)
 "dBi" = (
 /obj/random/foods/food_trash,
 /obj/effect/decal/cleanable/dirt,
@@ -13195,6 +13312,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"dEJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/bridge)
 "dFu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13315,6 +13436,7 @@
 	req_access = list(2);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -13484,6 +13606,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "dRY" = (
@@ -13639,6 +13762,10 @@
 "dZx" = (
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
+"dZU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories)
 "eal" = (
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
@@ -13731,6 +13858,7 @@
 	name = "Cloning Lab";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -13866,6 +13994,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "emi" = (
@@ -13909,6 +14038,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "epi" = (
@@ -14021,6 +14151,7 @@
 	req_one_access = list(1,4);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -14081,6 +14212,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "exJ" = (
@@ -14137,6 +14269,10 @@
 	icon_state = "asteroid7"
 	},
 /area/station/hallway/secondary/arrival)
+"eAO" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/chamber)
 "eAZ" = (
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
@@ -14169,6 +14305,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -14222,6 +14359,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkpurplefull"
@@ -14359,6 +14497,10 @@
 	icon_state = "red"
 	},
 /area/station/engineering/atmos)
+"eMJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel)
 "eMX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -14389,6 +14531,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal/set_burned,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "ePx" = (
@@ -14423,7 +14566,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/weapon/flora/monkey,
+/obj/machinery/vending/newyearmate,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -14474,6 +14617,10 @@
 	icon_state = "white"
 	},
 /area/station/medical/sleeper)
+"eTu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/teleport)
 "eTS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -14746,8 +14893,19 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/set_burned,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"ffF" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "ffT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
@@ -14785,6 +14943,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "fis" = (
@@ -15053,6 +15212,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "fCc" = (
@@ -15096,6 +15256,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "fES" = (
@@ -15239,6 +15400,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"fLa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos)
 "fLl" = (
 /obj/machinery/alarm{
 	pixel_y = 21
@@ -15432,6 +15597,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/office)
 "fXC" = (
@@ -15488,6 +15654,10 @@
 "gay" = (
 /turf/environment/space,
 /area/space)
+"gaL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/genetics_cloning)
 "gbe" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -15705,10 +15875,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "glU" = (
-/obj/item/weapon/flora/random,
 /obj/structure/sign/directions/supply{
 	pixel_y = 24
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "gmO" = (
@@ -15842,6 +16012,7 @@
 /area/station/medical/sleeper)
 "gqx" = (
 /obj/machinery/computer/station_alert,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkblue"
@@ -15996,6 +16167,7 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "gxa" = (
@@ -16126,6 +16298,7 @@
 "gDj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "gDs" = (
@@ -16179,6 +16352,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
@@ -16265,6 +16439,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "gKV" = (
@@ -16697,12 +16872,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "hbt" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/game_kit/random,
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
-	},
-/area/station/hallway/secondary/arrival)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/reception)
 "hbS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -16843,6 +17015,7 @@
 	opacity = 0;
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "hjE" = (
@@ -16868,6 +17041,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -16960,6 +17134,10 @@
 	icon_state = "asteroid"
 	},
 /area/station/maintenance/science)
+"htU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "huf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17168,6 +17346,10 @@
 	icon_state = "darkgreen"
 	},
 /area/station/bridge)
+"hFL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/telesci)
 "hFM" = (
 /obj/structure/closet/theatrecloset,
 /obj/item/device/guitar/electric,
@@ -17188,6 +17370,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "hHC" = (
@@ -17430,6 +17613,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -17469,6 +17653,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
 "hYL" = (
@@ -17538,6 +17723,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "iaw" = (
@@ -17800,6 +17986,10 @@
 	icon_state = "darkpurple"
 	},
 /area/station/rnd/hor)
+"ilQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/chargebay)
 "ilV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/newscaster{
@@ -17863,6 +18053,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17952,6 +18143,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "ivd" = (
@@ -18041,6 +18233,10 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"iys" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "iyE" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -18110,6 +18306,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "iBA" = (
@@ -18133,6 +18330,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/spectro)
 "iDT" = (
@@ -18203,6 +18401,7 @@
 /area/station/cargo/storage)
 "iGE" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/present,
 /turf/simulated/floor,
 /area/asteroid/mine/dwarf)
 "iGK" = (
@@ -18390,9 +18589,14 @@
 /obj/machinery/door/firedoor,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
+/area/station/hallway/secondary/arrival)
+"iSo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
 /area/station/hallway/secondary/arrival)
 "iSt" = (
 /turf/simulated/wall,
@@ -18519,6 +18723,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "iZn" = (
@@ -18583,6 +18788,7 @@
 /area/asteroid/research_outpost/spectro)
 "jbH" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -18638,6 +18844,7 @@
 /area/station/cargo/storage)
 "jcU" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -18767,6 +18974,13 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"jmr" = (
+/obj/structure/flora/junglebush/b,
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	icon_state = "grass1"
+	},
+/area/station/hallway/secondary/arrival)
 "jmQ" = (
 /obj/machinery/light/smart,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18805,8 +19019,7 @@
 /turf/simulated/wall,
 /area/station/civilian/kitchen)
 "jqk" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
@@ -18869,6 +19082,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -19271,6 +19485,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/prison)
+"jHC" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/science)
 "jIn" = (
 /obj/machinery/mineral/stacking_machine,
 /turf/simulated/floor/plating,
@@ -19290,6 +19508,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -19455,6 +19674,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"jQh" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "jQi" = (
 /obj/structure/sink{
 	dir = 8;
@@ -19656,6 +19879,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19700,6 +19924,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "jYA" = (
@@ -19817,6 +20042,7 @@
 	layer = 4;
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -19845,6 +20071,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -19860,6 +20087,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
 "kia" = (
@@ -19897,6 +20125,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "kjh" = (
@@ -20000,6 +20229,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -20014,6 +20244,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "knh" = (
@@ -20077,6 +20308,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -20321,6 +20553,10 @@
 "kDp" = (
 /turf/simulated/mineral/random/high_chance,
 /area/asteroid/mine/unexplored)
+"kDz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/central)
 "kDI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20468,6 +20704,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "kLq" = (
@@ -20562,6 +20799,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "kPH" = (
@@ -20770,6 +21008,7 @@
 	name = "Medbay"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -20870,21 +21109,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lef" = (
-/obj/structure/table/woodentable,
-/obj/random/randomfigure{
-	pixel_x = -4;
-	pixel_y = -7
-	},
-/obj/random/randomfigure{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/random/randomfigure{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
+/obj/item/weapon/present,
+/turf/simulated/floor{
+	icon_state = "grass1"
 	},
 /area/station/hallway/secondary/arrival)
 "lem" = (
@@ -20927,8 +21154,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"lfC" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/computer)
 "lfG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -20976,6 +21208,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"liB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/cold_room)
 "ljy" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -21046,6 +21282,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -21067,6 +21304,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"loE" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "loZ" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -21121,6 +21366,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "lre" = (
@@ -21398,6 +21644,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -21568,6 +21815,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/structure/sign/directions/dock_tablo/arrival,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "lOv" = (
@@ -21619,6 +21867,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lQu" = (
@@ -21672,6 +21921,10 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"lQW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/captain_quarters)
 "lSl" = (
 /obj/machinery/light_construct/small{
 	dir = 8
@@ -21679,6 +21932,7 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/item/weapon/present,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
 "lSs" = (
@@ -21700,6 +21954,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -21777,6 +22032,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"lZL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/morgue)
 "lZW" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -21925,12 +22184,17 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/office)
 "mhv" = (
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"mhz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/escape)
 "mhN" = (
 /obj/random/vending/cola,
 /turf/simulated/floor/wood,
@@ -21966,6 +22230,7 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "mkQ" = (
@@ -21988,6 +22253,16 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"mlx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/medbay)
+"mmF" = (
+/obj/item/weapon/present,
+/turf/simulated/floor/plating/airless{
+	icon_state = "dark"
+	},
+/area/space)
 "mnh" = (
 /obj/machinery/optable,
 /turf/simulated/floor{
@@ -22040,6 +22315,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "mpB" = (
@@ -22316,6 +22592,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -22570,6 +22847,7 @@
 	req_access = list(1);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "mRd" = (
@@ -22620,6 +22898,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"mTi" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "mTx" = (
 /obj/item/weapon/scrap_lump,
 /turf/simulated/floor/plating,
@@ -23009,6 +23296,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -23078,6 +23366,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/surgeryobs)
 "nkO" = (
@@ -23136,6 +23425,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -23240,6 +23530,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "npt" = (
@@ -23296,6 +23587,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -23331,6 +23623,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "nsG" = (
@@ -23406,6 +23699,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -23482,6 +23776,10 @@
 	},
 /turf/simulated/floor/plating/airless/asteroid,
 /area/asteroid/mine/explored)
+"nxi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/main)
 "nxj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -23986,6 +24284,15 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/central)
+"nYD" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/medical/surgeryobs)
 "nYR" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -24218,6 +24525,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
 "onq" = (
@@ -24301,6 +24609,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -24483,6 +24792,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -24548,6 +24858,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "oDk" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkstairs_alone"
 	},
@@ -24603,6 +24914,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -24632,6 +24944,7 @@
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -24713,13 +25026,13 @@
 	},
 /area/shuttle/supply/station)
 "oIl" = (
-/obj/item/weapon/flora/random,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small,
+/obj/item/decoration/snowman,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "oIn" = (
@@ -24919,6 +25232,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "oSq" = (
@@ -24959,6 +25273,7 @@
 	name = "Security Checkpoint";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -25089,6 +25404,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "oZc" = (
@@ -25277,6 +25593,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "piu" = (
@@ -25443,6 +25760,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/turf_decal/set_burned,
+/obj/item/decoration/snowman,
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
 "prP" = (
@@ -25644,6 +25962,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"pyJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/medbay)
 "pyP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25684,6 +26006,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -25702,6 +26025,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -25808,6 +26132,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -25963,6 +26288,25 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/lab)
+"pKL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "chapel";
+	name = "Privacy Shutters";
+	opacity = 0;
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/civilian/chapel/office)
 "pLw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -26154,6 +26498,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "pUb" = (
@@ -26294,6 +26639,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -26540,6 +26886,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics_cloning)
+"qnQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/locker)
 "qod" = (
 /obj/machinery/disposal,
 /obj/structure/cable,
@@ -26594,6 +26944,10 @@
 	icon_state = "dark"
 	},
 /area/station/tcommsat/chamber)
+"qpm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/exit)
 "qpE" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/snacks/mint,
@@ -26621,6 +26975,11 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"qrs" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/item/weapon/present,
+/turf/simulated/floor/plating,
+/area/asteroid/mine/dwarf)
 "qrH" = (
 /obj/item/roller,
 /obj/item/roller,
@@ -26653,6 +27012,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"qsL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hallway)
 "qtz" = (
 /obj/item/weapon/shard{
 	icon_state = "small"
@@ -26873,6 +27236,7 @@
 	req_access = list(58);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -26909,6 +27273,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"qAi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/storage)
 "qBf" = (
 /obj/machinery/camera{
 	c_tag = "Bar West";
@@ -27296,6 +27664,7 @@
 	req_access = list(63);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -27471,6 +27840,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "qWs" = (
@@ -27519,12 +27889,21 @@
 	icon_state = "grass1"
 	},
 /area/station/hallway/secondary/arrival)
+"qYX" = (
+/obj/structure/lattice,
+/obj/item/weapon/present,
+/turf/environment/space,
+/area/space)
 "qZl" = (
 /obj/structure/object_wall/pod{
 	icon_state = "0,2"
 	},
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
+"qZA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/asteroid/research_outpost/spectro)
 "qZX" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -27597,6 +27976,13 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/central)
+"rea" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkpurple"
+	},
+/area/station/rnd/hallway)
 "rfv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27752,6 +28138,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "rox" = (
@@ -27839,6 +28226,7 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "rsV" = (
@@ -27886,6 +28274,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "rxa" = (
@@ -28143,6 +28532,7 @@
 	opacity = 0;
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "rGx" = (
@@ -28282,6 +28672,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"rLT" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "rNo" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp{
@@ -28327,6 +28726,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28440,6 +28840,7 @@
 	layer = 4;
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -28673,6 +29074,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
@@ -28755,6 +29157,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkpurplefull"
@@ -28784,6 +29187,10 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/locker)
+"sqK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/dormitory)
 "sqQ" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/skills,
@@ -29226,8 +29633,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
+"sKo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/chargebay)
 "sKE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -29454,6 +29866,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkpurplefull"
@@ -29668,6 +30081,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "tmw" = (
@@ -29979,6 +30393,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -30025,6 +30440,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "tFS" = (
@@ -30224,6 +30640,7 @@
 "tPb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel/green,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -30243,19 +30660,9 @@
 	},
 /area/station/engineering/atmos)
 "tQc" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/camera{
-	c_tag = "Arrival Hallway Center";
-	pixel_x = -4
-	},
-/obj/structure/sign/painting{
-	pixel_y = 30
-	},
-/turf/simulated/floor{
-	icon_state = "grass1"
-	},
-/area/station/hallway/secondary/arrival)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/chamber)
 "tQr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30576,6 +30983,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "uah" = (
@@ -30646,6 +31054,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30724,6 +31133,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkblue"
@@ -30743,6 +31153,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "umx" = (
@@ -30800,6 +31211,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/asteroid/research_outpost/outpost_misc_lab)
+"uoo" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "upf" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -30995,6 +31415,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/shuttle/plating,
 /area/space)
 "uCi" = (
@@ -31261,6 +31682,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31300,6 +31722,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "uNK" = (
@@ -31398,6 +31821,15 @@
 /obj/random/scrap/safe_even,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"uSO" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
+/area/station/hallway/primary/central)
 "uTN" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/chargebay)
@@ -31470,6 +31902,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
+"uWF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/drone_fabrication)
 "uWY" = (
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless/catwalk,
@@ -31554,6 +31990,10 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
+"vcy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/storage)
 "vcI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31595,6 +32035,7 @@
 /area/station/engineering/break_room)
 "vdX" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -31791,6 +32232,14 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
+"vmY" = (
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel/green,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/primary/central)
 "vnl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31822,6 +32271,7 @@
 	req_access = list(1);
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "voe" = (
@@ -31858,6 +32308,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "vrl" = (
@@ -32364,6 +32815,10 @@
 	icon_state = "white"
 	},
 /area/station/medical/morgue)
+"vUU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/office)
 "vUY" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -32453,6 +32908,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "waf" = (
@@ -32650,6 +33106,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"wil" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/toilet)
 "wji" = (
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 8
@@ -32751,6 +33211,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "wlc" = (
@@ -32797,6 +33258,7 @@
 	opacity = 0;
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "wmB" = (
@@ -32925,6 +33387,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "wrO" = (
@@ -32939,6 +33402,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkblue"
@@ -33067,6 +33531,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"wzD" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/server)
 "wzN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -33095,6 +33563,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "wAS" = (
@@ -33111,6 +33580,7 @@
 	name = "Research Outpost External Access"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
 "wDD" = (
@@ -33352,6 +33822,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "wMX" = (
@@ -33414,11 +33885,16 @@
 	name = "Security Office";
 	req_one_access = list(1,4)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
 	},
 /area/station/security/main)
+"wQu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories/dormone)
 "wQx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -33543,6 +34019,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "wXL" = (
@@ -33553,6 +34030,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "wYk" = (
@@ -33634,6 +34112,7 @@
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "xbS" = (
@@ -33642,6 +34121,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "xcY" = (
@@ -33946,6 +34426,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "xrG" = (
@@ -34068,6 +34549,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "xwG" = (
@@ -34261,6 +34743,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkyellowfull"
 	},
@@ -34375,6 +34858,7 @@
 /area/station/hallway/primary/central)
 "xIK" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -34403,6 +34887,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "xKi" = (
@@ -34464,6 +34949,7 @@
 "xMe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "xMU" = (
@@ -34516,6 +35002,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -34734,6 +35221,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
+"xZM" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/auxsolarstarboard)
 "yaj" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
@@ -34748,6 +35239,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -34845,6 +35337,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"yeb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/cargo)
 "yey" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -49041,9 +49537,9 @@ crv
 gay
 crv
 wWW
+jQh
 wWW
-wWW
-wWW
+jQh
 wWW
 gay
 crv
@@ -49553,13 +50049,13 @@ qws
 crv
 crv
 wWW
-wWW
+iys
 aat
 adx
 adG
 adx
 aat
-wWW
+iys
 wWW
 crv
 gay
@@ -49809,7 +50305,7 @@ crv
 qws
 gay
 gay
-wWW
+iys
 acX
 adn
 wWW
@@ -49817,7 +50313,7 @@ wWW
 wWW
 adX
 acX
-wWW
+iys
 crv
 crv
 qws
@@ -50066,7 +50562,7 @@ crv
 qws
 crv
 crv
-wWW
+jQh
 acY
 ado
 wWW
@@ -50074,7 +50570,7 @@ adH
 wWW
 adY
 aeg
-wWW
+jQh
 crv
 crv
 qws
@@ -50846,7 +51342,7 @@ wWW
 aeb
 aat
 aem
-wWW
+iys
 gay
 crv
 qws
@@ -51350,7 +51846,7 @@ qws
 crv
 gay
 crv
-wWW
+iys
 pWD
 adc
 afA
@@ -51360,7 +51856,7 @@ adS
 apH
 aej
 aeo
-wWW
+iys
 crv
 gay
 qws
@@ -51606,7 +52102,7 @@ azF
 qws
 crv
 abl
-wWW
+iys
 wWW
 wWW
 wWW
@@ -52633,7 +53129,7 @@ azF
 gay
 qws
 crv
-hXh
+eTu
 abu
 aoN
 aoP
@@ -52858,7 +53354,7 @@ crv
 crv
 gay
 crv
-ahz
+vUU
 mhl
 mhl
 mhl
@@ -52894,7 +53390,7 @@ hXh
 hXh
 sCX
 sCX
-sCX
+tQc
 sCX
 mFe
 oAf
@@ -52903,8 +53399,8 @@ rzG
 sCX
 sCX
 sCX
-vlu
-vlu
+lfC
+lfC
 gay
 azF
 azF
@@ -53416,7 +53912,7 @@ rzG
 uFO
 adf
 apT
-sCX
+tQc
 crv
 qws
 qws
@@ -53629,7 +54125,7 @@ crv
 crv
 gay
 crv
-ahz
+vUU
 fGY
 exJ
 wmB
@@ -53644,7 +54140,7 @@ aiJ
 wtn
 wtn
 wgw
-pNu
+dAs
 obV
 wjV
 kcr
@@ -53663,7 +54159,7 @@ gay
 gay
 qws
 crv
-sCX
+tQc
 sCX
 xgl
 jyy
@@ -53890,7 +54386,7 @@ ahz
 ahz
 vyl
 ahz
-qBV
+pKL
 fVM
 qBV
 ahz
@@ -53905,7 +54401,7 @@ pNu
 ajp
 tLC
 lIp
-pNu
+dAs
 akd
 akr
 akv
@@ -53921,7 +54417,7 @@ gay
 qws
 crv
 crv
-sCX
+eAO
 apa
 gtx
 gtx
@@ -54158,7 +54654,7 @@ jAT
 jAT
 epi
 ffn
-pNu
+dAs
 aXo
 lDV
 aXo
@@ -54186,7 +54682,7 @@ adf
 iBA
 vWz
 wju
-sCX
+eAO
 jGN
 qws
 qws
@@ -54437,12 +54933,12 @@ qws
 crv
 sCX
 sCX
-sCX
+tQc
 nGN
 apF
 dFS
 sCX
-sCX
+tQc
 sCX
 crv
 qws
@@ -54694,10 +55190,10 @@ qws
 gay
 crv
 gay
+tQc
 sCX
 sCX
-sCX
-sCX
+tQc
 sCX
 crv
 crv
@@ -55178,7 +55674,7 @@ aoL
 hCQ
 abm
 ajW
-aiI
+eMJ
 rhz
 wVp
 ahO
@@ -55427,7 +55923,7 @@ uao
 cJm
 fTo
 ftP
-aiI
+eMJ
 vmg
 oVl
 aRA
@@ -55448,7 +55944,7 @@ pNu
 pNu
 pNu
 pNu
-pNu
+dAs
 akv
 akV
 alo
@@ -55687,8 +56183,8 @@ srC
 dDY
 rTG
 rTG
-rTG
-rTG
+mlx
+mlx
 gRj
 gRj
 gRj
@@ -55705,7 +56201,7 @@ ajt
 ake
 sqi
 alj
-akb
+mhz
 akw
 akh
 alp
@@ -56208,7 +56704,7 @@ rTG
 anl
 anz
 anK
-rTG
+mlx
 ahV
 kOj
 aii
@@ -56444,9 +56940,9 @@ cES
 dZx
 dZx
 dZx
-fSx
-fSx
-fSx
+loE
+loE
+loE
 xSr
 hVT
 peD
@@ -56730,7 +57226,7 @@ iSt
 iSt
 iSt
 iSt
-iSt
+qnQ
 eZe
 ait
 akb
@@ -57513,7 +58009,7 @@ aqu
 akb
 crv
 crv
-uRQ
+fLa
 lfk
 wmc
 hht
@@ -57737,7 +58233,7 @@ pVN
 aaT
 fLx
 kLq
-dDY
+pyJ
 oag
 oag
 oag
@@ -57753,7 +58249,7 @@ rTG
 ahE
 ahW
 aht
-qcu
+qpm
 aik
 aik
 aik
@@ -58245,7 +58741,7 @@ ppw
 rTG
 aAT
 aAT
-rTG
+mlx
 qdP
 aaK
 aaW
@@ -58259,7 +58755,7 @@ oag
 tXZ
 bWg
 dgy
-xKi
+hbt
 xzF
 ans
 koD
@@ -58499,7 +58995,7 @@ rTG
 bJc
 pNR
 rTG
-aAT
+lZL
 dqs
 mnh
 aAT
@@ -58521,7 +59017,7 @@ rTG
 sFk
 anG
 anM
-qcu
+qpm
 aiA
 doQ
 ajB
@@ -59031,7 +59527,7 @@ qXD
 muZ
 aVc
 qzd
-xKi
+hbt
 adr
 koD
 koD
@@ -59287,11 +59783,11 @@ seq
 gXZ
 lpL
 xlY
-xKi
+hbt
 xKi
 ffx
 rTG
-rTG
+mlx
 qcu
 aiC
 aiU
@@ -59527,9 +60023,9 @@ uJy
 ycH
 uSe
 rTG
-aAT
+lZL
 due
-aAT
+lZL
 aAT
 aaG
 aaQ
@@ -60049,7 +60545,7 @@ fRN
 nfC
 lDB
 abI
-abM
+nYD
 vmd
 frG
 gBX
@@ -60088,7 +60584,7 @@ adg
 ydN
 peN
 pQB
-wuN
+uWF
 iCb
 apf
 acI
@@ -60321,12 +60817,12 @@ fRu
 vAK
 vNm
 fIW
-fIW
+sqK
 fIW
 fIW
 cPE
 fIW
-fIW
+sqK
 fIW
 fIW
 fIw
@@ -60558,7 +61054,7 @@ mJj
 uqL
 aRT
 fTe
-mJj
+gaL
 aaF
 aaF
 aaF
@@ -60575,7 +61071,7 @@ eJe
 mXM
 vNm
 fIW
-fIW
+sqK
 fIW
 fIW
 dUH
@@ -60820,18 +61316,18 @@ jSG
 tHr
 wav
 lyC
-rjM
+qAi
 rjM
 skg
 nlP
 rjM
-rjM
+qAi
 xCy
 xQL
 tyQ
 qxr
-fIW
-fIW
+sqK
+sqK
 oip
 ibW
 emi
@@ -60850,7 +61346,7 @@ fIW
 hNU
 tyQ
 tTE
-mGO
+cyE
 mGO
 lZZ
 gMz
@@ -61072,7 +61568,7 @@ cfW
 eVc
 rTG
 mJj
-mJj
+gaL
 gzn
 hjE
 ozJ
@@ -61327,7 +61823,7 @@ gva
 cmp
 muH
 vNe
-rjM
+qAi
 dcF
 uKl
 mRd
@@ -61360,7 +61856,7 @@ ixg
 rLx
 trh
 ptc
-fIW
+sqK
 wDD
 xBh
 tKl
@@ -61857,7 +62353,7 @@ rjM
 cyF
 nYR
 jVa
-fIW
+sqK
 ejA
 hAT
 jWm
@@ -62100,16 +62596,16 @@ leO
 fbu
 rTG
 rjM
-rjM
+qAi
 rjM
 kMv
 oHF
 qrH
 xjS
 xsf
+qAi
 rjM
-rjM
-rjM
+qAi
 rjM
 wkh
 bdB
@@ -62132,18 +62628,18 @@ amy
 whA
 dtX
 glg
-inL
+ffF
 dnE
 ivY
 vdi
 agB
 hqn
 hqn
-hqn
+bki
 hqn
 hqn
 crv
-scr
+uoo
 apP
 acS
 sFn
@@ -62360,7 +62856,7 @@ uFy
 vNg
 rTG
 rjM
-rjM
+qAi
 rjM
 fDS
 kRW
@@ -62371,7 +62867,7 @@ bAg
 xvy
 nYR
 ifz
-fIW
+sqK
 iIA
 amy
 nGv
@@ -62400,7 +62896,7 @@ acB
 aqZ
 hqn
 gay
-scr
+uoo
 jcF
 acz
 sJs
@@ -62646,7 +63142,7 @@ avP
 pyc
 amy
 qoL
-fIW
+sqK
 jaa
 kQj
 msn
@@ -62657,7 +63153,7 @@ abd
 acD
 hqn
 crv
-scr
+uoo
 pNm
 adi
 sFn
@@ -62890,7 +63386,7 @@ xvp
 uDr
 yeS
 xvp
-uUx
+dZU
 wWy
 qCA
 qBf
@@ -62900,7 +63396,7 @@ bLO
 aqD
 ixg
 ixg
-fIW
+sqK
 fIW
 lBY
 fIW
@@ -63135,7 +63631,7 @@ rTG
 cYF
 rTG
 rTG
-rTG
+mlx
 rTG
 rTG
 fOO
@@ -63165,7 +63661,7 @@ xCy
 ntn
 tyQ
 qxr
-hqn
+bki
 hqn
 hqn
 hqn
@@ -63385,9 +63881,9 @@ rzB
 rzB
 rzB
 rzB
+iSo
 hvW
-hvW
-hvW
+iSo
 bwm
 dYd
 mdk
@@ -63428,7 +63924,7 @@ gay
 crv
 gay
 gay
-sFn
+vcy
 lBf
 mVa
 pSh
@@ -63680,7 +64176,7 @@ eSJ
 xhi
 rJd
 xCy
-lmc
+wQu
 lmc
 sFn
 sFn
@@ -63899,7 +64395,7 @@ rzB
 rzB
 rzB
 rzB
-xGz
+mTi
 lOj
 xGz
 ikn
@@ -64157,8 +64653,8 @@ rzB
 rzB
 rzB
 gay
-xGz
-mPB
+mTi
+jmr
 bzC
 hgN
 cxV
@@ -64185,10 +64681,10 @@ lOI
 iWN
 whq
 ixg
-bzg
+wil
 bzg
 pAp
-bzg
+wil
 gLt
 lXu
 bjl
@@ -64206,7 +64702,7 @@ mvQ
 gfQ
 scr
 wXL
-scr
+uoo
 vgT
 juX
 cwG
@@ -64414,10 +64910,10 @@ rzB
 rzB
 rzB
 gay
-xGz
+mTi
 jqk
 ccc
-dNp
+cxV
 eAC
 lss
 mdk
@@ -64427,7 +64923,7 @@ jaa
 eJe
 pyi
 cET
-tPb
+uSO
 txl
 pcy
 sDK
@@ -64672,9 +65168,9 @@ rzB
 rzB
 gay
 hvW
-tQc
+mPB
 lef
-hbt
+cxV
 yjV
 vJa
 rGx
@@ -64928,7 +65424,7 @@ rzB
 rzB
 rzB
 gay
-xGz
+mTi
 tEV
 twE
 dNp
@@ -64959,7 +65455,7 @@ bEv
 hFQ
 emk
 vAK
-xIK
+vmY
 vAK
 hRP
 eJe
@@ -65185,7 +65681,7 @@ rzB
 rzB
 rzB
 gay
-xGz
+mTi
 qYG
 dOV
 pvV
@@ -65199,9 +65695,9 @@ qtH
 ifz
 ivd
 fIW
-fIW
-ibz
-fIW
+sqK
+cxX
+sqK
 jpf
 jpf
 wyB
@@ -65231,7 +65727,7 @@ abh
 xTy
 ykW
 nqt
-sFn
+vcy
 acb
 acb
 crv
@@ -65441,7 +65937,7 @@ rzB
 rzB
 rzB
 rzB
-xGz
+mTi
 lOj
 xGz
 ezO
@@ -65956,12 +66452,12 @@ rzB
 rzB
 rzB
 hvW
-hvW
+iSo
 hvW
 hvW
 ifx
 ifx
-ifx
+dEJ
 ifx
 ifx
 hvW
@@ -66005,7 +66501,7 @@ apm
 vlw
 gih
 aof
-gpH
+cAr
 jWx
 jWx
 jWx
@@ -66226,7 +66722,7 @@ jaa
 smC
 pyi
 lDE
-fIW
+sqK
 lyd
 kKJ
 clc
@@ -66249,7 +66745,7 @@ xCy
 uyd
 jKM
 qxr
-xCy
+kDz
 xCy
 xCy
 sFn
@@ -66516,7 +67012,7 @@ sFn
 knL
 arr
 aru
-vlw
+rLT
 anZ
 adO
 gpH
@@ -66735,7 +67231,7 @@ tcD
 iqS
 iqS
 iqS
-xCy
+kDz
 xCy
 pyP
 nYR
@@ -67000,7 +67496,7 @@ nun
 inL
 wlr
 lMc
-rlx
+liB
 mgp
 bFA
 sGz
@@ -67019,7 +67515,7 @@ ews
 jaa
 lrM
 rdJ
-rsV
+yeb
 qIz
 oBN
 mZt
@@ -67511,7 +68007,7 @@ hGT
 jaa
 nYR
 lWZ
-fIW
+sqK
 amy
 tOZ
 eDN
@@ -67535,7 +68031,7 @@ lrM
 rdJ
 uOX
 uOX
-uOX
+ilQ
 uTN
 ckF
 ckF
@@ -68042,7 +68538,7 @@ ibW
 cEc
 pLw
 cIU
-inL
+ffF
 baR
 gQR
 ueF
@@ -68060,7 +68556,7 @@ jbE
 tgk
 dMZ
 apC
-rNw
+qZA
 arw
 aoy
 rsV
@@ -68299,7 +68795,7 @@ ssM
 abe
 qUh
 aAE
-fIW
+sqK
 hNU
 jKM
 jUL
@@ -68525,7 +69021,7 @@ crv
 qws
 qws
 crv
-wxl
+dwV
 wxl
 iqS
 iqS
@@ -68540,7 +69036,7 @@ wxl
 iGg
 tyQ
 qxr
-fIW
+sqK
 fIW
 xeu
 dQA
@@ -68560,7 +69056,7 @@ fIW
 cyF
 xwG
 vYu
-xCy
+kDz
 aay
 xxI
 cgP
@@ -68805,11 +69301,11 @@ fIW
 fIW
 fIW
 ibz
+sqK
 fIW
 fIW
 fIW
-fIW
-fIW
+sqK
 fIW
 fIW
 rIv
@@ -68818,7 +69314,7 @@ fPZ
 sAc
 xQc
 kvc
-uTN
+sKo
 uTN
 uTN
 uTN
@@ -68833,7 +69329,7 @@ iDh
 pON
 rNw
 noD
-noD
+qsL
 noD
 apV
 apY
@@ -69591,7 +70087,7 @@ ldn
 dTU
 lyH
 bRz
-bwK
+rea
 gKV
 bwK
 sos
@@ -69605,7 +70101,7 @@ apD
 gNM
 aLm
 pMW
-noD
+qsL
 aoR
 aqc
 ary
@@ -70097,7 +70593,7 @@ hgW
 hgW
 lUt
 kPA
-lUt
+jHC
 woA
 aqm
 afY
@@ -70840,7 +71336,7 @@ crv
 crv
 crv
 crv
-xnX
+wzD
 mFZ
 pLS
 uMc
@@ -70891,7 +71387,7 @@ afn
 amV
 anc
 anR
-isF
+aHA
 aqd
 apq
 lUt
@@ -71107,7 +71603,7 @@ jzF
 tnj
 tnj
 tnj
-tnj
+lQW
 tnj
 dxg
 tnj
@@ -71122,7 +71618,7 @@ ajF
 wys
 ajm
 aqX
-hgW
+bTC
 ajK
 sSl
 bBj
@@ -71363,7 +71859,7 @@ cFV
 cNr
 fwz
 dCm
-cFV
+htU
 klr
 gxV
 rns
@@ -71374,7 +71870,7 @@ dws
 edC
 nkz
 oZc
-sLc
+nxi
 tFK
 dII
 xze
@@ -71883,7 +72379,7 @@ gxV
 esR
 lBC
 nRk
-oeZ
+cYq
 dRK
 qyt
 nkO
@@ -71918,7 +72414,7 @@ isF
 uoj
 uoj
 cpz
-isF
+aHA
 aoS
 ahn
 afd
@@ -72129,7 +72625,7 @@ crv
 gay
 qEL
 crv
-cFV
+htU
 cFV
 cFV
 kia
@@ -72164,13 +72660,13 @@ afd
 wyg
 wyg
 wyg
-wyg
+hFL
 wyg
 uIN
 ahe
 acd
 ayh
-isF
+aHA
 hCa
 hCa
 hCa
@@ -72389,14 +72885,14 @@ crv
 crv
 gay
 cFV
-cFV
+htU
 cFV
 cFV
 cXm
 tnj
 tnj
 tnj
-tnj
+lQW
 oeZ
 fbJ
 eIT
@@ -72664,7 +73160,7 @@ sxF
 ryq
 cJy
 cSK
-hgW
+bTC
 ajK
 rtz
 aeT
@@ -72911,7 +73407,7 @@ cXm
 cXm
 wYk
 wYk
-oeZ
+cYq
 oeZ
 fHC
 aiB
@@ -73175,7 +73671,7 @@ oeZ
 oeZ
 oeZ
 hgW
-hgW
+bTC
 hgW
 hgW
 hgW
@@ -73426,7 +73922,7 @@ vnl
 wVf
 dUN
 ivh
-wYk
+xZM
 tSw
 nsG
 xST
@@ -77539,7 +78035,7 @@ ggV
 qiA
 nHP
 krl
-dlI
+qrs
 hnw
 ioF
 skE
@@ -78858,7 +79354,7 @@ hvD
 hvD
 hvD
 hvD
-cXm
+dtN
 cXm
 skE
 pwU
@@ -79370,7 +79866,7 @@ esQ
 hvD
 hvD
 cXm
-cXm
+dtN
 cXm
 cXm
 cXm
@@ -79630,7 +80126,7 @@ cXm
 cXm
 cXm
 cXm
-cXm
+dtN
 cXm
 skE
 esQ
@@ -79882,7 +80378,7 @@ esQ
 esQ
 pwU
 skE
-cXm
+dtN
 cXm
 cXm
 cXm
@@ -80140,13 +80636,13 @@ esQ
 esQ
 hvD
 cXm
+dtN
+cXm
+dtN
 cXm
 cXm
 cXm
-cXm
-cXm
-cXm
-cXm
+dtN
 hvD
 esQ
 esQ
@@ -91691,7 +92187,7 @@ kTf
 afR
 gEx
 gEx
-crv
+qYX
 agN
 agJ
 agO
@@ -91947,8 +92443,8 @@ svM
 svM
 age
 gEx
-crv
-crv
+qYX
+qYX
 gay
 agJ
 agO
@@ -92206,7 +92702,7 @@ agf
 gEx
 agx
 agH
-crv
+qYX
 afR
 svM
 gay
@@ -92461,8 +92957,8 @@ afQ
 afT
 agg
 agp
-crv
-crv
+qYX
+qYX
 crv
 agR
 gay
@@ -92718,7 +93214,7 @@ afQ
 afU
 agh
 agg
-agf
+mmF
 agJ
 agO
 gay

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -265,6 +265,7 @@
 /obj/structure/sign/departments/science{
 	pixel_y = -32
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -330,6 +331,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aaG" = (
@@ -409,6 +411,7 @@
 	name = "E.V.A.";
 	req_one_access = list(1,5,11,18,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1007,6 +1010,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "abI" = (
@@ -1262,6 +1266,7 @@
 	name = "Kitchen Freezer";
 	req_access = list(28)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitehall"
@@ -1377,6 +1382,7 @@
 	dir = 1;
 	icon_state = "spline_plain"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1951,6 +1957,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "adu" = (
@@ -2092,6 +2099,7 @@
 	name = "Escape Medical Checkpoint";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -2116,6 +2124,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "adR" = (
@@ -2261,6 +2270,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aee" = (
@@ -2295,6 +2305,7 @@
 	id_tag = "Dorm3";
 	name = "Dorm 3"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/dormthree)
 "aeh" = (
@@ -2715,6 +2726,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -2817,6 +2829,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3227,6 +3240,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "afI" = (
@@ -3276,6 +3290,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "afO" = (
@@ -3539,6 +3554,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -3572,6 +3588,10 @@
 	icon_state = "blackchoco"
 	},
 /area/station/engineering/monitoring)
+"ahS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/brainstorm_center)
 "ahZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3595,6 +3615,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood14"
 	},
@@ -3641,6 +3662,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "ajf" = (
@@ -3800,6 +3822,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -4305,6 +4328,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "dark"
@@ -4423,6 +4447,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/chamber)
 "apG" = (
@@ -5265,6 +5290,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "ayw" = (
@@ -5558,6 +5584,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "aAY" = (
@@ -5568,6 +5595,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -5749,6 +5777,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aBU" = (
@@ -6024,6 +6053,7 @@
 	grilled = 1;
 	id = "Detective"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aEL" = (
@@ -6205,6 +6235,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -6250,6 +6281,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -6394,6 +6426,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/misc_lab)
+"aHy" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "aHS" = (
 /obj/machinery/computer/reconstitutor,
 /turf/simulated/floor{
@@ -6440,6 +6478,10 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/virology)
+"aIV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/drone_fabrication)
 "aJp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6459,6 +6501,7 @@
 	req_access = list(65)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "aJB" = (
@@ -6504,6 +6547,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brigright)
+"aJZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/ai_upload)
 "aKj" = (
 /obj/item/weapon/cigbutt,
 /turf/simulated/floor/plating,
@@ -6535,6 +6582,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "green"
@@ -6862,6 +6910,7 @@
 	name = "Head of Personnel's Office";
 	req_access = list(57)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -7058,6 +7107,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -7224,6 +7274,7 @@
 /area/station/civilian/bar)
 "aRy" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -7730,6 +7781,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -8122,6 +8174,7 @@
 	name = "Isolation A";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -8275,6 +8328,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -8456,6 +8510,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "beO" = (
@@ -8737,6 +8792,7 @@
 	name = "Conference Room Maintenance";
 	req_access = list(19)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8840,6 +8896,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -8858,6 +8915,7 @@
 	icon_state = "gr_window_polarized";
 	id = "op3.5"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery3)
 "biv" = (
@@ -9085,6 +9143,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -9459,6 +9518,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
 	},
@@ -9614,6 +9674,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "boe" = (
@@ -10050,6 +10111,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "brY" = (
@@ -10326,6 +10388,7 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -10459,6 +10522,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "bvq" = (
@@ -10507,8 +10571,13 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
+"bvH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/server)
 "bvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10792,6 +10861,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "byz" = (
@@ -10882,6 +10952,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10953,6 +11024,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitecorner"
@@ -11093,6 +11165,15 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"bBx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "bBy" = (
 /turf/simulated/floor{
 	icon_state = "darkstairs_wide"
@@ -11353,6 +11434,7 @@
 	dir = 4
 	},
 /obj/structure/window/thin/reinforced,
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/medical/sleeper)
 "bEV" = (
@@ -11526,6 +11608,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"bGH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/patient_a)
 "bGR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11588,6 +11674,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "bHs" = (
@@ -11655,6 +11742,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
+"bIB" = (
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "bIO" = (
 /obj/structure/window/thin/reinforced,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -11665,6 +11756,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/dormitories/theater)
 "bIZ" = (
@@ -11851,6 +11943,7 @@
 	dir = 4;
 	pixel_y = 40
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -11969,6 +12062,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreenfull"
@@ -12227,6 +12321,7 @@
 /obj/structure/sign/departments/security{
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redcorner"
 	},
@@ -12245,6 +12340,7 @@
 	icon_state = "gr_window_polarized";
 	id = "op2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery2)
 "bPH" = (
@@ -12279,6 +12375,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "bPY" = (
@@ -12670,6 +12767,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bTs" = (
@@ -12867,6 +12965,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bUO" = (
@@ -12894,6 +12993,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bUP" = (
@@ -13252,6 +13352,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -13269,6 +13370,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -13294,6 +13396,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
+"bZd" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/bar)
+"bZe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/prison/toilet)
 "bZi" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -13600,6 +13710,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -13632,6 +13743,12 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"ccu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/main{
+	name = "Security Equipment"
+	})
 "ccC" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/stamp/iaa{
@@ -13685,6 +13802,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -13900,6 +14018,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -14060,6 +14179,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "cgL" = (
@@ -14200,6 +14320,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/lobby)
+"cib" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/exit)
 "cip" = (
 /obj/item/weapon/shard{
 	icon_state = "small"
@@ -14246,6 +14370,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "cjg" = (
@@ -14499,6 +14624,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14509,6 +14635,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "clm" = (
@@ -14541,6 +14668,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14567,6 +14695,7 @@
 	name = "Break Room";
 	req_access = list(47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14713,6 +14842,7 @@
 	name = "Theater Backroom";
 	req_access = list(46)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood10"
 	},
@@ -14775,6 +14905,7 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -14835,6 +14966,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "cpa" = (
@@ -14851,6 +14983,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -14903,6 +15036,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "purplecorner"
@@ -14984,6 +15118,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cri" = (
@@ -15174,6 +15309,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "csI" = (
@@ -15285,6 +15421,7 @@
 	name = "Bridge";
 	req_access = list(19)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -15299,6 +15436,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "cul" = (
@@ -15321,6 +15459,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "cuw" = (
@@ -15351,6 +15490,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/bar)
 "cuH" = (
@@ -15589,6 +15729,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -15598,6 +15739,10 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"cwR" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/miningoffice)
 "cwT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15656,6 +15801,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -15718,6 +15864,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "cxX" = (
@@ -15780,6 +15927,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/bar)
 "czg" = (
@@ -16133,6 +16281,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "cBV" = (
@@ -16675,6 +16824,7 @@
 	name = "Blueshield Office";
 	req_access = list(42)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -16760,6 +16910,7 @@
 	},
 /area/station/hallway/primary/bridgehall)
 "cGZ" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "wood_stairs2"
@@ -16964,6 +17115,7 @@
 	},
 /area/station/medical/hallway)
 "cIZ" = (
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "browncorner"
@@ -17028,6 +17180,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -17049,6 +17202,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "cJH" = (
@@ -17142,6 +17296,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/bridge)
+"cKU" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "cKX" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/soda{
@@ -17195,6 +17353,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cLt" = (
@@ -17235,6 +17394,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "cLT" = (
@@ -17476,6 +17636,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "cNL" = (
@@ -17520,6 +17681,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway/outbranch)
 "cNY" = (
@@ -17701,6 +17863,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cPu" = (
@@ -17764,6 +17927,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17974,6 +18138,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "cRL" = (
@@ -18060,6 +18225,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "cSc" = (
@@ -18253,6 +18419,7 @@
 	name = "Private Office"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood4"
 	},
@@ -18264,6 +18431,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluecorners"
 	},
@@ -18430,6 +18598,7 @@
 	dir = 4
 	},
 /obj/structure/window/thin/reinforced,
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/bar)
 "cVU" = (
@@ -18558,6 +18727,7 @@
 	name = "Marshal";
 	req_access = list(58)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -18609,6 +18779,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/bridgehall)
 "cXF" = (
@@ -18821,6 +18992,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19040,6 +19212,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -19247,6 +19420,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "dfo" = (
@@ -19591,6 +19765,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "djf" = (
@@ -19699,6 +19874,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "dkd" = (
@@ -19895,6 +20071,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -20002,6 +20179,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "dnT" = (
@@ -20085,6 +20263,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/medical/surgery)
+"doD" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/blueshield)
 "doE" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/mailman,
@@ -20318,6 +20500,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "dqQ" = (
@@ -20440,6 +20623,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "drz" = (
@@ -20449,6 +20633,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
 	},
@@ -20579,6 +20764,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -20618,6 +20804,7 @@
 	name = "Central Park"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -20799,6 +20986,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "dvy" = (
@@ -20927,6 +21115,7 @@
 	},
 /area/station/engineering/atmos)
 "dwG" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "wood_stairs"
@@ -21081,6 +21270,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -21173,6 +21363,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -21229,6 +21420,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "dzB" = (
@@ -21392,6 +21584,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"dBN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/tools)
 "dBS" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/rig/medical,
@@ -21480,6 +21676,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
+"dCq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/prison/toilet)
 "dCr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21594,6 +21794,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 8
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "dDK" = (
@@ -21609,6 +21810,7 @@
 	name = "Privacy Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "dDL" = (
@@ -21803,6 +22005,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "dGG" = (
@@ -21825,6 +22028,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/barbershop)
 "dGI" = (
@@ -21912,6 +22116,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "dHS" = (
@@ -21957,6 +22162,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/janitor)
 "dIp" = (
@@ -21968,6 +22174,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "dIs" = (
@@ -22149,6 +22356,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brownfull"
 	},
@@ -22198,6 +22406,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"dLb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor,
+/area/station/civilian/dormitories)
 "dLg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22257,6 +22476,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "dLv" = (
@@ -22283,6 +22503,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22329,6 +22550,7 @@
 	layer = 4;
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -22367,6 +22589,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22437,6 +22660,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "dNe" = (
@@ -22444,6 +22668,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -22511,6 +22736,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "dOv" = (
@@ -22551,6 +22777,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/locker)
 "dOE" = (
@@ -22718,6 +22945,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
+"dQU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/engine)
 "dRj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/cigbutt,
@@ -22760,6 +22991,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "dSn" = (
@@ -22954,6 +23186,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -23067,6 +23300,10 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"dWo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/robotics)
 "dWr" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -23159,6 +23396,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "dXj" = (
@@ -23189,6 +23427,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "dXw" = (
@@ -23302,6 +23541,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"dYn" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/garden)
 "dYw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/scrap_lump,
@@ -23463,6 +23706,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -23526,6 +23770,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -23575,6 +23820,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
+"ech" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/computer)
 "ecj" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -23687,6 +23936,10 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/surgery)
+"edp" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/primary/bridgehall)
 "edq" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -23731,6 +23984,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -23783,6 +24037,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "eee" = (
@@ -23927,9 +24182,8 @@
 /obj/structure/disposalpipe/sortjunction/flipped{
 	sortType = "Кафетерий"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "efn" = (
 /obj/structure/window/thin/reinforced{
@@ -24152,6 +24406,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -24403,6 +24658,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "eje" = (
@@ -24706,6 +24962,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "enj" = (
@@ -24924,6 +25181,7 @@
 	req_access = list(60)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -25054,6 +25312,12 @@
 	icon_state = "blackchoco"
 	},
 /area/station/security/interrogation)
+"eqa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "eqc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25256,6 +25520,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -25428,10 +25693,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"etQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/equip)
 "etR" = (
 /obj/random/foods/food_trash,
 /obj/effect/decal/cleanable/dirt,
@@ -25533,6 +25803,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -25576,6 +25847,11 @@
 	icon_state = "solarpanel"
 	},
 /area/station/solar/starboard)
+"evo" = (
+/obj/structure/lattice,
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/xenobiology)
 "evq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25586,6 +25862,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -25801,6 +26078,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26036,6 +26314,7 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -26095,6 +26374,7 @@
 /area/station/medical/sleeper)
 "ezW" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -26157,6 +26437,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "eAA" = (
@@ -26474,6 +26755,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26618,6 +26900,10 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/station/security/secconfhall)
+"eFR" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/genetics)
 "eFT" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -26711,6 +26997,7 @@
 	})
 "eHi" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -26789,6 +27076,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -26899,6 +27187,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "eJM" = (
@@ -26941,6 +27230,10 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/teleport)
+"eKd" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor/carpet/blue,
+/area/station/hallway/secondary/entry)
 "eKj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27037,6 +27330,10 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
+"eKP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/dormitory)
 "eKW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -27239,6 +27536,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -27310,6 +27608,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -27508,6 +27807,7 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "green"
@@ -27892,6 +28192,10 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/security/blueshield)
+"eTP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/teleport)
 "eUh" = (
 /obj/item/weapon/bedsheet/mime,
 /obj/structure/stool/bed/pod,
@@ -27923,6 +28227,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "eUj" = (
@@ -27951,6 +28256,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/security/detectives_office)
 "eUs" = (
@@ -28192,6 +28498,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -28547,6 +28854,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -28575,6 +28883,7 @@
 	name = "Unisex Showers"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -28746,6 +29055,7 @@
 	icon_state = "pipe-c";
 	layer = 1.9
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -28978,6 +29288,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/drone_fabrication)
 "fgw" = (
@@ -29069,6 +29380,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -29177,6 +29489,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
 "fiC" = (
@@ -29296,6 +29609,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "fjv" = (
@@ -29305,6 +29619,10 @@
 	icon_state = "Stairs2_wide"
 	},
 /area/station/maintenance/bridge)
+"fjw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "fjy" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -29413,6 +29731,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -29555,6 +29874,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29589,6 +29909,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -29677,6 +29998,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood14"
 	},
@@ -29928,6 +30250,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30107,6 +30430,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "fqL" = (
@@ -30452,6 +30776,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "ftm" = (
@@ -30472,6 +30797,10 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"fto" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "ftt" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -30505,6 +30834,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "fty" = (
@@ -30749,6 +31079,7 @@
 	req_access = list(48)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brownfull"
 	},
@@ -30770,6 +31101,7 @@
 /area/station/medical/hallway)
 "fwJ" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -30805,6 +31137,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "fwT" = (
@@ -30814,6 +31147,7 @@
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "fwU" = (
@@ -30910,6 +31244,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "fxz" = (
@@ -31071,6 +31406,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
+"fzs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/qm)
 "fzx" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -31168,6 +31507,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "fAL" = (
@@ -31241,6 +31581,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "fBZ" = (
@@ -31309,6 +31650,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/engine,
 /area/station/rnd/misc_lab)
 "fCG" = (
@@ -31342,6 +31684,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31580,6 +31923,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"fGb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/bridge)
 "fGe" = (
 /turf/simulated/floor{
 	icon_state = "darkyellowcorners"
@@ -31602,6 +31949,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -31662,6 +32010,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -31760,6 +32109,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/medical/genetics)
+"fHN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/altar)
 "fHS" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -32459,6 +32812,10 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"fPw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/chamber)
 "fPy" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -32754,6 +33111,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -32943,6 +33301,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "fTf" = (
@@ -33006,6 +33365,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -33069,6 +33429,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
 "fUt" = (
@@ -33459,6 +33820,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "fWN" = (
@@ -33543,6 +33905,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "fXX" = (
@@ -33623,6 +33986,7 @@
 	name = "Evidence Storage";
 	req_one_access = list(4,68)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "dark"
@@ -33710,6 +34074,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "fZK" = (
@@ -33728,6 +34093,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood10"
 	},
@@ -33766,6 +34132,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "fZZ" = (
@@ -34061,6 +34428,10 @@
 	icon_state = "black"
 	},
 /area/station/security/prison)
+"gdn" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/ai_monitored/eva)
 "gds" = (
 /obj/machinery/camera{
 	c_tag = "Dorm West 2";
@@ -34107,6 +34478,7 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -34422,6 +34794,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -34543,6 +34916,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/brainstorm_center)
 "ghi" = (
@@ -34821,6 +35195,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "gkk" = (
@@ -35073,6 +35448,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/equip)
+"gnk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/vacantoffice)
 "gnx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -35086,6 +35465,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -35157,6 +35537,7 @@
 	icon_state = "pipe-c";
 	layer = 1.9
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitechoco"
 	},
@@ -35439,6 +35820,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "grP" = (
@@ -35505,6 +35887,10 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/medical/patients_rooms)
+"gsE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/mixing)
 "gsF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -35531,6 +35917,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "gta" = (
@@ -35620,6 +36007,10 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/bridgehall)
+"gtW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/genetics_cloning)
 "gtX" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -35840,6 +36231,10 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/kitchen)
+"gwd" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/rust)
 "gwf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35884,6 +36279,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "gws" = (
@@ -35902,6 +36298,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -35926,6 +36323,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "gwG" = (
@@ -35978,6 +36376,10 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/bridgehall)
+"gwV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories)
 "gwZ" = (
 /obj/machinery/light_switch{
 	pixel_y = -26
@@ -36035,6 +36437,7 @@
 	name = "E.V.A. Maintenance";
 	req_one_access = list(1,5,11,18,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "gxo" = (
@@ -36292,6 +36695,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "gzs" = (
@@ -36334,6 +36738,7 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -36389,6 +36794,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "gAh" = (
@@ -36405,6 +36811,7 @@
 	anchored = 1;
 	id = "op3"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -36481,6 +36888,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "gBi" = (
@@ -36521,6 +36929,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "gBo" = (
@@ -36563,6 +36972,7 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -36593,6 +37003,10 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/bar)
+"gCF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/hos)
 "gCM" = (
 /obj/machinery/light/small,
 /obj/structure/stool/bed/chair/schair/wagon{
@@ -36675,6 +37089,10 @@
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/bridgehall)
+"gDW" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor,
+/area/station/civilian/dormitories)
 "gDX" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
@@ -36700,6 +37118,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -37059,6 +37478,7 @@
 	req_access = list(67)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "gHn" = (
@@ -37112,6 +37532,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkyellowfull"
@@ -37254,6 +37675,7 @@
 	name = "Common Channel";
 	pixel_y = 25
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "gIr" = (
@@ -37343,6 +37765,21 @@
 	icon_state = "2,2"
 	},
 /area/shuttle/supply/station)
+"gJV" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "Security_private";
+	opacity = 0
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint)
 "gKa" = (
 /obj/random/foods/food_trash,
 /turf/simulated/floor/plating,
@@ -37620,6 +38057,10 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/market)
+"gMi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/cryo)
 "gMl" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -37654,6 +38095,10 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/outerlabs)
+"gMH" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/chemistry)
 "gMR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -37702,6 +38147,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "gMY" = (
@@ -37744,6 +38190,7 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "gNi" = (
@@ -37880,6 +38327,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -38012,6 +38460,7 @@
 	req_one_access = list(9,12,47)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "gPf" = (
@@ -38166,6 +38615,10 @@
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
+"gQz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/gateway)
 "gQE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38544,6 +38997,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"gUW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/forensic_office)
 "gVa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -38602,6 +39059,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "gVl" = (
@@ -39086,6 +39544,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/bar)
 "haZ" = (
@@ -39290,6 +39749,10 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"hdt" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/robotics)
 "hdx" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=N-MB";
@@ -39448,6 +39911,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/garden)
 "heQ" = (
@@ -39571,6 +40035,17 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/toilet)
+"hfO" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "hfV" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/guide_to_robotics{
@@ -39668,6 +40143,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"hhF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/patients_rooms)
 "hhJ" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -39745,6 +40224,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -40113,6 +40593,10 @@
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"hml" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/kitchen)
 "hmm" = (
 /obj/machinery/door/poddoor{
 	dir = 4;
@@ -40190,6 +40674,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"hna" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "hnb" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -40202,6 +40690,7 @@
 	name = "Holodeck Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -40235,6 +40724,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "hnC" = (
@@ -40522,6 +41012,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
+"hri" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "hrl" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -40641,6 +41139,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/space)
 "hsD" = (
@@ -40932,6 +41431,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -41023,6 +41523,7 @@
 	icon_state = "gr_window_polarized";
 	id = "MedLunchPark"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
 "hxt" = (
@@ -41046,6 +41547,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "hxz" = (
@@ -41137,6 +41639,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "hyK" = (
@@ -41181,6 +41684,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41246,6 +41750,7 @@
 /obj/structure/sign/departments/cargo{
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "browncorner"
@@ -41268,6 +41773,10 @@
 	icon_state = "white"
 	},
 /area/station/medical/genetics)
+"hAm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/brig)
 "hAn" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -41343,6 +41852,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "hAX" = (
@@ -41587,6 +42097,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/brig)
+"hEb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "hEd" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -41610,6 +42129,7 @@
 /obj/item/device/radio/intercom{
 	pixel_x = 25
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitecorner"
@@ -41675,6 +42195,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -41709,6 +42230,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -41761,6 +42283,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "hFH" = (
@@ -41860,6 +42383,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -41940,6 +42464,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "hHl" = (
@@ -42081,6 +42606,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "hIX" = (
@@ -42144,6 +42670,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -42281,12 +42808,17 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"hKP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/seclunch)
 "hLl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
 "hLo" = (
@@ -42826,6 +43358,7 @@
 	name = "Morgue";
 	req_one_access = list(6,28)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42836,6 +43369,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/test_area)
 "hQI" = (
@@ -43029,6 +43563,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/dormitories/theater)
 "hSM" = (
@@ -43305,6 +43840,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkgreen"
@@ -43322,6 +43858,10 @@
 	icon_state = "stairs_middle"
 	},
 /area/station/maintenance/brig)
+"hWa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/arrival)
 "hWg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43596,6 +44136,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "hZG" = (
@@ -43821,6 +44362,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood10"
 	},
@@ -44031,6 +44573,7 @@
 /area/station/rnd/hallway/florahall)
 "idJ" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -44180,6 +44723,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "ieO" = (
@@ -44240,6 +44784,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/environment/space,
 /turf/simulated/floor{
 	dir = 1;
@@ -44293,6 +44838,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/patients_rooms)
+"ifD" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/ai_monitored/storage_secure)
 "ifF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -44582,6 +45131,7 @@
 /area/station/engineering/atmos)
 "iis" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -44870,6 +45420,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/patient_a)
 "ikF" = (
@@ -45148,6 +45699,7 @@
 	name = "Engine Room";
 	req_one_access = list(11,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -45329,6 +45881,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "ioW" = (
@@ -45366,9 +45919,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "ipv" = (
 /obj/machinery/door/firedoor,
@@ -45383,6 +45935,7 @@
 	id_tag = "Dorm2";
 	name = "Dorm 2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/dormtwo)
 "ipG" = (
@@ -45481,6 +46034,7 @@
 	id_tag = "EngiRest";
 	name = "Engineering Restroom"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -45644,6 +46198,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "isI" = (
@@ -45718,6 +46273,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -45733,6 +46289,7 @@
 	layer = 4;
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "greencorner"
 	},
@@ -45999,6 +46556,7 @@
 	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "ivK" = (
@@ -46297,6 +46855,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "iyf" = (
@@ -46309,6 +46868,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "iyp" = (
@@ -46374,6 +46934,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkredcorners"
 	},
@@ -46408,6 +46969,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "iyZ" = (
@@ -46774,6 +47336,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "iBM" = (
@@ -46782,6 +47345,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "iBO" = (
@@ -46830,6 +47394,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "iCD" = (
@@ -46971,6 +47536,7 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -47009,6 +47575,7 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkyellowfull"
@@ -47040,6 +47607,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -47107,6 +47675,17 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/outerlabs)
+"iFG" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/bridge)
 "iFJ" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -47272,6 +47851,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "iHD" = (
@@ -47584,6 +48164,13 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/dormitories)
+"iKm" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "redyellowfull"
+	},
+/area/station/civilian/bar)
 "iKt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47793,6 +48380,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"iNZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/central)
 "iOa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
 	dir = 4;
@@ -47824,6 +48415,7 @@
 	name = "Medbay Technician";
 	req_access = list(5,6)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -47939,6 +48531,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
 	},
@@ -47967,6 +48560,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -48252,6 +48846,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
 "iSv" = (
@@ -48418,6 +49013,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "iUa" = (
@@ -48517,6 +49113,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"iUL" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "iUT" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/turf_decal/set_damaged,
@@ -48629,6 +49234,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/hallway)
 "iWY" = (
@@ -48668,6 +49274,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/morgue)
+"iXw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/office)
 "iXK" = (
 /obj/structure/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -48857,6 +49467,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "jae" = (
@@ -48921,6 +49532,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main{
 	name = "Security Equipment"
@@ -48931,6 +49543,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "jaM" = (
@@ -48953,6 +49566,10 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"jaY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/monitoring)
 "jbe" = (
 /obj/structure/stool/bed/chair/metal,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -49089,6 +49706,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "jdd" = (
@@ -49374,6 +49992,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "jfU" = (
@@ -49419,7 +50038,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"jgm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/secdorm)
 "jgq" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "wood_stairs2"
@@ -49443,6 +50067,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "jgD" = (
@@ -49470,6 +50095,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -49609,6 +50235,7 @@
 	dir = 1
 	},
 /obj/effect/decal/turf_decal/set_burned,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/maintenance/bridge)
 "jia" = (
@@ -49681,6 +50308,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "jiv" = (
@@ -49801,6 +50429,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/garden)
 "jjy" = (
@@ -50052,12 +50681,27 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
+"jmG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/office)
 "jnd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
+"jne" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/rnd/mixing)
 "jnj" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -50079,6 +50723,7 @@
 	icon_state = "gr_window_polarized";
 	id = "Courtroom"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/tribunal)
 "jny" = (
@@ -50226,6 +50871,7 @@
 	layer = 4;
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -50372,6 +51018,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/structure/cable,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "jqg" = (
@@ -50500,6 +51147,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
 "jrk" = (
@@ -50672,6 +51320,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/snowman,
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "jtN" = (
@@ -50744,6 +51393,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -50773,6 +51423,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -50808,6 +51459,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -50868,6 +51520,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -51067,6 +51720,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "jxi" = (
@@ -51198,6 +51852,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -51356,6 +52011,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -51454,6 +52110,7 @@
 	name = "Recycler office";
 	req_access = list(67)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -51506,6 +52163,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
+"jAi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "jAk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51778,6 +52445,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "jCD" = (
@@ -51947,6 +52615,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
 "jEf" = (
@@ -52014,6 +52683,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "jFe" = (
@@ -52024,6 +52694,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "jFh" = (
@@ -52281,6 +52952,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/rnd/brainstorm_center)
+"jHB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/interrogation)
 "jHE" = (
 /obj/structure/dresser,
 /obj/item/device/radio/intercom{
@@ -52316,6 +52991,7 @@
 /area/station/engineering/atmos)
 "jHP" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -52355,6 +53031,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "jHY" = (
@@ -52630,6 +53307,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
 "jKT" = (
@@ -52716,6 +53394,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -52814,6 +53493,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "jMS" = (
@@ -52824,6 +53504,10 @@
 	icon_state = "wood14"
 	},
 /area/station/civilian/library)
+"jMU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/gym)
 "jNc" = (
 /obj/structure/closet/secure_closet/RD,
 /turf/simulated/floor/carpet/purple,
@@ -53053,6 +53737,19 @@
 /area/station/security/main{
 	name = "Security Equipment"
 	})
+"jQq" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/civilian/garden)
+"jQs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/lab)
 "jQw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53062,6 +53759,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitepurplecorner"
 	},
@@ -53420,6 +54118,7 @@
 	icon_state = "gr_window"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "jUF" = (
@@ -53596,6 +54295,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "jXm" = (
@@ -53919,6 +54619,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "kaC" = (
@@ -53968,6 +54669,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "kbc" = (
@@ -53997,6 +54699,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "kbi" = (
@@ -54313,6 +55016,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -54767,6 +55471,7 @@
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "kkg" = (
@@ -54871,6 +55576,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -55533,6 +56239,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
 "krX" = (
@@ -55742,6 +56449,10 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
+"kuo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/storage/tech)
 "kup" = (
 /obj/machinery/shower{
 	dir = 8
@@ -55901,6 +56612,7 @@
 	icon_state = "gr_window_polarized";
 	id = "geneticpenpsych2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "kvR" = (
@@ -55972,6 +56684,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "kwN" = (
@@ -56224,6 +56937,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "kyZ" = (
@@ -56242,6 +56956,14 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"kza" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/brig)
 "kze" = (
 /obj/item/weapon/flora,
 /obj/structure/table/reinforced,
@@ -56352,6 +57074,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "kAv" = (
@@ -56403,6 +57126,7 @@
 	name = "Kitchen Freezer";
 	req_access = list(28)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -56428,6 +57152,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "kBf" = (
@@ -56470,6 +57195,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/brainstorm_center)
 "kBA" = (
@@ -56545,6 +57271,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
+"kCm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/virology)
 "kCo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56570,6 +57300,7 @@
 	grilled = 1;
 	id = "Detective"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "kCy" = (
@@ -56634,6 +57365,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "kDo" = (
@@ -56895,6 +57627,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "kHd" = (
@@ -56922,6 +57655,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -57092,6 +57826,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "kJn" = (
@@ -57110,6 +57845,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "kJt" = (
@@ -57151,6 +57887,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -57400,6 +58137,10 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
+"kNj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/bridgehall)
 "kNr" = (
 /obj/machinery/disposal,
 /obj/machinery/camera{
@@ -57456,6 +58197,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -57477,6 +58219,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "kOa" = (
@@ -57540,6 +58283,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "kOD" = (
@@ -57619,6 +58363,7 @@
 	icon_state = "gr_window_polarized";
 	id = "geneticpenpsych"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "kQh" = (
@@ -57676,6 +58421,10 @@
 /obj/structure/sign/warning/pods,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/brigright)
+"kQU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/virology)
 "kQX" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -58163,6 +58912,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -58579,6 +59329,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "kYM" = (
@@ -58685,6 +59436,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
 "laq" = (
@@ -58729,6 +59481,17 @@
 /obj/random/scrap/safe_even,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"laz" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/science)
 "laF" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/simulated/wall,
@@ -58763,6 +59526,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -58784,6 +59548,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
 "laM" = (
@@ -58909,6 +59674,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -59023,6 +59789,7 @@
 	name = "Virology";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreenfull"
@@ -59257,6 +60024,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -59477,6 +60245,7 @@
 /area/station/civilian/market)
 "lgg" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -59617,6 +60386,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -60262,6 +61032,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/structure/sign/directions/dock_tablo/tablo3,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "lpy" = (
@@ -60355,6 +61126,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "wood_stairs2"
@@ -60461,6 +61233,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/library)
 "lrp" = (
@@ -60472,6 +61245,10 @@
 	},
 /turf/environment/space,
 /area/space)
+"lrx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/medbreak)
 "lry" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
@@ -60552,6 +61329,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -60817,6 +61595,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/secdorm)
 "lvW" = (
@@ -60846,6 +61625,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -60890,6 +61670,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "lwt" = (
@@ -61033,6 +61814,7 @@
 	},
 /area/station/engineering/chiefs_office)
 "lyS" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "wood_stairs2"
@@ -61054,6 +61836,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "lzg" = (
@@ -61097,6 +61880,7 @@
 /area/station/maintenance/brig)
 "lzr" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -61114,6 +61898,7 @@
 /area/station/maintenance/science)
 "lzK" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "arrival"
@@ -61285,6 +62070,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/hallway/secondary/entry)
+"lBs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/locker)
 "lBt" = (
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -61293,6 +62082,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "lBv" = (
@@ -61345,6 +62135,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -61440,6 +62231,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "lCw" = (
@@ -61491,6 +62283,7 @@
 	name = "Engineering Break Room";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
 	},
@@ -61551,6 +62344,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -61639,6 +62433,10 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/drone_fabrication)
+"lEy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/medbay)
 "lEG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -61966,6 +62764,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
 "lIl" = (
@@ -62291,6 +63090,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/secconfhall)
 "lLs" = (
@@ -62427,6 +63227,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowcorner"
@@ -62465,6 +63266,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "lNh" = (
@@ -62632,6 +63434,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "lPI" = (
@@ -62699,6 +63502,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/patient_b)
 "lQf" = (
@@ -62811,6 +63615,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -62868,6 +63673,10 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod3/station)
+"lRw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/portsolar)
 "lRD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -63043,6 +63852,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "lTF" = (
@@ -63541,6 +64351,7 @@
 	name = "Security";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -63591,6 +64402,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "lYN" = (
@@ -63682,6 +64494,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "lZb" = (
@@ -63875,6 +64688,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
 "mbd" = (
@@ -63922,6 +64736,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brownfull"
 	},
@@ -64405,6 +65220,7 @@
 	name = "Lethal Injection Storage";
 	req_access = list(58)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -64639,6 +65455,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -64734,6 +65551,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/medical/sleeper)
 "mjB" = (
@@ -64758,6 +65576,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -64815,6 +65634,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "mkO" = (
@@ -65263,6 +66083,10 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"mpL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/library)
 "mqc" = (
 /obj/item/airbag{
 	pixel_x = -5;
@@ -65669,10 +66493,15 @@
 	})
 "mun" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
 /area/station/hallway/secondary/entry)
+"muA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/surgery2)
 "muI" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -65719,6 +66548,7 @@
 	name = "Brig Medical Checkpoint";
 	req_one_access = list(1,4)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -65731,6 +66561,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "muX" = (
@@ -65834,6 +66665,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "mwh" = (
@@ -65847,6 +66679,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "mwj" = (
@@ -65881,8 +66714,13 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
+"mwG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/seclunch)
 "mwL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -66090,6 +66928,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/bridgehall)
 "myU" = (
@@ -66157,6 +66996,10 @@
 	icon_state = "whitechoco"
 	},
 /area/station/rnd/hallway)
+"mzo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/morgue)
 "mzw" = (
 /obj/item/device/radio/intercom/pod{
 	dir = 4;
@@ -66207,6 +67050,7 @@
 /area/station/civilian/bar)
 "mAq" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "arrival"
@@ -66261,6 +67105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -66303,6 +67148,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "mAU" = (
@@ -66376,6 +67222,13 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"mBu" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mBz" = (
 /obj/effect/decal/turf_decal/metal{
 	dir = 8;
@@ -66524,6 +67377,10 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/drone_fabrication)
+"mDe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/cmo)
 "mDk" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -66747,6 +67604,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -67057,6 +67915,7 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "mKA" = (
@@ -67324,6 +68183,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "mNO" = (
@@ -67714,6 +68574,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "mRG" = (
@@ -68235,6 +69096,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/prison)
+"mXu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "mXB" = (
 /obj/machinery/door/window{
 	dir = 4;
@@ -68435,6 +69300,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "mZG" = (
@@ -68505,6 +69371,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "naf" = (
@@ -68823,6 +69690,7 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -68939,6 +69807,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -69302,6 +70171,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "green"
 	},
@@ -69331,6 +70201,7 @@
 	dir = 4;
 	name = "Unit 1"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -69471,6 +70342,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/structure/sign/warning/detailed,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "njk" = (
@@ -69706,6 +70578,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "nlT" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "wood_stairs2"
@@ -69718,6 +70591,7 @@
 	name = "Cargo Bay Maintenance";
 	req_access = list(50)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "nmc" = (
@@ -70020,6 +70894,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "npk" = (
@@ -70398,6 +71273,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "nsK" = (
@@ -70598,6 +71474,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "nvH" = (
@@ -70970,6 +71847,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "nAc" = (
@@ -71034,6 +71912,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "nAN" = (
@@ -71231,6 +72110,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison/toilet)
 "nCV" = (
@@ -71520,6 +72400,17 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"nFG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "nFK" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor{
@@ -71602,6 +72493,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "nGy" = (
@@ -71810,6 +72702,7 @@
 	layer = 4;
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -71836,6 +72729,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
 "nIO" = (
@@ -71862,6 +72756,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -71922,6 +72817,7 @@
 	dir = 4;
 	icon_state = "spline_plain"
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "redyellowfull"
@@ -71965,6 +72861,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72058,6 +72955,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72112,6 +73010,7 @@
 	req_access = list(50)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brownfull"
 	},
@@ -72285,6 +73184,10 @@
 	icon_state = "blue"
 	},
 /area/station/bridge/hop_office)
+"nML" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/ai_monitored/eva)
 "nMS" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -72407,6 +73310,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
 "nPn" = (
@@ -72642,6 +73546,7 @@
 	req_access = list(19,23)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72705,6 +73610,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -72848,6 +73754,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "nSC" = (
@@ -73018,6 +73925,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "nUF" = (
@@ -73173,6 +74081,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "nVZ" = (
@@ -73291,6 +74200,7 @@
 	name = "Captain's Quarters";
 	req_access = list(20)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -73383,6 +74293,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/bar)
 "nXe" = (
@@ -73426,6 +74337,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -73489,6 +74401,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "nXS" = (
@@ -73528,6 +74441,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -73546,6 +74460,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "nYt" = (
@@ -73574,6 +74489,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/forensic_office)
 "nYP" = (
@@ -73622,6 +74538,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood10"
 	},
@@ -73843,6 +74760,10 @@
 /obj/item/weapon/wrench,
 /turf/simulated/floor/wood,
 /area/station/maintenance/bridge)
+"obs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/misc_lab)
 "obt" = (
 /obj/structure/grille,
 /obj/structure/window/thin/reinforced{
@@ -73918,6 +74839,7 @@
 /area/station/maintenance/bridge)
 "obY" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -73977,6 +74899,7 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -73996,6 +74919,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74023,6 +74947,7 @@
 	req_access = list(25)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood6"
 	},
@@ -74137,6 +75062,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -74179,6 +75105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -74646,6 +75573,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "oku" = (
@@ -74663,6 +75591,15 @@
 	icon_state = "darkstairs_wide"
 	},
 /area/station/security/lobby)
+"olc" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "oln" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -74819,6 +75756,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -75348,6 +76286,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -75394,6 +76333,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "ouz" = (
@@ -75513,6 +76453,7 @@
 	name = "Morgue";
 	req_access = list(5,6)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -75983,6 +76924,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "oBk" = (
@@ -76074,6 +77016,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "oCs" = (
@@ -76133,6 +77076,7 @@
 /area/shuttle/escape_pod5/station)
 "oDj" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitepurplecorner"
 	},
@@ -76252,6 +77196,7 @@
 	req_one_access = list(31,48,67)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -76626,6 +77571,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/janitor)
 "oHn" = (
@@ -76723,6 +77669,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -76792,6 +77739,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -77034,6 +77982,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"oLj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories/dormtwo)
 "oLo" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hor)
@@ -77069,6 +78021,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -77328,6 +78281,10 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
+"oOd" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/server)
 "oOf" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 1
@@ -77401,6 +78358,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -77753,6 +78711,7 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -77808,6 +78767,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "oSS" = (
@@ -77862,6 +78822,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -78030,6 +78991,7 @@
 	dir = 4;
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/maintenance/science)
 "oUW" = (
@@ -78499,6 +79461,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/rust)
 "oZb" = (
@@ -78598,6 +79561,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkredcorners"
 	},
@@ -78797,6 +79761,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "pbZ" = (
@@ -79010,6 +79975,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -79088,6 +80054,7 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -79235,6 +80202,10 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/medbreak)
+"phh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories/dormthree)
 "php" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79469,6 +80440,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -79549,6 +80521,7 @@
 	name = "Arrival Airlock";
 	req_one_access = list(65,48)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "pjV" = (
@@ -79937,6 +80910,7 @@
 	name = "Holodeck Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -80126,6 +81100,7 @@
 	name = "Operating Theatre 2";
 	req_access = list(45)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -80139,6 +81114,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
 "pqi" = (
@@ -80274,6 +81250,10 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"pru" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hor)
 "prB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -80283,6 +81263,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/cmo)
+"prD" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories/dormone)
 "prL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/extinguisher_cabinet{
@@ -80425,6 +81409,7 @@
 	req_access = list(63)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -80452,6 +81437,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -80462,6 +81448,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -80475,6 +81462,7 @@
 /obj/structure/transit_tube{
 	icon_state = "N-S"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "puH" = (
@@ -80742,6 +81730,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -80941,6 +81930,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "pAm" = (
@@ -80967,6 +81957,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -81060,6 +82051,10 @@
 	},
 /turf/environment/space,
 /area/space)
+"pBz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/mass_driver)
 "pBA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81207,6 +82202,10 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/xenobiology)
+"pDu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/science)
 "pDN" = (
 /obj/item/weapon/caution/cone,
 /turf/simulated/floor/plating,
@@ -81329,6 +82328,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood14"
 	},
@@ -81381,6 +82381,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "arrivalcorner"
@@ -81763,6 +82764,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -81840,6 +82842,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/wall/r_wall,
 /area/station/medical/virology)
 "pLC" = (
@@ -81947,6 +82950,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "pMn" = (
@@ -81977,6 +82981,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "pMv" = (
@@ -82020,6 +83025,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/rust)
 "pMI" = (
@@ -82178,6 +83184,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brownfull"
 	},
@@ -82274,6 +83281,7 @@
 	id_tag = "Dorm1";
 	name = "Dorm 1"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/dormone)
 "pOK" = (
@@ -82320,6 +83328,7 @@
 	icon_state = "0-2";
 	pixel_y = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "pPh" = (
@@ -82995,6 +84004,10 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/bridgehall)
+"pWe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/execution)
 "pWf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -83075,6 +84088,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"pWL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/break_room)
 "pWM" = (
 /obj/structure/stool,
 /obj/machinery/light/small{
@@ -83428,6 +84445,7 @@
 	name = "Auxiliary Tool Storage";
 	req_access = list(12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "qav" = (
@@ -83453,6 +84471,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood14"
 	},
@@ -83566,6 +84585,7 @@
 	icon_state = "gr_window_polarized";
 	id = "op1.5"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
 "qbC" = (
@@ -83739,6 +84759,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/locker)
 "qdd" = (
@@ -83999,6 +85020,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -84025,6 +85047,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "qgS" = (
@@ -84514,6 +85537,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84574,6 +85598,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "qlN" = (
@@ -84622,6 +85647,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitebluecorner"
@@ -84871,6 +85897,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84939,6 +85966,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/chemistry)
 "qoM" = (
@@ -84946,6 +85974,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -84975,6 +86004,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/rust)
 "qpd" = (
@@ -85232,6 +86262,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "qsf" = (
@@ -85261,6 +86292,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -85402,6 +86434,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -85452,6 +86485,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "qtM" = (
@@ -85934,6 +86968,7 @@
 	name = "Monkey Pen";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -86029,6 +87064,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
 "qAM" = (
@@ -86290,6 +87326,15 @@
 	icon_state = "darkredfull"
 	},
 /area/station/security/lobby)
+"qDr" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "qDv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -86313,6 +87358,10 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
+"qDP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/reception)
 "qDZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -86395,6 +87444,10 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/simulated/wall/r_wall,
 /area/station/medical/chemistry)
+"qFx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/prison)
 "qFy" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -86411,6 +87464,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/brigright)
+"qFU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/forensic_office)
 "qFV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -86430,6 +87487,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/rust)
 "qGb" = (
@@ -86516,6 +87574,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
 "qGF" = (
@@ -86572,8 +87631,13 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/chemistry)
+"qHa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/hallway)
 "qHg" = (
 /obj/machinery/newscaster{
 	pixel_y = -28
@@ -86884,6 +87948,10 @@
 /area/station/security/main{
 	name = "Security Equipment"
 	})
+"qJV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "qJX" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -86925,6 +87993,7 @@
 /area/station/solar/port)
 "qKd" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -87219,10 +88288,12 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "qNv" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -87359,6 +88430,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -87431,6 +88503,7 @@
 /area/station/security/seclunch)
 "qOK" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "dark"
@@ -87505,6 +88578,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -87548,6 +88622,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -87681,6 +88756,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood4"
 	},
@@ -87719,6 +88795,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"qRe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos)
 "qRf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -87793,6 +88873,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -87955,6 +89036,22 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"qUD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "qUE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -88098,6 +89195,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "qVW" = (
@@ -88252,6 +89350,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "qXN" = (
@@ -88386,6 +89485,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "qZl" = (
@@ -88508,6 +89608,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/tribunal)
 "rai" = (
@@ -88535,6 +89636,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/secconfhall)
 "raq" = (
@@ -88605,6 +89707,7 @@
 	req_access = list(61)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -88852,6 +89955,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "rdk" = (
@@ -88889,6 +89993,7 @@
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/maintenance/bridge)
 "rdD" = (
@@ -88973,6 +90078,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -89145,6 +90251,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "rgC" = (
@@ -89428,6 +90535,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/server)
 "rkh" = (
@@ -89589,6 +90697,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "green"
 	},
@@ -89849,6 +90958,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"rqr" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/tox_launch)
 "rqy" = (
 /obj/effect/decal/cleanable/egg_smudge,
 /turf/simulated/floor/plating,
@@ -89881,6 +90994,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
+"rrb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hallway)
 "rrp" = (
 /obj/structure/barricade/wooden,
 /obj/structure/door_assembly/door_assembly_med,
@@ -90069,6 +91186,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "rsK" = (
@@ -90285,6 +91403,7 @@
 	dir = 8;
 	pixel_y = 24
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -90670,6 +91789,7 @@
 	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "rxJ" = (
@@ -90705,6 +91825,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "rxT" = (
@@ -90867,6 +91988,10 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/bridgehall)
+"rzo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/janitor)
 "rzs" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 4
@@ -91166,6 +92291,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "rDk" = (
@@ -91254,6 +92380,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"rEu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/range)
 "rEv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91531,6 +92661,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "rHr" = (
@@ -91651,6 +92782,10 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"rIK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/secdorm)
 "rIL" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/simulated/floor/bluegrid{
@@ -92212,6 +93347,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -92275,6 +93411,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "rOk" = (
@@ -92355,6 +93492,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -92414,6 +93552,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "rQR" = (
@@ -92616,6 +93755,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "rTw" = (
@@ -92770,6 +93910,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -92985,6 +94126,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "rXw" = (
@@ -93130,6 +94272,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkyellow"
@@ -93278,6 +94421,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -93375,6 +94519,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "sbZ" = (
@@ -93453,8 +94598,13 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
+"scZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/patient_b)
 "sdn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -93508,8 +94658,13 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
+"sdN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/meeting_room)
 "sdR" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -93985,6 +95140,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -94372,6 +95528,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "smQ" = (
@@ -94555,6 +95712,7 @@
 	name = "Brig Restroom"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
 "soy" = (
@@ -94697,6 +95855,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"spR" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/storage)
 "sqa" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/simulated/floor{
@@ -95024,6 +96186,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -95071,6 +96234,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
 "ssC" = (
@@ -95127,6 +96291,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/maintenance/bridge)
 "sta" = (
@@ -95251,9 +96416,11 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "sum" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "wood_stairs"
@@ -95313,6 +96480,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -95349,6 +96517,7 @@
 	name = "Security";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkred"
@@ -95829,6 +96998,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "sAD" = (
@@ -95994,6 +97164,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "sCd" = (
@@ -96543,6 +97714,10 @@
 	icon_state = "purplechecker"
 	},
 /area/station/civilian/barbershop)
+"sHy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/telesci)
 "sHG" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/manual/wiki/medical_genetics,
@@ -96704,6 +97879,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway/outbranch)
 "sIQ" = (
@@ -96719,6 +97895,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -96732,6 +97909,7 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -96810,6 +97988,7 @@
 	req_access = list(40)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood4"
 	},
@@ -96838,6 +98017,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -96862,6 +98042,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -97316,6 +98497,7 @@
 	req_access = list(39)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -97326,6 +98508,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/sleeper)
 "sOQ" = (
@@ -97339,6 +98522,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -97503,6 +98687,7 @@
 	name = "Blueshield Storage";
 	req_access = list(42)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -97596,6 +98781,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "sSK" = (
@@ -97677,6 +98863,7 @@
 	anchored = 1;
 	id = "op1"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -97796,6 +98983,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -97824,6 +99012,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -97843,6 +99032,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkred"
@@ -97897,6 +99087,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
 "sVV" = (
@@ -97938,6 +99129,10 @@
 /obj/structure/cryofeed,
 /turf/simulated/floor/plating,
 /area/station/security/secdorm)
+"sWd" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/surgery)
 "sWo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -97950,6 +99145,19 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
 /area/station/maintenance/brig)
+"sWy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/genetics)
+"sWA" = (
+/obj/machinery/door/airlock/external{
+	dir = 4;
+	name = "Arrival Airlock"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "sWB" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder{
@@ -98079,6 +99287,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "sXW" = (
@@ -98178,6 +99387,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "sZf" = (
@@ -98256,6 +99466,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -98479,6 +99690,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/rust)
 "tbs" = (
@@ -98496,6 +99708,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"tbv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint)
 "tbE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/book/manual/wiki/security_space_law{
@@ -98565,6 +99781,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "tbZ" = (
@@ -98606,6 +99823,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery3)
 "tct" = (
@@ -98672,6 +99890,7 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "tdz" = (
@@ -98688,6 +99907,7 @@
 	name = "Security";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkred"
@@ -99141,6 +100361,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "thW" = (
@@ -99384,6 +100605,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/seclunch)
 "tlI" = (
@@ -99518,6 +100740,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "tmP" = (
@@ -99961,6 +101184,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "tqw" = (
@@ -99990,6 +101214,7 @@
 /area/station/maintenance/brig)
 "tqO" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "tqP" = (
@@ -100017,6 +101242,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "tro" = (
@@ -100175,6 +101401,7 @@
 	id = "bar-m";
 	name = "Bar Shutters"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "tsz" = (
@@ -100185,6 +101412,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/rust)
 "tsC" = (
@@ -100431,6 +101659,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "tud" = (
@@ -100510,6 +101739,7 @@
 	anchored = 1;
 	id = "op1"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -100522,6 +101752,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wood_stairs2"
 	},
@@ -100712,6 +101943,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -100853,6 +102085,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -100957,6 +102190,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "tzW" = (
@@ -101003,6 +102237,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "tAi" = (
@@ -101081,6 +102316,7 @@
 	name = "Teleport Access";
 	req_access = list(17)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "tBk" = (
@@ -101158,6 +102394,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"tCb" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access = list(1)
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "darkredfull"
+	},
+/area/station/security/checkpoint)
 "tCc" = (
 /obj/item/weapon/minihoe{
 	desc = "It's used for removing weeds or scratching your back. ''Property of Desmond.R.'' is wroten on the handle";
@@ -101235,6 +102483,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "tCA" = (
@@ -101340,6 +102589,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/garden)
 "tCU" = (
@@ -101525,6 +102775,10 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/outerlabs)
+"tFp" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/chargebay)
 "tFu" = (
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -101747,6 +103001,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "tHI" = (
@@ -101802,6 +103057,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "tHU" = (
@@ -101879,6 +103135,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -101942,6 +103199,20 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/storage)
+"tJv" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 1
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 4
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/grass,
+/area/station/civilian/bar)
 "tJG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -102009,6 +103280,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/sppodconstr)
+"tKe" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	dir = 1;
+	icon_state = "siding_wood_line"
+	},
+/obj/item/decoration/snowman,
+/turf/simulated/floor/wood{
+	icon_state = "wood10"
+	},
+/area/station/civilian/dormitories/theater)
 "tKi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -102047,6 +103328,7 @@
 /area/station/rnd/sppodconstr)
 "tKM" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -102193,6 +103475,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"tMs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/hallway/outbranch)
 "tMA" = (
 /obj/structure/cryofeed/right,
 /obj/machinery/camera{
@@ -102211,6 +103497,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/chamber)
 "tMM" = (
@@ -102577,6 +103864,10 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/garden)
+"tRm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/xenobiology)
 "tRu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -102734,6 +104025,10 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"tSy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/toilet)
 "tSz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -103241,6 +104536,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "tXC" = (
@@ -103306,6 +104602,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "tYj" = (
@@ -103411,6 +104708,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood14"
 	},
@@ -103561,6 +104859,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -103936,6 +105235,7 @@
 	name = "Assembly Line (KEEP OUT)";
 	req_access = list(32)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "ues" = (
@@ -104483,11 +105783,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/chiefs_office)
+"uiz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/armoury)
 "uiI" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -104680,6 +105985,7 @@
 	},
 /area/station/bridge/captain_quarters)
 "ukX" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wood_stairs2"
 	},
@@ -104701,6 +106007,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway/florahall)
 "ulk" = (
@@ -104758,6 +106065,7 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "ulA" = (
@@ -104830,6 +106138,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "umq" = (
@@ -105011,6 +106320,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -105100,6 +106410,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkred"
@@ -105155,6 +106466,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greenfull"
@@ -105183,6 +106495,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"upm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/nuke_storage)
 "upp" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/security/bodycam,
@@ -105228,6 +106544,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/chamber)
 "upS" = (
@@ -105662,6 +106979,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "utp" = (
@@ -105717,6 +107035,7 @@
 	icon_state = "0-2";
 	pixel_y = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "utQ" = (
@@ -105771,6 +107090,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"uur" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge)
 "uuy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -106047,6 +107370,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brigright)
+"uxT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/barbershop)
 "uyk" = (
 /obj/item/stack/sheet/wood,
 /turf/simulated/floor/plating,
@@ -106400,6 +107727,7 @@
 /area/station/civilian/dormitories)
 "uCt" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitecorner"
@@ -106856,6 +108184,7 @@
 	layer = 4;
 	pixel_x = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "greencorner"
@@ -106943,6 +108272,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -107065,6 +108395,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "uID" = (
@@ -107165,6 +108496,10 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"uKo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/surgery3)
 "uKp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -107248,6 +108583,12 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/brig)
+"uLd" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/primary/central)
 "uLe" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -107356,11 +108697,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"uMl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "uMm" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -107378,6 +108731,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
+"uMJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/monitoring)
 "uMK" = (
 /obj/structure/table,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -107416,6 +108773,10 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/nuke_storage)
+"uNp" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/hydroponics)
 "uNq" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/status_display{
@@ -107460,6 +108821,10 @@
 	icon_state = "blue"
 	},
 /area/station/medical/sleeper)
+"uNA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/brig/solitary_confinement)
 "uNC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -107490,6 +108855,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/tribunal)
 "uNP" = (
@@ -107634,6 +109000,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "uPP" = (
@@ -107727,6 +109094,7 @@
 	pixel_x = 30;
 	pixel_y = 13
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -107912,6 +109280,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "uRN" = (
@@ -108385,6 +109754,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"uVZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories/theater)
 "uWd" = (
 /turf/simulated/wall,
 /area/station/medical/hallway/outbranch)
@@ -108448,6 +109821,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "uWx" = (
@@ -108871,6 +110245,10 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"vbm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel)
 "vbx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
@@ -108911,6 +110289,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brigright)
 "vbW" = (
@@ -108967,6 +110346,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/brigright)
+"vcK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/cmf_room)
+"vcQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/bridge/captain_quarters)
 "vcU" = (
 /obj/structure/largecrate,
 /turf/simulated/floor/plating,
@@ -109280,6 +110667,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -109302,6 +110690,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"vgW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/xenobiology)
 "vha" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -109335,6 +110727,7 @@
 	req_access = list(10,13)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "vhv" = (
@@ -109615,6 +111008,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -109656,6 +111050,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "vkP" = (
@@ -109733,6 +111128,7 @@
 	icon_state = "gr_window_polarized";
 	id = "psych"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
 "vlN" = (
@@ -110186,6 +111582,14 @@
 	icon_state = "neutralchoco"
 	},
 /area/station/medical/surgeryobs)
+"vrF" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/portsolar)
 "vrG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -110295,6 +111699,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
 "vsI" = (
@@ -110375,6 +111780,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -110422,6 +111828,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -110433,8 +111840,13 @@
 	req_one_access = list(12,22)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
+"vtF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/psych)
 "vtY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -110492,6 +111904,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -110522,6 +111935,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/tribunal)
 "vuL" = (
@@ -110663,6 +112077,7 @@
 /area/station/rnd/test_area)
 "vwA" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "vwI" = (
@@ -110692,6 +112107,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/outerlabs)
+"vwU" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "vwV" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -110793,6 +112217,7 @@
 	opacity = 0
 	},
 /obj/structure/window/fulltile/reinforced,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "vyC" = (
@@ -110837,6 +112262,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/rust)
 "vzr" = (
@@ -110986,6 +112412,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -111108,6 +112535,10 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"vCO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/reception)
 "vCQ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -111140,6 +112571,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 1
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "vCV" = (
@@ -111263,6 +112695,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/engine,
 /area/station/rnd/misc_lab)
 "vEi" = (
@@ -111342,6 +112775,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -111462,6 +112896,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -111548,6 +112983,7 @@
 	name = "Equipment Storage";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -111622,6 +113058,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "dark"
@@ -111716,11 +113153,16 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
+"vIl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/brigright)
 "vIp" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "vIr" = (
@@ -111893,6 +113335,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -111908,6 +113351,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "vJX" = (
@@ -111967,6 +113411,7 @@
 /area/station/civilian/chapel)
 "vKq" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "browncorner"
@@ -111998,6 +113443,10 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"vKz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/hallway)
 "vKA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -112203,6 +113652,10 @@
 	icon_state = "freezerfloor2"
 	},
 /area/station/security/secdorm)
+"vLY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat)
 "vMn" = (
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/cut/red,
@@ -112343,6 +113796,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -112688,6 +114142,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -112978,6 +114433,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -113157,6 +114613,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/maintenance/brig)
 "vVm" = (
@@ -113731,6 +115188,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brownfull"
 	},
@@ -113741,6 +115199,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "waN" = (
@@ -113858,6 +115317,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "wcf" = (
@@ -114089,6 +115549,10 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/toilet)
+"weM" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/prison)
 "weS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -114202,6 +115666,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brigright)
 "wfG" = (
@@ -114238,6 +115703,10 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/bridgehall)
+"wfN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/secconfhall)
 "wfW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -114436,6 +115905,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "whY" = (
@@ -114667,6 +116137,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "wkf" = (
@@ -114864,6 +116335,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "wmg" = (
@@ -114955,6 +116427,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brownfull"
 	},
@@ -114974,6 +116447,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "wnd" = (
@@ -114984,6 +116458,14 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"wnh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/item/device/flashlight/lamp/fir/special,
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "wnm" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -115248,6 +116730,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "wpM" = (
@@ -115255,6 +116738,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "wpQ" = (
@@ -115348,6 +116832,7 @@
 	req_one_access = list(1,4)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -115357,6 +116842,7 @@
 	c_tag = "Brig Leisure Hallway";
 	dir = 5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -115443,6 +116929,7 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -115528,6 +117015,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/prison)
+"wsq" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycleroffice)
 "wsw" = (
 /obj/machinery/door/airlock/highsecurity{
 	locked = 1;
@@ -115545,6 +117036,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -115592,6 +117084,7 @@
 	name = "Tech Storage";
 	req_access = list(23)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkyellowfull"
@@ -115620,6 +117113,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "wsQ" = (
@@ -115716,6 +117210,7 @@
 	name = "Bar Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood12"
 	},
@@ -116015,6 +117510,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "wyQ" = (
@@ -116295,6 +117791,12 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
+"wCe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/main{
+	name = "Security Equipment"
+	})
 "wCp" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/item/clothing/under/patient_gown,
@@ -116335,6 +117837,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/hos)
+"wCE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "wCN" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
@@ -116547,6 +118053,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -116609,6 +118116,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
+"wFg" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/genetics_cloning)
 "wFh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -116915,6 +118426,7 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -116955,6 +118467,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"wJw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/chiefs_office)
 "wJy" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -117093,6 +118609,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/secconfhall)
 "wLI" = (
@@ -117114,6 +118631,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "wLK" = (
@@ -117343,6 +118861,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"wNF" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/disposal)
 "wNJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/trashcart,
@@ -117654,6 +119176,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"wRR" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/hop_office)
 "wSe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -117920,6 +119446,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -118228,6 +119755,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"wYv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/test_area)
 "wYD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -118263,6 +119794,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -118372,6 +119904,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "wZR" = (
@@ -118885,6 +120418,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "xfc" = (
@@ -119000,6 +120534,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whitechoco"
 	},
@@ -119107,6 +120642,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "xio" = (
@@ -119182,6 +120718,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "xjo" = (
@@ -119438,6 +120975,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "arrivalcorner"
@@ -119606,6 +121144,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "xnE" = (
@@ -119648,6 +121187,7 @@
 	name = "Telecoms Server Access";
 	req_access = list(61)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -119855,6 +121395,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -119965,6 +121506,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "xqM" = (
@@ -119973,8 +121515,13 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
+"xqP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/patients_rooms)
 "xqX" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -120134,6 +121681,10 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
+"xsw" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/primary)
 "xsH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -120204,6 +121755,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "xtE" = (
@@ -120256,6 +121808,10 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/bridge)
+"xud" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/tribunal)
 "xut" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -120738,6 +122294,7 @@
 "xBl" = (
 /obj/structure/mineral_door/wood,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/maintenance/bridge)
 "xBr" = (
@@ -120888,6 +122445,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "xCZ" = (
@@ -121089,6 +122647,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "xGb" = (
@@ -121250,6 +122809,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -121371,6 +122931,7 @@
 /obj/structure/sign/departments/holy{
 	pixel_y = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -121617,6 +123178,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "xLs" = (
@@ -121634,6 +123196,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "xLz" = (
@@ -121669,6 +123232,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/medical/sleeper)
 "xLK" = (
@@ -121708,6 +123272,7 @@
 /area/station/rnd/lab)
 "xMc" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "browncorner"
@@ -121726,6 +123291,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "xMl" = (
@@ -121850,6 +123416,10 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/grass,
 /area/station/maintenance/brig)
+"xOe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry)
 "xOf" = (
 /obj/structure/morgue,
 /turf/simulated/floor{
@@ -121876,6 +123446,10 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/tribunal)
+"xOl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hallway/florahall)
 "xOp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/foods/food_trash,
@@ -122223,6 +123797,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/bridge/teleporter)
 "xSm" = (
@@ -122250,6 +123825,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood{
 	icon_state = "wood7"
 	},
@@ -122268,6 +123844,10 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/checkpoint)
+"xSO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/captain_quarters)
 "xSP" = (
 /obj/structure/object_wall/pod{
 	icon_state = "3,2"
@@ -122345,6 +123925,12 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"xTI" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "xTN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -122582,6 +124168,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "xWW" = (
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "wood_stairs2"
 	},
@@ -122618,6 +124205,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/bridgehall)
 "xXy" = (
@@ -122665,6 +124253,10 @@
 	icon_state = "barber"
 	},
 /area/station/medical/hallway)
+"xXS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/storage)
 "xYn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -122796,6 +124388,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "xZz" = (
@@ -122916,6 +124509,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -122954,6 +124548,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
 "ybm" = (
@@ -123102,6 +124697,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreenfull"
@@ -123168,6 +124764,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/grass,
 /area/station/civilian/bar)
 "ycL" = (
@@ -123337,6 +124934,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "yeW" = (
@@ -123666,6 +125264,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "ykf" = (
@@ -123696,6 +125295,7 @@
 	icon_state = "gr_window_polarized";
 	id = "Library"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "ykV" = (
@@ -123785,6 +125385,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -133698,7 +135299,7 @@ yka
 akw
 rIG
 bZN
-jys
+hna
 wFw
 wFw
 wFw
@@ -133998,7 +135599,7 @@ kHU
 kHU
 pGE
 vkj
-pGE
+vrF
 kHU
 kHU
 kHU
@@ -134253,7 +135854,7 @@ plf
 plf
 plf
 kHU
-pGE
+vrF
 uYD
 pGE
 kHU
@@ -134509,11 +136110,11 @@ plf
 plf
 plf
 plf
-pGE
+vrF
 pGE
 jxa
 pGE
-pGE
+vrF
 plf
 plf
 plf
@@ -134734,7 +136335,7 @@ wFw
 wFw
 mnb
 afM
-xdA
+sWA
 afM
 jzl
 czH
@@ -134745,7 +136346,7 @@ uHr
 uHr
 uHr
 jzl
-czH
+xOe
 czH
 isD
 isD
@@ -134766,7 +136367,7 @@ kHU
 kHU
 kHU
 kHU
-uks
+lRw
 ejQ
 kWW
 gkA
@@ -135284,7 +136885,7 @@ uks
 tYP
 nQe
 jCA
-uks
+lRw
 plf
 plf
 plf
@@ -135496,7 +137097,7 @@ aff
 aFq
 ngx
 ajd
-aFq
+wCE
 aFq
 wFw
 wFw
@@ -135517,10 +137118,10 @@ uHr
 uHr
 czH
 czH
-czH
+xOe
 ivp
 mcz
-uqs
+wNF
 non
 oLF
 ivN
@@ -136047,9 +137648,9 @@ khI
 wOE
 wOE
 uqs
-bQs
-bQs
-bQs
+hfO
+hfO
+hfO
 uqs
 glh
 rrW
@@ -136291,7 +137892,7 @@ kHU
 trc
 sJY
 bOJ
-uqs
+wNF
 wcJ
 gsF
 nNB
@@ -136562,10 +138163,10 @@ aQd
 rRX
 rRX
 rRX
+xXS
 rRX
 rRX
-rRX
-rRX
+xXS
 rRX
 qfw
 wOE
@@ -137320,7 +138921,7 @@ uHr
 czH
 qEE
 czH
-uqs
+wNF
 uqs
 uqs
 uqs
@@ -137330,7 +138931,7 @@ uUl
 dRj
 qOg
 bBK
-rRX
+xXS
 fHk
 lXb
 jtL
@@ -137339,7 +138940,7 @@ jPC
 jqM
 rRX
 jOa
-ahm
+qDr
 kHU
 kHU
 kHU
@@ -137524,12 +139125,12 @@ kHU
 cck
 eEf
 eEf
-pOf
+olc
 eEf
 eEf
-pOf
+olc
 kHU
-pOf
+olc
 its
 cck
 igP
@@ -137554,7 +139155,7 @@ jSl
 sxE
 pWf
 czH
-czH
+xOe
 oGr
 gme
 xPc
@@ -137562,18 +139163,18 @@ czH
 czH
 dkJ
 lIE
+xOe
 czH
 czH
 czH
 czH
 czH
-czH
-czH
+xOe
 isD
 isD
 isD
 czH
-czH
+xOe
 czH
 grO
 wUR
@@ -137581,8 +139182,8 @@ dqu
 tNy
 gJL
 shl
-wUR
-rRX
+cwR
+xXS
 kaO
 rRX
 rRX
@@ -137596,7 +139197,7 @@ jPC
 fBa
 rRX
 pOd
-ahm
+qDr
 plf
 atu
 gpH
@@ -137778,17 +139379,17 @@ plf
 plf
 plf
 kHU
-pOf
+olc
 aqg
 vqr
-pOf
+olc
 cjg
 afI
-pOf
+olc
 kHU
-pOf
+olc
 afG
-pOf
+olc
 kHU
 kHU
 kHU
@@ -137816,15 +139417,15 @@ ogh
 ogh
 ogh
 uww
-czH
+xOe
 tmU
 kfO
 emH
-czH
+xOe
 xtM
 czH
 srq
-czH
+xOe
 hfi
 mcz
 mcz
@@ -138035,22 +139636,22 @@ mRW
 mRW
 plf
 kHU
-pOf
+olc
 dCU
 mWP
-pOf
+olc
 dCU
 mWP
-pOf
+olc
 wkc
-pOf
+olc
 adG
-pOf
+olc
+cib
 wqE
 wqE
 wqE
-wqE
-wqE
+cib
 adS
 afo
 afu
@@ -138070,7 +139671,7 @@ dFQ
 dkc
 kxp
 ofG
-ofG
+eKd
 ofG
 puc
 dkc
@@ -138292,7 +139893,7 @@ svJ
 mRW
 plf
 kHU
-pOf
+olc
 clz
 clz
 beA
@@ -138300,7 +139901,7 @@ clz
 clz
 pOf
 dIs
-pOf
+olc
 hyS
 beA
 qkf
@@ -138312,7 +139913,7 @@ adW
 afp
 afs
 afA
-wqE
+cib
 nlB
 nlB
 nlB
@@ -138334,7 +139935,7 @@ xWW
 tmU
 kfO
 kUo
-czH
+xOe
 ojx
 czH
 sDZ
@@ -138600,11 +140201,11 @@ fjH
 fRG
 eYW
 mcz
-czH
+xOe
 eLf
 efn
 cLp
-wUR
+cwR
 tDX
 kFL
 qUL
@@ -138859,10 +140460,10 @@ eYW
 mcz
 czH
 czH
+iXw
 fXg
 fXg
-fXg
-wUR
+cwR
 klW
 ryA
 rHM
@@ -139083,7 +140684,7 @@ aeh
 afs
 afs
 afE
-wqE
+cib
 nlB
 nlB
 nlB
@@ -139123,7 +140724,7 @@ fXg
 fXg
 bKd
 fXg
-rRX
+xXS
 ieO
 fVU
 wtC
@@ -139347,7 +140948,7 @@ nlB
 nlB
 nlB
 kHU
-svz
+hWa
 ely
 ibW
 cnl
@@ -139358,7 +140959,7 @@ yeE
 yeE
 yeE
 czH
-czH
+xOe
 oYr
 awN
 czH
@@ -139373,7 +140974,7 @@ eYW
 mcz
 mcz
 cFS
-bKd
+bBx
 lmt
 anS
 tVH
@@ -139394,7 +140995,7 @@ bLA
 bZi
 tGl
 rTE
-ohJ
+vwU
 rxR
 lxc
 wPi
@@ -139599,7 +141200,7 @@ jFe
 wqE
 afO
 wqE
-wqE
+cib
 wqE
 czH
 czH
@@ -139651,7 +141252,7 @@ aOi
 aOi
 pgl
 rTE
-ohJ
+vwU
 plf
 kHU
 tAR
@@ -139887,7 +141488,7 @@ adD
 sUy
 mcz
 mvg
-bKd
+bBx
 iol
 uwb
 jtR
@@ -139908,7 +141509,7 @@ kHE
 kYs
 xKO
 rTE
-ohJ
+vwU
 plf
 kHU
 tsK
@@ -140090,7 +141691,7 @@ mRW
 anW
 qJp
 xvp
-wqE
+cib
 afP
 jhm
 nrI
@@ -140407,7 +142008,7 @@ lfs
 pvU
 kNH
 rjM
-bKd
+bBx
 hdK
 dfb
 ksD
@@ -140418,10 +142019,10 @@ jzI
 aAT
 aAT
 bvD
-aAT
+wsq
 aAT
 fjj
-fjj
+eKP
 fjj
 pGa
 pGa
@@ -140438,7 +142039,7 @@ uiI
 uOv
 uOv
 uoF
-pGa
+fto
 plf
 plf
 rLR
@@ -140627,7 +142228,7 @@ ieH
 ieH
 wRi
 wRi
-wRi
+tbv
 wRi
 kbd
 vVE
@@ -140664,7 +142265,7 @@ lVY
 huR
 vhD
 grn
-fXg
+iXw
 eYC
 iyu
 qMZ
@@ -140862,7 +142463,7 @@ dFi
 wJz
 nmw
 ikc
-wqE
+cib
 uat
 wqE
 bfs
@@ -140871,10 +142472,10 @@ tXt
 drt
 vSV
 iBI
-mRW
+hAm
 kdT
 qiZ
-wRi
+tbv
 mMM
 rkI
 kJt
@@ -140932,7 +142533,7 @@ fdM
 hyK
 rWz
 eql
-aAT
+wsq
 aAT
 fjj
 bcE
@@ -141147,7 +142748,7 @@ cNL
 qLf
 atv
 qlw
-wRi
+tbv
 gNz
 wqP
 rGo
@@ -141376,7 +142977,7 @@ ums
 wOg
 gwf
 rwL
-wqE
+cib
 oas
 evu
 bkt
@@ -141384,7 +142985,7 @@ evu
 qPH
 mRW
 mRW
-mRW
+hAm
 mRW
 gbs
 dHX
@@ -141399,7 +143000,7 @@ vpT
 evY
 kyo
 pFe
-laM
+tCb
 xLi
 eMI
 ddd
@@ -141611,7 +143212,7 @@ ruI
 ruI
 ruI
 ruI
-ruI
+pWe
 ruI
 fZZ
 qcu
@@ -141696,7 +143297,7 @@ cDc
 oII
 rda
 atx
-aAT
+wsq
 hfk
 nAc
 fmD
@@ -141704,11 +143305,11 @@ dxo
 fGO
 dbo
 lcK
-aAT
+wsq
 kWd
 bfl
 pXk
-pGa
+fto
 iut
 hOh
 pwh
@@ -141864,7 +143465,7 @@ mRW
 mRW
 mRW
 ruI
-ruI
+pWe
 sUz
 mot
 tmV
@@ -141894,7 +143495,7 @@ icu
 wqE
 wqE
 wqE
-wqE
+cib
 wqE
 mRW
 iHs
@@ -141904,7 +143505,7 @@ gbs
 igp
 wRi
 wRi
-wRi
+tbv
 wRi
 sYv
 wRi
@@ -141933,7 +143534,7 @@ fOv
 fiP
 mIY
 qWl
-dvz
+dBN
 xeL
 onc
 qhy
@@ -142175,7 +143776,7 @@ hsD
 gel
 eoK
 pKK
-vFZ
+gJV
 ihg
 jHd
 fwk
@@ -142185,7 +143786,7 @@ gjn
 cUF
 cUF
 hkV
-dvz
+dBN
 dvz
 dvz
 vTf
@@ -142216,7 +143817,7 @@ wHq
 rLk
 aAT
 fBP
-aAT
+wsq
 aAT
 bWf
 iyL
@@ -142422,11 +144023,11 @@ mRW
 csl
 ohR
 gbs
+tbv
 wRi
 wRi
 wRi
-wRi
-wRi
+tbv
 wRi
 nyB
 ttD
@@ -142640,7 +144241,7 @@ bTs
 krg
 sHV
 gLM
-ruI
+pWe
 ruI
 ruI
 mys
@@ -142689,7 +144290,7 @@ wRi
 vHk
 wRi
 wRi
-wRi
+tbv
 dSp
 wqP
 erF
@@ -142699,7 +144300,7 @@ gjn
 cUF
 cUF
 eAo
-ear
+xsw
 oVs
 tQr
 jOG
@@ -142708,7 +144309,7 @@ uul
 gXv
 keN
 jUW
-fXg
+iXw
 fXg
 nmb
 fXg
@@ -142727,7 +144328,7 @@ oYx
 miq
 ptN
 iUy
-rLk
+fzs
 iag
 hiK
 wPl
@@ -142903,15 +144504,15 @@ aWu
 oXD
 lnu
 oMm
+qFx
 oMm
 oMm
-oMm
-oMm
+qFx
 oMm
 sCr
 sCr
 sCr
-sCr
+dCq
 sCr
 sCr
 sCr
@@ -142926,9 +144527,9 @@ dVb
 ikj
 cNr
 cNr
+gQz
 cNr
-cNr
-cNr
+gQz
 cNr
 cNr
 bsW
@@ -142977,7 +144578,7 @@ usj
 tyE
 sDg
 iLz
-rLk
+fzs
 jOr
 sdR
 hlg
@@ -143149,13 +144750,13 @@ emF
 dgr
 cfv
 gFK
-emF
+uNA
 lpC
 mOe
 bpX
 aPa
 oMm
-oMm
+qFx
 oMm
 oMm
 oMm
@@ -143215,12 +144816,12 @@ ear
 ear
 vER
 mip
-agH
+rzo
 rkh
 rAv
 mwL
 fYj
-agH
+rzo
 tpP
 lLc
 gOL
@@ -143228,19 +144829,19 @@ vKb
 jew
 fXg
 fXg
+iXw
 fXg
 fXg
 fXg
+iXw
 fXg
-fXg
-fXg
 rLk
 rLk
 rLk
 rLk
 rLk
 rLk
-rLk
+fzs
 rLk
 pvx
 kzI
@@ -143402,7 +145003,7 @@ mRW
 mRW
 fRo
 rNu
-emF
+uNA
 eer
 tvR
 gQE
@@ -143426,7 +145027,7 @@ ncT
 puY
 dSL
 eyV
-ncT
+bZe
 giR
 rrx
 ery
@@ -143437,7 +145038,7 @@ vBb
 wkp
 rZn
 gbs
-cNr
+gQz
 pmh
 abT
 shh
@@ -143465,7 +145066,7 @@ nye
 gOv
 sfz
 pcn
-fjj
+eKP
 pim
 sNV
 uKD
@@ -143522,7 +145123,7 @@ uiI
 uOv
 uOv
 uOv
-pGa
+fto
 plf
 plf
 plf
@@ -143689,7 +145290,7 @@ kTN
 rtc
 odx
 odx
-sCr
+dCq
 mHN
 mRW
 mRW
@@ -143734,7 +145335,7 @@ xrn
 ehe
 tie
 ikA
-agH
+rzo
 fca
 nNU
 fjj
@@ -143936,7 +145537,7 @@ gri
 blI
 lJo
 cHA
-ncT
+bZe
 dud
 cYS
 cGg
@@ -143979,7 +145580,7 @@ tiK
 gOv
 sfz
 pcn
-fjj
+eKP
 wNt
 poH
 fjj
@@ -144000,10 +145601,10 @@ fBx
 fBx
 fBx
 qlD
-qlD
+gwV
 qZb
 qlD
-qlD
+gwV
 axb
 axb
 axb
@@ -144194,14 +145795,14 @@ mir
 xcF
 raq
 ncT
-ncT
+bZe
 ncT
 ncT
 ncT
 nCU
 mbb
 ncT
-ncT
+bZe
 rBn
 sCr
 bTD
@@ -144238,15 +145839,15 @@ bcu
 czH
 fjj
 fjj
-fjj
+eKP
 fjj
 fjj
 mkG
 fjj
-agH
+rzo
 agH
 dIm
-agH
+rzo
 agH
 pKS
 nNU
@@ -144430,7 +146031,7 @@ nIw
 gbs
 mRW
 mRW
-emF
+uNA
 fZh
 vdB
 eXB
@@ -144504,7 +146105,7 @@ nZW
 ujk
 ybP
 ncB
-fjj
+eKP
 qpR
 keN
 fBx
@@ -144691,7 +146292,7 @@ emF
 ett
 iqk
 oCu
-emF
+uNA
 lpC
 cSi
 abv
@@ -144720,7 +146321,7 @@ jXX
 sCr
 bWJ
 goZ
-cNr
+gQz
 vOu
 jfG
 bkd
@@ -144764,7 +146365,7 @@ mqB
 wpM
 uIK
 nNU
-fBx
+oLj
 tYW
 hYS
 qUE
@@ -144780,7 +146381,7 @@ pzr
 opW
 lWp
 fGj
-axb
+prD
 ryH
 jIR
 fjj
@@ -145035,7 +146636,7 @@ cWG
 axb
 axb
 tZD
-axb
+prD
 axb
 fjj
 gZR
@@ -145259,7 +146860,7 @@ cwe
 crV
 cMJ
 mOQ
-mOQ
+uNp
 mOQ
 fZV
 mOQ
@@ -145289,7 +146890,7 @@ lho
 uUX
 gQM
 eZe
-axb
+prD
 lSm
 cQU
 hQP
@@ -145311,7 +146912,7 @@ rBj
 rBj
 lrD
 rBj
-rBj
+jMU
 rBj
 fjj
 fjj
@@ -145512,7 +147113,7 @@ uRf
 uwC
 aPB
 qzc
-qzc
+hml
 qzc
 mOQ
 mOQ
@@ -145520,7 +147121,7 @@ ckx
 npA
 eVp
 wHo
-mOQ
+uNp
 fVR
 uBq
 uBq
@@ -145528,11 +147129,11 @@ sHT
 uBq
 uBq
 iHb
-mOQ
+uNp
 emu
 mLs
 dEZ
-fjj
+eKP
 dYw
 bBf
 hAI
@@ -145540,17 +147141,17 @@ fBx
 fBx
 fBx
 fBx
-fBx
+oLj
 mic
 lho
 uUX
 gQM
 xRN
 axb
+prD
 axb
 axb
-axb
-axb
+prD
 fjj
 gTZ
 fjj
@@ -145559,10 +147160,10 @@ fjj
 fjj
 rBj
 rBj
+jMU
 rBj
 rBj
-rBj
-rBj
+jMU
 sPr
 aKp
 gzB
@@ -145711,7 +147312,7 @@ tvZ
 crC
 qfl
 san
-san
+rEu
 san
 san
 ndP
@@ -145750,12 +147351,12 @@ dZo
 liO
 jcE
 cNr
+gQz
 cNr
 cNr
 cNr
 cNr
-cNr
-cNr
+gQz
 cNr
 cNr
 cNr
@@ -145785,7 +147386,7 @@ fii
 fii
 kqh
 uBq
-hBy
+hEb
 emu
 mLs
 ttx
@@ -145981,7 +147582,7 @@ lLq
 cSi
 abv
 nLs
-oMm
+qFx
 cTi
 tjB
 kff
@@ -146002,7 +147603,7 @@ xIQ
 uYM
 dFm
 cqS
-oMm
+qFx
 sfl
 mqy
 dVb
@@ -146060,7 +147661,7 @@ umV
 toJ
 gQM
 lwN
-ats
+tSy
 dqQ
 kqY
 uOL
@@ -146083,9 +147684,9 @@ adx
 clm
 adx
 bRn
+jMU
 rBj
-rBj
-rBj
+jMU
 rHp
 rHp
 rHp
@@ -146250,7 +147851,7 @@ gOl
 jHW
 hmm
 gOl
-gOl
+weM
 jHW
 lAm
 xqH
@@ -146273,7 +147874,7 @@ dVb
 gbs
 dVb
 gbs
-mtd
+kza
 bqL
 mLs
 nJA
@@ -146291,7 +147892,7 @@ wAw
 mBz
 wAw
 mBz
-hBy
+hEb
 uBq
 asu
 kVJ
@@ -146303,10 +147904,10 @@ hBy
 oBk
 mLs
 dEZ
-fjj
+eKP
 uIK
 nNU
-srY
+phh
 lZV
 sFz
 oFi
@@ -146323,12 +147924,12 @@ xec
 xec
 bhE
 ats
-ats
+tSy
 ats
 xZO
 ats
 usc
-ats
+tSy
 oaj
 aea
 aea
@@ -146525,7 +148126,7 @@ rKF
 rKF
 rKF
 rKF
-rKF
+xud
 raa
 rKF
 rKF
@@ -146534,14 +148135,14 @@ rKF
 aax
 qHr
 nJA
-qzc
+hml
 pWi
 wsQ
 pWi
 nSP
 lNH
 jNf
-qzc
+hml
 nfy
 gZx
 grt
@@ -146556,7 +148157,7 @@ fOa
 gzs
 qyl
 uBq
-hBy
+hEb
 emu
 mLs
 fKc
@@ -146565,7 +148166,7 @@ nms
 tMM
 srY
 srY
-srY
+phh
 wMP
 srY
 srY
@@ -146738,7 +148339,7 @@ jJY
 tvZ
 crC
 gbs
-san
+rEu
 uCN
 hHE
 bdh
@@ -146760,7 +148361,7 @@ gOl
 uSa
 bTd
 bme
-gOl
+weM
 fec
 uHt
 bme
@@ -146768,17 +148369,17 @@ gOl
 fec
 bTd
 cIw
-oMm
+qFx
 uWv
 mAT
 aol
 nSw
-oMm
+qFx
 gbs
 haN
 nlh
 gNi
-rKF
+xud
 bje
 rmm
 bqC
@@ -146825,13 +148426,13 @@ srY
 kkp
 pZK
 sXN
-srY
+phh
 vQB
 lho
 toJ
 gQM
 eZe
-ats
+tSy
 fab
 acp
 acp
@@ -146999,7 +148600,7 @@ san
 hHE
 hHE
 hHE
-fJh
+wfN
 ajf
 oRY
 xvI
@@ -147044,11 +148645,11 @@ xCD
 kzh
 fje
 jGc
-rKF
+xud
 eAF
 aFo
 xbI
-qzc
+hml
 eil
 eTc
 xQd
@@ -147070,7 +148671,7 @@ fii
 dnn
 fSg
 nAG
-hBy
+hEb
 emu
 mLs
 quG
@@ -147078,7 +148679,7 @@ qlD
 qlD
 hwS
 srY
-srY
+phh
 srY
 srY
 srY
@@ -147331,7 +148932,7 @@ sbi
 lfa
 qIR
 dEZ
-qlD
+gwV
 oEY
 kQX
 nll
@@ -147339,7 +148940,7 @@ wJK
 tMA
 oEY
 oEY
-qlD
+gwV
 lTy
 lho
 toJ
@@ -147353,7 +148954,7 @@ lLo
 lLo
 ats
 jgN
-ats
+tSy
 ats
 ats
 ats
@@ -147508,7 +149109,7 @@ dVb
 jcE
 dVb
 gbs
-san
+rEu
 koq
 hpl
 pVG
@@ -147584,7 +149185,7 @@ oxC
 gzs
 weS
 uBq
-hBy
+hEb
 emu
 mLs
 dEZ
@@ -147613,7 +149214,7 @@ dTe
 nYV
 rEx
 eaq
-ats
+tSy
 jHv
 vvN
 uwW
@@ -147776,7 +149377,7 @@ lIg
 uZE
 xZb
 xZb
-xZb
+nFG
 sgT
 tEY
 iwg
@@ -147788,7 +149389,7 @@ jBL
 btT
 axz
 jKu
-skN
+qUD
 skN
 rxH
 skN
@@ -147869,7 +149470,7 @@ pYZ
 nnE
 ats
 ats
-ats
+tSy
 ats
 ijh
 odd
@@ -148136,7 +149737,7 @@ syB
 xKo
 uwW
 guU
-rBj
+jMU
 wYO
 rHp
 waI
@@ -148284,7 +149885,7 @@ aeB
 iyH
 ohH
 xEk
-cbk
+ccu
 cbk
 jaw
 ylX
@@ -148333,7 +149934,7 @@ rKF
 jwu
 qHr
 nJA
-qzc
+hml
 dTr
 kyK
 eFp
@@ -148344,7 +149945,7 @@ tic
 eFp
 mGD
 xnm
-qzc
+hml
 xef
 elx
 azm
@@ -148537,7 +150138,7 @@ rXC
 pWX
 cqR
 pxM
-pxM
+wCe
 pxM
 pxM
 pxM
@@ -148610,7 +150211,7 @@ bjW
 oVJ
 rJR
 fZV
-mOQ
+uNp
 ifQ
 mOQ
 ruK
@@ -148624,7 +150225,7 @@ wId
 sdB
 sdB
 sdB
-qlD
+gwV
 vQB
 lho
 toJ
@@ -148829,7 +150430,7 @@ arP
 cGO
 bsD
 tLi
-oMm
+qFx
 xio
 ccT
 eRr
@@ -148843,7 +150444,7 @@ qoI
 xoJ
 van
 pyG
-rKF
+xud
 cXL
 qHr
 abr
@@ -148866,19 +150467,19 @@ hSM
 jBz
 hSM
 hSM
-hSM
+iKm
 mOQ
 mOQ
 mOQ
 jeH
 lnY
 oJQ
-qlD
-qlD
+gwV
+gwV
 cuu
+gwV
 qlD
-qlD
-qlD
+gwV
 cuu
 qlD
 qlD
@@ -148887,7 +150488,7 @@ fpd
 seU
 rIJ
 oBW
-lLo
+uxT
 lLo
 ssA
 dGG
@@ -148896,23 +150497,23 @@ lLo
 ats
 fkn
 ats
+tSy
 ats
 ats
-ats
-rBj
+jMU
 rBj
 sGG
 lpM
 sAl
-rBj
+jMU
+eht
+lBs
 eht
 eht
+lBs
 eht
 eht
-eht
-eht
-eht
-eht
+lBs
 eht
 eht
 rHp
@@ -149156,7 +150757,7 @@ bcc
 jfd
 vOU
 fcP
-qlD
+gwV
 wVH
 wWt
 cMb
@@ -149307,7 +150908,7 @@ mRW
 mRW
 mRW
 mRW
-pxM
+wCe
 abh
 abh
 qJP
@@ -149400,7 +151001,7 @@ jUp
 thX
 rAQ
 gSy
-jUp
+jAi
 jUp
 jUp
 wsb
@@ -149622,18 +151223,18 @@ puj
 inE
 sfm
 qSV
-dlp
+tJv
 ycJ
 czd
 cVI
 mME
-dTp
-dlp
+xTI
+tJv
 ycJ
 cVI
 qPx
 dTp
-dlp
+tJv
 czd
 ycJ
 cVI
@@ -149657,7 +151258,7 @@ qOD
 qOD
 tsW
 mWq
-mWq
+dLb
 mWq
 mWq
 mWq
@@ -149670,7 +151271,7 @@ rlX
 mWq
 mWq
 mWq
-mWq
+dLb
 mWq
 vjJ
 wos
@@ -149885,9 +151486,9 @@ ryx
 xQG
 oSJ
 dTp
-oDZ
-bYg
-xQG
+bIB
+wnh
+bIB
 kti
 dTp
 mJs
@@ -149914,7 +151515,7 @@ kSN
 nBf
 dBU
 fUj
-kSN
+hri
 kSN
 kSN
 kSN
@@ -150078,7 +151679,7 @@ mRW
 gbs
 gbs
 jcE
-pxM
+wCe
 mWZ
 qqZ
 vTu
@@ -150166,7 +151767,7 @@ qlD
 nLm
 kOa
 nLm
-qlD
+gwV
 dlE
 pfY
 ktM
@@ -150184,7 +151785,7 @@ bGi
 hOq
 kOa
 nLm
-qlD
+gwV
 dlE
 aoI
 baG
@@ -150370,7 +151971,7 @@ iBl
 hGM
 mxp
 dmC
-cuX
+doD
 uku
 omg
 omg
@@ -150418,28 +152019,28 @@ bbD
 akg
 akg
 akg
+mpL
 akg
+mpL
 akg
+mpL
 akg
-akg
-akg
-akg
-akg
+mpL
 akg
 mwd
 akg
+mpL
 akg
-akg
-akg
+mpL
 akg
 fqJ
 pYX
 pYX
+vbm
 pNq
 pNq
 pNq
-pNq
-pNq
+vbm
 pNq
 pNq
 dbf
@@ -150666,13 +152267,13 @@ acy
 acF
 acy
 acV
-gYQ
+uVZ
 bBN
 tOY
 bLF
 dfk
 fhr
-akg
+mpL
 jqk
 lot
 rpE
@@ -150698,13 +152299,13 @@ pNq
 dKw
 cOq
 qGb
-pNq
+vbm
 djA
 aoI
-baG
+gDW
 gQM
 uCq
-eht
+lBs
 cGw
 gHn
 jvb
@@ -150854,13 +152455,13 @@ dnW
 uVO
 mbj
 lfH
-tWL
+gCF
 tWL
 wme
 qPb
 fJz
 tWL
-tWL
+gCF
 xcK
 wKY
 oWa
@@ -150871,7 +152472,7 @@ wkz
 knf
 hUm
 mgk
-mgk
+gUW
 mgk
 mgk
 isW
@@ -150933,11 +152534,11 @@ akg
 eSA
 pLY
 fOH
-akg
+mpL
 hwX
 csz
 jAK
-akg
+mpL
 aWq
 trr
 kyj
@@ -150950,7 +152551,7 @@ xxT
 kQJ
 pNq
 pNq
-pNq
+vbm
 pNq
 ncK
 pNq
@@ -150962,11 +152563,11 @@ fUo
 xIR
 pNq
 bAp
+pBz
 bAp
 bAp
-bAp
-bAp
-bAp
+pBz
+pBz
 oQd
 bAp
 bAp
@@ -151143,7 +152744,7 @@ azK
 ylU
 cuX
 peo
-omg
+fjw
 wLp
 gyq
 fWv
@@ -151365,7 +152966,7 @@ hNT
 nmC
 mLa
 tWL
-tWL
+gCF
 tWL
 tWL
 tWL
@@ -151398,7 +152999,7 @@ eTN
 skO
 cOR
 gFU
-cuX
+doD
 qxU
 omg
 omg
@@ -151432,7 +153033,7 @@ nWX
 aGp
 abt
 acm
-uWs
+tKe
 kEQ
 oRS
 ilL
@@ -151462,7 +153063,7 @@ eFq
 akg
 tkS
 iVU
-pNq
+vbm
 aGK
 nhP
 cCX
@@ -151484,7 +153085,7 @@ cmq
 qmC
 kqT
 bAp
-bAp
+pBz
 gAd
 kHU
 kHU
@@ -151640,7 +153241,7 @@ dsQ
 eBw
 lJn
 gyJ
-uSD
+qFU
 uSD
 eVq
 mQz
@@ -151650,7 +153251,7 @@ ckE
 mvq
 nRc
 kHX
-cuX
+doD
 eJI
 wLU
 moR
@@ -151674,7 +153275,7 @@ uIC
 jeH
 aFo
 oJQ
-oCg
+bZd
 oCg
 oCg
 jLo
@@ -151710,13 +153311,13 @@ neS
 nwq
 nwq
 oPc
-akg
+mpL
 aGm
 hAC
 oSS
 tjX
 dte
-akg
+mpL
 bGB
 tOi
 pNq
@@ -151888,7 +153489,7 @@ upp
 htU
 vGh
 rIb
-tWL
+gCF
 trC
 dCn
 mnm
@@ -151921,7 +153522,7 @@ ccC
 pmq
 xVT
 kso
-omg
+fjw
 eCN
 qQE
 eCN
@@ -152148,7 +153749,7 @@ rIb
 tWL
 dsQ
 dsQ
-dsQ
+uiz
 dsQ
 dsQ
 uok
@@ -152178,7 +153779,7 @@ omg
 omg
 omg
 omg
-omg
+fjw
 dXU
 gIw
 wEK
@@ -152207,14 +153808,14 @@ gYQ
 gYQ
 ibG
 gYQ
+uVZ
 gYQ
-gYQ
-gYQ
+uVZ
 tOY
 tWu
 mLs
 dEZ
-akg
+mpL
 akg
 ahd
 lPj
@@ -152445,7 +154046,7 @@ uIC
 bOp
 qHr
 uWp
-oCg
+bZd
 bSl
 vTX
 dcL
@@ -152465,13 +154066,13 @@ usu
 kKU
 yja
 avl
-gYQ
-jnj
+uVZ
+uLd
 jnj
 sDk
 mLs
 wNa
-akg
+mpL
 bVn
 jxu
 vtl
@@ -152481,7 +154082,7 @@ jKL
 mDu
 nwq
 erq
-akg
+mpL
 iRD
 jDV
 cka
@@ -152683,7 +154284,7 @@ sbo
 cwY
 lHC
 eLo
-cuX
+doD
 dLS
 peo
 nmC
@@ -152692,7 +154293,7 @@ rUu
 miO
 dbR
 nRU
-eCN
+gnk
 hMC
 lms
 wTt
@@ -152747,7 +154348,7 @@ txI
 ttB
 rQF
 wTc
-pNq
+vbm
 lgC
 nhP
 gMd
@@ -152767,7 +154368,7 @@ aqP
 rAO
 cmq
 kqT
-kqT
+aHy
 bAp
 bAp
 gAd
@@ -152911,7 +154512,7 @@ jCB
 wHi
 rWC
 kHt
-xQw
+jHB
 lIV
 cgZ
 luw
@@ -152936,14 +154537,14 @@ isW
 isW
 isW
 cuX
-cuX
+doD
 cuX
 cuX
 cuX
 cuX
 nhh
 peo
-nmC
+vIl
 qNy
 aZQ
 eFu
@@ -152967,7 +154568,7 @@ sYK
 oCg
 tsw
 tsw
-oCg
+bZd
 hAU
 euZ
 sIV
@@ -153005,27 +154606,27 @@ ndv
 ndv
 ndv
 ndv
-qbh
+jmG
 qbh
 qtd
 qbh
 pNq
 adX
 adB
-vts
+fHN
 fWc
-vts
+fHN
 bHr
 mwx
 vts
-vts
+fHN
 vts
 eZB
 bAp
 hXu
 vIy
 vIy
-bAp
+pBz
 plf
 plf
 plf
@@ -153207,21 +154808,21 @@ pqi
 tEw
 pFL
 eCN
-eCN
+gnk
 cTK
 eCN
 eCN
-eCN
+gnk
 eCN
 gHG
 qHr
 uWp
-oCg
+bZd
 oCg
 oCg
 odu
 oCg
-oCg
+bZd
 dlp
 dVE
 oCg
@@ -153231,18 +154832,18 @@ tdF
 iEG
 uVT
 gYQ
+uVZ
 gYQ
-gYQ
-gYQ
+uVZ
 gYQ
 gYQ
 gYQ
 suw
-tOY
+iNZ
 sDk
 mLs
 uWp
-akg
+mpL
 xPp
 qGz
 bxp
@@ -153462,12 +155063,12 @@ nmC
 nmC
 nmC
 nmC
-nmC
+vIl
 nmC
 mkf
 tdF
 bOp
-bOp
+mBu
 bOp
 bOp
 dNl
@@ -153503,7 +155104,7 @@ akg
 akg
 gBc
 fmi
-akg
+mpL
 sww
 jKL
 kON
@@ -153537,7 +155138,7 @@ vts
 enX
 bAp
 bAp
-bAp
+pBz
 bAp
 bAp
 iVU
@@ -153689,7 +155290,7 @@ tRx
 xQw
 xQw
 xQw
-xQw
+jHB
 hIW
 kNR
 xQw
@@ -153701,7 +155302,7 @@ afY
 uxo
 rHr
 epo
-mgk
+gUW
 cTy
 wHR
 nmC
@@ -153724,7 +155325,7 @@ bYG
 nrN
 rlk
 rlk
-rlk
+eqa
 rlk
 rlk
 rlk
@@ -153945,7 +155546,7 @@ wkJ
 rGQ
 cGD
 epQ
-xQw
+jHB
 pmo
 nLs
 nLs
@@ -154013,7 +155614,7 @@ qUU
 qUU
 sRT
 qUU
-akg
+mpL
 xRe
 xBr
 vFo
@@ -154023,7 +155624,7 @@ fkE
 qUl
 thW
 uHE
-akg
+mpL
 qEx
 rMA
 qEx
@@ -154040,14 +155641,14 @@ qbh
 wAs
 bur
 bur
-vts
+fHN
 wsl
 fRr
 adC
 fTn
 adL
 ryX
-vts
+fHN
 fWr
 dsJ
 yeW
@@ -154206,12 +155807,12 @@ dTW
 rnk
 gal
 lIg
-lIg
+uMl
 iXS
 oGP
 xFC
 uSD
-uSD
+qFU
 mgk
 mgk
 mgk
@@ -154244,16 +155845,16 @@ mXl
 vTo
 kxt
 dKv
+gdn
 dKv
+gdn
 dKv
-dKv
-dKv
 qZZ
 qZZ
+dYn
 qZZ
 qZZ
-qZZ
-qZZ
+dYn
 aKu
 heO
 nhA
@@ -154296,7 +155897,7 @@ qbh
 qbh
 pNq
 vtD
-pNq
+vbm
 vts
 hVs
 wsl
@@ -154454,7 +156055,7 @@ nqO
 qaS
 nmC
 xQM
-vAm
+rIK
 uKQ
 uKQ
 uKQ
@@ -154467,7 +156068,7 @@ sVt
 mFl
 dOy
 sSm
-pmU
+hKP
 uav
 ivd
 aVA
@@ -154492,7 +156093,7 @@ ehP
 oUA
 vZB
 dKv
-dKv
+gdn
 dKv
 dKv
 dKv
@@ -154514,7 +156115,7 @@ qZZ
 bfJ
 stM
 gfi
-qZZ
+dYn
 noA
 rmb
 bBX
@@ -154523,10 +156124,10 @@ cCr
 bgK
 iwZ
 qZZ
-qZZ
+dYn
 dtr
 dtr
-qZZ
+dYn
 akg
 vvx
 dyU
@@ -154557,7 +156158,7 @@ iVU
 vts
 vts
 vts
-vts
+fHN
 vts
 vts
 vts
@@ -154717,10 +156318,10 @@ jUk
 uKQ
 uJK
 uKQ
-uKQ
+jgm
 byR
 lvx
-uKQ
+jgm
 tlC
 nXr
 tlC
@@ -154761,7 +156362,7 @@ eJK
 llc
 fOD
 amV
-dKv
+gdn
 nax
 euV
 euV
@@ -154785,10 +156386,10 @@ kVA
 kVA
 jKc
 akg
-akg
+mpL
 gBc
 qax
-akg
+mpL
 akg
 kQJ
 kQJ
@@ -155005,7 +156606,7 @@ cBZ
 tSd
 dcg
 hNT
-dKv
+gdn
 ldi
 fZc
 wdX
@@ -155024,11 +156625,11 @@ abd
 abn
 iJe
 xRI
-nVU
+jQq
 rfV
 eKs
 mgZ
-nVU
+jQq
 dyt
 acv
 acu
@@ -155049,20 +156650,20 @@ kVA
 pYX
 kEU
 xdd
-xdd
+mzo
 uEt
 tUR
 cGG
 vVm
 aFF
 uEt
-xdd
+mzo
 xzK
 hGk
 lmI
 uWd
 uWd
-uWd
+tMs
 uWd
 uWd
 sIO
@@ -155281,11 +156882,11 @@ nQs
 qVz
 nON
 abn
-nVU
+jQq
 hAt
 cHc
 lUC
-nVU
+jQq
 acn
 kVA
 mPo
@@ -155325,7 +156926,7 @@ eDG
 diH
 uci
 bke
-dtp
+mDe
 dtp
 dtp
 dtp
@@ -155498,7 +157099,7 @@ ddr
 tvK
 hed
 qOG
-ivd
+mwG
 bfn
 hOY
 nmC
@@ -155531,7 +157132,7 @@ uRN
 aaR
 aaR
 aaR
-aaR
+nML
 dKv
 aaZ
 kVA
@@ -155577,7 +157178,7 @@ cRL
 iOp
 nyq
 hSQ
-uWd
+tMs
 rJl
 bsf
 mOU
@@ -155817,7 +157418,7 @@ iQU
 kVA
 hkf
 pHP
-pYX
+lEy
 nXs
 xdd
 qUw
@@ -155831,10 +157432,10 @@ xdd
 kgR
 ucQ
 mmD
-uWd
+tMs
 uED
 uWd
-uWd
+tMs
 uWd
 uWd
 aPF
@@ -155999,7 +157600,7 @@ fpr
 qNy
 qNy
 mqu
-vAm
+rIK
 dlY
 qQx
 pgv
@@ -156011,7 +157612,7 @@ qYA
 hBX
 bmU
 qsv
-ivd
+mwG
 ivd
 kvR
 nmC
@@ -156052,11 +157653,11 @@ hMW
 abo
 uEd
 abK
-nVU
+jQq
 rfV
 tRb
 mgZ
-nVU
+jQq
 aco
 kbS
 uEd
@@ -156084,7 +157685,7 @@ wqx
 hWg
 xaL
 ggO
-xdd
+mzo
 uWd
 vtx
 cNW
@@ -156262,8 +157863,8 @@ rBe
 bUr
 jry
 cpQ
-vAm
-ivd
+rIK
+mwG
 ivd
 ivd
 cwK
@@ -156290,7 +157891,7 @@ cBZ
 ngm
 fpZ
 plD
-dKv
+gdn
 hMp
 qEP
 toX
@@ -156303,7 +157904,7 @@ rZk
 gyA
 kyf
 tBS
-dKv
+gdn
 bgK
 eca
 duo
@@ -156330,7 +157931,7 @@ eOh
 mKC
 neV
 efV
-xqf
+lrx
 xqf
 tfZ
 xqf
@@ -156514,7 +158115,7 @@ nmC
 nmC
 nmC
 vAm
-vAm
+rIK
 vAm
 vAm
 vAm
@@ -156566,7 +158167,7 @@ abu
 gZo
 uEd
 abN
-nVU
+jQq
 rfV
 tRb
 ius
@@ -156814,7 +158415,7 @@ riP
 aaB
 aaO
 aaR
-aaR
+nML
 aaR
 aaR
 dKv
@@ -156863,7 +158464,7 @@ mQG
 ber
 jBp
 jBp
-jBp
+gMi
 mIw
 grS
 jBp
@@ -157111,7 +158712,7 @@ xqf
 xdd
 xdd
 xdd
-xdd
+mzo
 xdd
 wZR
 bxm
@@ -157124,13 +158725,13 @@ foA
 lcd
 eRk
 oZs
-jKh
+sWd
 bgi
 gKm
 ibk
 uKO
 ezt
-jKh
+sWd
 jka
 urG
 kbi
@@ -157293,17 +158894,17 @@ aov
 aov
 aov
 aov
+pWL
 aov
 aov
 aov
 aov
-aov
-aov
+pWL
 wGW
 wGW
+uMJ
 wGW
-wGW
-wGW
+uMJ
 wGW
 jnX
 taN
@@ -157556,7 +159157,7 @@ kXw
 uNq
 cRV
 cZe
-wGW
+uMJ
 fgf
 jxy
 neI
@@ -157575,7 +159176,7 @@ cBZ
 nmC
 nmC
 ydq
-dKv
+gdn
 iwu
 kms
 aaw
@@ -157594,11 +159195,11 @@ oCP
 aaL
 kVA
 abP
-nVU
+jQq
 dhR
 jPi
 joP
-nVU
+jQq
 kVA
 acx
 ulm
@@ -157805,7 +159406,7 @@ kHU
 aov
 aov
 vrI
-aov
+pWL
 bCB
 gKj
 ujc
@@ -157833,7 +159434,7 @@ uTa
 uHU
 dcg
 dKv
-dKv
+gdn
 dKv
 sOR
 aaI
@@ -157845,17 +159446,17 @@ clj
 dBS
 dBS
 dBS
-dKv
+gdn
 bBX
 por
 abx
 jGg
 qZu
-nVU
+jQq
 rfV
 jPi
 hcC
-nVU
+jQq
 abE
 amv
 rET
@@ -157902,11 +159503,11 @@ gOg
 aDA
 aKA
 mAu
-mAu
+muA
 bin
 mAu
 mAu
-mAu
+muA
 mAu
 fNU
 iVU
@@ -158086,7 +159687,7 @@ bmF
 eqt
 eIn
 oEO
-uTa
+kNj
 shY
 ydq
 uTa
@@ -158101,18 +159702,18 @@ dKv
 dKv
 dKv
 dKv
-dKv
+gdn
 dKv
 qZZ
 xzY
 bBX
 bBX
 bBX
-nVU
+jQq
 rfV
 jPi
 hcC
-nVU
+jQq
 noA
 pxq
 xQb
@@ -158124,7 +159725,7 @@ iwZ
 acL
 iwZ
 qZZ
-qZZ
+dYn
 jLO
 dtr
 qZZ
@@ -158134,7 +159735,7 @@ kOw
 kOw
 qwX
 qwX
-qwX
+qDP
 xLE
 mjx
 bEN
@@ -158346,7 +159947,7 @@ uTa
 uTa
 nmC
 wfE
-uTa
+kNj
 uTa
 uTa
 srx
@@ -158377,7 +159978,7 @@ qZZ
 qZZ
 qZZ
 qZZ
-qZZ
+dYn
 qZZ
 qZZ
 qZZ
@@ -158421,7 +160022,7 @@ gXX
 slT
 iOZ
 tqb
-mAu
+muA
 uqP
 udN
 pYX
@@ -159097,7 +160698,7 @@ wdP
 vdD
 rUi
 tFV
-aov
+pWL
 nOz
 gfV
 hkN
@@ -159338,7 +160939,7 @@ bFi
 oYU
 tsz
 bFi
-bFi
+gwd
 vzl
 tsz
 pMF
@@ -159361,7 +160962,7 @@ nSc
 dYV
 kwM
 kwM
-wGW
+uMJ
 xpP
 eIn
 bdN
@@ -159372,12 +160973,12 @@ ieG
 cDC
 uTa
 uTa
-jIl
+fGb
 fiA
-kVq
+vcK
 kVq
 eoS
-kVq
+vcK
 kVq
 uTa
 xrx
@@ -159590,7 +161191,7 @@ kHU
 kHU
 kHU
 kHU
-bFi
+gwd
 cQM
 pOv
 jIc
@@ -159600,7 +161201,7 @@ tiM
 tnG
 vrU
 cCY
-bFi
+gwd
 ixJ
 lYj
 ixJ
@@ -159664,7 +161265,7 @@ cRu
 fuG
 xoQ
 jWS
-jWS
+vcQ
 jWS
 xoQ
 wig
@@ -159705,10 +161306,10 @@ vDa
 tup
 nux
 nux
-nux
+scZ
 nux
 kMH
-kMH
+bGH
 kMH
 pYX
 qoq
@@ -159885,7 +161486,7 @@ fmU
 aSB
 rQo
 oUH
-uTa
+kNj
 fqh
 bXg
 kVq
@@ -159915,7 +161516,7 @@ tQT
 nYY
 kxT
 gKK
-fnw
+uur
 gww
 ctS
 rQI
@@ -159957,7 +161558,7 @@ sta
 dnK
 phW
 ghR
-vDa
+uKo
 dlz
 icm
 nux
@@ -160156,7 +161757,7 @@ ogw
 fnU
 aaf
 wbY
-jjH
+wRR
 oQO
 vlV
 wtc
@@ -160176,7 +161777,7 @@ fnw
 ouQ
 nXe
 pUF
-xoQ
+xSO
 xoQ
 xoQ
 nWD
@@ -160223,7 +161824,7 @@ eDz
 nux
 rUe
 lhA
-kMH
+bGH
 wTH
 nXG
 fEW
@@ -160393,7 +161994,7 @@ wGW
 pgH
 pgH
 tUO
-tUO
+kuo
 tUO
 lHD
 mhD
@@ -160403,7 +162004,7 @@ tUO
 eJR
 txu
 kVq
-kVq
+vcK
 nIQ
 kVq
 jjH
@@ -160495,7 +162096,7 @@ xeQ
 xeQ
 uYo
 uYo
-uYo
+kQU
 owc
 xAZ
 owc
@@ -160617,7 +162218,7 @@ pka
 plf
 plf
 plf
-bFi
+gwd
 cQM
 kPH
 thc
@@ -160699,7 +162300,7 @@ vKi
 lgU
 tTV
 qwX
-usO
+vCO
 usO
 usO
 usO
@@ -160722,7 +162323,7 @@ heq
 sWU
 ufn
 frv
-vDa
+uKo
 pPn
 kxQ
 swU
@@ -160757,7 +162358,7 @@ xAZ
 usR
 xAZ
 vju
-uYo
+kQU
 plf
 plf
 plf
@@ -160905,7 +162506,7 @@ mqN
 jok
 ouZ
 tUO
-tUO
+kuo
 tUO
 iaI
 aRH
@@ -160913,7 +162514,7 @@ ayw
 faH
 faH
 qpd
-tUO
+kuo
 mzb
 iCO
 kVq
@@ -160931,7 +162532,7 @@ jjH
 fnw
 flh
 fnw
-fnw
+uur
 eyS
 xlf
 czv
@@ -160943,7 +162544,7 @@ csf
 kge
 iaa
 djg
-fnw
+uur
 fnw
 aXs
 fnw
@@ -160973,13 +162574,13 @@ xXE
 pgz
 lGE
 sAS
-jBp
+gMi
 jBp
 jBp
 vyC
 mbC
 jBp
-vDa
+uKo
 vDa
 vDa
 vDa
@@ -160994,15 +162595,15 @@ hfC
 tMe
 uvc
 jcx
-hOs
+vKz
 hOs
 aAX
-hOs
+vKz
 uYo
 spA
 uYo
 uYo
-uYo
+kQU
 pMa
 jpq
 rvG
@@ -161176,7 +162777,7 @@ uKf
 kVq
 kVq
 kVq
-kVq
+vcK
 jjH
 dJU
 jvl
@@ -161188,7 +162789,7 @@ mhH
 nrc
 iIo
 fCG
-mhH
+sdN
 fnw
 fnw
 fnw
@@ -161204,7 +162805,7 @@ xoQ
 dZC
 egm
 xYB
-jWS
+vcQ
 jWS
 wVj
 jWS
@@ -161265,11 +162866,11 @@ psf
 kCo
 huI
 mJZ
-uYo
+kQU
 xnu
 qzP
 xnu
-uYo
+kQU
 pLB
 uYo
 xqM
@@ -161434,7 +163035,7 @@ sKY
 lNV
 sKY
 cmM
-jjH
+wRR
 uYm
 sMf
 uID
@@ -161465,7 +163066,7 @@ usa
 eYr
 pXm
 mbx
-xoQ
+xSO
 mqK
 qNq
 ryh
@@ -161645,7 +163246,7 @@ pka
 plf
 plf
 plf
-bFi
+gwd
 cQM
 kPH
 jlC
@@ -161674,7 +163275,7 @@ dpL
 jzt
 kCy
 gfS
-ouZ
+jaY
 xHY
 aDd
 tUO
@@ -161703,9 +163304,9 @@ nWu
 oWZ
 xar
 cFo
-mhH
+sdN
 kHU
-hIB
+aJZ
 abZ
 jKH
 kWQ
@@ -161738,7 +163339,7 @@ uCS
 apM
 woi
 umb
-yag
+gtW
 lBt
 tJj
 erK
@@ -161769,7 +163370,7 @@ hOs
 lPQ
 mWv
 raY
-uYo
+kQU
 aep
 aer
 aew
@@ -161787,7 +163388,7 @@ baE
 neh
 sgQ
 xxH
-uYo
+kQU
 plf
 plf
 plf
@@ -161937,7 +163538,7 @@ tUO
 tUO
 tUO
 tUO
-tUO
+kuo
 tUO
 uPW
 tUO
@@ -161949,7 +163550,7 @@ jIl
 jIl
 rtN
 vOc
-jjH
+wRR
 lyB
 nsl
 gaU
@@ -161968,7 +163569,7 @@ mSV
 xGH
 scD
 reO
-hIB
+aJZ
 plf
 xoQ
 ndw
@@ -162004,7 +163605,7 @@ yag
 xzH
 fZF
 fZF
-xzH
+eFR
 xzH
 mOx
 ihP
@@ -162022,14 +163623,14 @@ hfC
 vVr
 niA
 cgN
-hOs
+vKz
 hOs
 gPe
 hOs
 uYo
 uYo
 uYo
-uYo
+kQU
 uYo
 xVh
 xVh
@@ -162162,12 +163763,12 @@ kOn
 kOn
 hDL
 hDL
+dQU
 hDL
 hDL
+dQU
 hDL
-hDL
-hDL
-hDL
+dQU
 hDL
 hDL
 hDL
@@ -162178,7 +163779,7 @@ hDL
 crb
 cLr
 fth
-bnx
+etQ
 bvk
 jDk
 tDS
@@ -162293,11 +163894,11 @@ gHK
 vRC
 sjC
 lFF
-xVh
+kCm
 pvG
 mvm
 pPK
-xVh
+kCm
 wpc
 qtm
 aIK
@@ -162482,7 +164083,7 @@ jIL
 ggs
 jIL
 rQV
-hIB
+aJZ
 plf
 xoQ
 kWH
@@ -162497,13 +164098,13 @@ xoQ
 xro
 qNq
 huj
-nGQ
+gMH
 saZ
 frj
 pbI
 gMY
 sMd
-nGQ
+gMH
 caY
 gfC
 gnI
@@ -162535,7 +164136,7 @@ xgj
 xgj
 xgj
 vtj
-xgj
+hhF
 xgj
 iun
 xZf
@@ -162558,7 +164159,7 @@ whV
 qRV
 aeP
 htg
-uYo
+kQU
 plf
 plf
 plf
@@ -162723,7 +164324,7 @@ lBv
 jjH
 jjH
 jjH
-jjH
+wRR
 jjH
 rhl
 kfm
@@ -162733,7 +164334,7 @@ cdw
 kql
 mhH
 kHU
-hIB
+aJZ
 acb
 lUz
 ggs
@@ -162741,21 +164342,21 @@ bBv
 acj
 hIB
 kHU
-xoQ
+xSO
 jdp
 iFM
 vfU
 pUo
+xSO
 xoQ
 xoQ
-xoQ
-xoQ
+xSO
 xoQ
 xmf
 ciI
 cpP
 nGQ
-nGQ
+gMH
 nGQ
 nGQ
 nGQ
@@ -162782,12 +164383,12 @@ pbe
 hwl
 hwl
 hwl
-kmW
+vtF
 vqo
 wNO
 uVw
 iix
-xgj
+hhF
 lrK
 ikz
 tkP
@@ -163019,7 +164620,7 @@ wAA
 ils
 epE
 lMn
-xLZ
+jQs
 tJG
 uJF
 uJF
@@ -163189,7 +164790,7 @@ kHU
 plf
 xsj
 iDB
-hDL
+dQU
 cDr
 dPT
 hOv
@@ -163223,7 +164824,7 @@ nTa
 wWR
 jyM
 gVl
-vTP
+aIV
 acJ
 fLX
 jIl
@@ -163252,14 +164853,14 @@ nQC
 nQC
 qsh
 nQC
-nQC
+upm
 nQC
 kHU
 kLH
 kLH
 kLH
 kLH
-kLH
+qJV
 kLH
 gGg
 eAd
@@ -163281,7 +164882,7 @@ jWU
 rCF
 usE
 cHO
-cHO
+wFg
 qtG
 laG
 qtG
@@ -163294,7 +164895,7 @@ fUt
 fUt
 fUt
 fUt
-fUt
+oOd
 fUt
 fUt
 eGW
@@ -163321,15 +164922,15 @@ leq
 iAJ
 bzY
 kfd
-uYo
+kQU
 vsL
 utR
 gvh
-uYo
+kQU
 xeQ
 xeQ
 xeQ
-uYo
+kQU
 plf
 plf
 plf
@@ -163463,7 +165064,7 @@ svO
 gqz
 svO
 vkV
-bnx
+etQ
 fSD
 kCa
 nfC
@@ -163474,7 +165075,7 @@ peC
 peC
 hyD
 fLA
-vTP
+aIV
 vrM
 iRU
 pfs
@@ -163502,9 +165103,9 @@ phY
 rIx
 cEZ
 hyH
-mhH
+sdN
 plf
-nQC
+upm
 bEV
 rES
 cWR
@@ -163512,7 +165113,7 @@ bqP
 tWZ
 nQC
 plf
-kLH
+qJV
 sBn
 edk
 edk
@@ -163713,7 +165314,7 @@ osX
 jAk
 nVK
 lub
-hDL
+dQU
 pWM
 eyj
 kAT
@@ -163754,7 +165355,7 @@ vOc
 tDn
 mhH
 mhH
-mhH
+sdN
 mhH
 bhm
 mhH
@@ -163767,7 +165368,7 @@ efs
 rxJ
 uNg
 pNO
-nQC
+upm
 kHU
 kLH
 uQk
@@ -163776,7 +165377,7 @@ gYT
 tuW
 vGN
 umq
-kLH
+qJV
 izf
 boQ
 oex
@@ -163815,7 +165416,7 @@ hIp
 kJV
 kJV
 fmL
-xgj
+hhF
 acS
 xgj
 oTa
@@ -163971,12 +165572,12 @@ uSB
 uuy
 hDL
 hDL
+dQU
 hDL
 hDL
+dQU
 hDL
-hDL
-hDL
-hDL
+dQU
 bnx
 dHP
 rNj
@@ -163990,7 +165591,7 @@ rOk
 rOk
 rOk
 rOk
-rOk
+wJw
 rOk
 vTP
 vTP
@@ -164023,7 +165624,7 @@ nQC
 tHI
 qGe
 gYz
-nQC
+upm
 nQC
 plf
 kLH
@@ -164060,7 +165661,7 @@ iuj
 ehQ
 xZn
 wFd
-jLW
+sWy
 gMU
 qPj
 jBV
@@ -164219,7 +165820,7 @@ hoI
 hyJ
 byu
 umn
-hDL
+dQU
 hDL
 ftt
 hDL
@@ -164277,20 +165878,20 @@ rRo
 plf
 plf
 nQC
-nQC
+upm
 nQC
 nQC
 nQC
 plf
 plf
-kLH
+qJV
 ozx
 wXS
 eEW
 eEW
 eEW
 eEW
-kLH
+qJV
 fjy
 wOp
 oex
@@ -164325,10 +165926,10 @@ fUt
 fUt
 fUt
 fUt
+xqP
 odA
 odA
-odA
-odA
+xqP
 odA
 odA
 odA
@@ -164491,7 +166092,7 @@ imw
 oVg
 nGA
 nGA
-bnx
+etQ
 tdU
 nlE
 iUc
@@ -164555,7 +166156,7 @@ bOa
 rwe
 gok
 xLZ
-xLZ
+jQs
 xLZ
 xLZ
 xLZ
@@ -164577,7 +166178,7 @@ xzH
 jLW
 fUt
 pji
-fUt
+oOd
 fUt
 jgI
 khy
@@ -164588,7 +166189,7 @@ cSV
 xsV
 aHl
 gaR
-cSV
+obs
 cSV
 xgj
 prb
@@ -164800,7 +166401,7 @@ rRo
 tlI
 pEz
 kLH
-kLH
+qJV
 kLH
 kLH
 kLH
@@ -164817,7 +166418,7 @@ qbC
 tnC
 sIl
 add
-aPU
+rrb
 udY
 vSA
 hMT
@@ -164835,7 +166436,7 @@ fwJ
 coq
 nxu
 oto
-cSV
+obs
 xXf
 bRN
 hyF
@@ -165017,7 +166618,7 @@ boy
 rtz
 gmg
 rOk
-rOk
+wJw
 rOk
 rOk
 rOk
@@ -165266,7 +166867,7 @@ bnx
 kgl
 sPk
 tDS
-rOk
+wJw
 oFz
 eQL
 wAX
@@ -165326,12 +166927,12 @@ lZC
 oex
 vnR
 iFJ
-aPU
+rrb
 bUh
 pbE
 pbE
 ukC
-aPU
+rrb
 msi
 nRo
 qZN
@@ -165519,13 +167120,13 @@ wSs
 jcG
 rgR
 rgR
-bnx
+etQ
 dSB
 xcE
 tDS
 rOk
 rOk
-rOk
+wJw
 qlM
 qlM
 rOk
@@ -165583,17 +167184,17 @@ shc
 lBL
 mRG
 bOw
+hdt
 bOw
 bOw
 bOw
 bOw
 bOw
-bOw
-wPj
+dWo
 nRo
 rai
 juu
-juu
+ahS
 kBp
 kBp
 juu
@@ -165617,7 +167218,7 @@ wiO
 wiO
 wiO
 sce
-cSV
+obs
 aaE
 eha
 eha
@@ -165635,7 +167236,7 @@ kHU
 vNi
 vNi
 vNi
-vNi
+vgW
 vNi
 kHU
 kHU
@@ -165761,7 +167362,7 @@ hoI
 hyJ
 byu
 umn
-hDL
+dQU
 hDL
 ftt
 hDL
@@ -165769,7 +167370,7 @@ hDL
 qNP
 ioa
 lyl
-hDL
+dQU
 iAt
 wcE
 qed
@@ -165781,7 +167382,7 @@ hyE
 gni
 cRj
 oUz
-iir
+qRe
 rVx
 xUp
 nTc
@@ -165825,11 +167426,11 @@ rRo
 fKt
 kHu
 xfs
+edp
 xfs
 xfs
 xfs
-xfs
-xfs
+edp
 brc
 nJa
 uTa
@@ -165886,7 +167487,7 @@ sOd
 eha
 plf
 vNi
-vNi
+vgW
 vNi
 vNi
 vNi
@@ -165896,7 +167497,7 @@ pkz
 vNi
 vNi
 vNi
-vNi
+vgW
 vNi
 plf
 pka
@@ -166028,10 +167629,10 @@ rno
 hDL
 hDL
 iir
+qRe
 iir
 iir
-iir
-iir
+qRe
 iir
 iir
 fxy
@@ -166042,7 +167643,7 @@ iir
 rVx
 xUp
 nTc
-iir
+qRe
 iir
 uUi
 njb
@@ -166120,7 +167721,7 @@ xKy
 juu
 fTV
 tyj
-cSV
+obs
 cjE
 qaK
 bRN
@@ -166146,7 +167747,7 @@ vNi
 jtc
 mmz
 pkz
-uhI
+tRm
 iwE
 mTv
 hva
@@ -166384,7 +167985,7 @@ oya
 muU
 cSV
 cSV
-cSV
+obs
 kyk
 kyk
 cSV
@@ -166407,7 +168008,7 @@ uhI
 iwE
 pkz
 pkz
-uhI
+tRm
 iwE
 pkz
 kKK
@@ -166546,12 +168147,12 @@ qaQ
 wHy
 kmg
 wGz
-xyJ
+iUL
 iYC
 roz
 cJh
 hSZ
-xyJ
+iUL
 sDx
 roz
 kDT
@@ -166635,7 +168236,7 @@ ghg
 gNJ
 iCl
 kQE
-aby
+sHy
 xTj
 ryb
 oMk
@@ -166656,7 +168257,7 @@ fxz
 eha
 kHU
 kHU
-vNi
+vgW
 iwE
 pkz
 pkz
@@ -166668,7 +168269,7 @@ uhI
 iwE
 pkz
 pkz
-vNi
+vgW
 plf
 kHU
 kHU
@@ -166787,7 +168388,7 @@ kHU
 plf
 gNa
 fkk
-hDL
+dQU
 ixY
 dPT
 hOv
@@ -166808,13 +168409,13 @@ mhM
 tHf
 cfL
 aAo
-xyJ
+iUL
 jHO
 tHf
 mAt
 ppr
 rbK
-iir
+qRe
 nLj
 ykV
 uZA
@@ -166853,12 +168454,12 @@ rRo
 xfs
 bUk
 xfs
-xfs
+edp
 xLz
 fkX
 oiN
 xfs
-eha
+pDu
 oUS
 rwD
 rwD
@@ -167055,7 +168656,7 @@ aBv
 hZl
 jEh
 iir
-iir
+qRe
 wZD
 ezm
 wZD
@@ -167065,7 +168666,7 @@ lVV
 pQR
 lZb
 aAo
-xyJ
+iUL
 gzf
 tHf
 mAt
@@ -167117,7 +168718,7 @@ myS
 xfs
 otC
 fQT
-rwD
+tFp
 uet
 uVD
 mLS
@@ -167391,7 +168992,7 @@ hII
 kDj
 eiB
 tsb
-juu
+ahS
 aOj
 rAK
 aZL
@@ -167402,7 +169003,7 @@ aBU
 aZL
 qyz
 vwb
-juu
+ahS
 brf
 qaE
 lsq
@@ -167416,7 +169017,7 @@ mfj
 mfj
 mfj
 mfj
-aby
+sHy
 myg
 djr
 fgF
@@ -167575,7 +169176,7 @@ qjV
 xgP
 dwB
 iir
-iir
+qRe
 oiB
 mKz
 ioL
@@ -167585,8 +169186,8 @@ nwL
 bff
 dTD
 nwL
-iir
-jIl
+qRe
+fGb
 jIl
 jIl
 jIl
@@ -167631,14 +169232,14 @@ iQs
 eha
 fgF
 cwu
-rwD
+tFp
 pJZ
 nrs
 rjR
 pbo
 dXI
 vxt
-rwD
+tFp
 xBY
 ktG
 uez
@@ -167658,7 +169259,7 @@ kBp
 kBp
 clB
 kBp
-juu
+ahS
 juu
 bht
 xkv
@@ -167670,15 +169271,15 @@ aby
 aby
 aby
 aby
+sHy
 aby
 aby
 aby
-aby
-aPU
+rrb
 aPU
 aPU
 ulW
-vNi
+vgW
 gUd
 vNi
 vNi
@@ -167700,7 +169301,7 @@ pcW
 vNi
 vNi
 vNi
-vNi
+vgW
 vNi
 kHU
 kHU
@@ -167818,11 +169419,11 @@ hDL
 hDL
 hDL
 hDL
+dQU
 hDL
+dQU
 hDL
-hDL
-hDL
-hDL
+dQU
 hDL
 tbY
 iir
@@ -167846,12 +169447,12 @@ iir
 tjY
 tjY
 cRk
-jIl
+fGb
 jIl
 vOc
 eaG
 vOc
-jIl
+fGb
 kik
 gTR
 buD
@@ -167902,7 +169503,7 @@ cLH
 cLH
 bOw
 aPU
-jvj
+qHa
 lJT
 ijD
 exE
@@ -168082,7 +169683,7 @@ plf
 iir
 ucp
 ucp
-iir
+qRe
 wZD
 qWK
 ntJ
@@ -168157,7 +169758,7 @@ lon
 vnf
 mEp
 bXU
-bOw
+hdt
 xai
 tDO
 lJT
@@ -168404,11 +170005,11 @@ vzu
 ckn
 rwD
 rwD
-rwD
+tFp
 xKs
 vWP
 rwD
-rwD
+tFp
 bOw
 orR
 vCZ
@@ -168421,7 +170022,7 @@ eSK
 qZN
 nCE
 oLo
-oLo
+pru
 oLo
 tHH
 lbU
@@ -168618,7 +170219,7 @@ xux
 udR
 lqs
 hts
-jIl
+fGb
 sEM
 sEM
 sEM
@@ -168686,12 +170287,12 @@ rhH
 azO
 mQq
 nLN
-oLo
+pru
 qek
 uNC
 oqO
 cCI
-eWl
+xOl
 epi
 fMs
 biv
@@ -168699,14 +170300,14 @@ oSW
 bcB
 wLl
 xlx
-jvj
+qHa
 eXb
 jvj
 jvj
 aPU
 aPU
 xVu
-vNi
+vgW
 gUd
 vNi
 dXr
@@ -168726,7 +170327,7 @@ afi
 jmu
 jPh
 vNi
-vNi
+vgW
 vNi
 vNi
 vNi
@@ -168923,14 +170524,14 @@ mPI
 baO
 eVr
 lmU
-bOw
+hdt
 dzP
 ugv
 xQv
-bOw
+hdt
 bOw
 fgF
-eha
+pDu
 aOD
 sNp
 arE
@@ -169127,7 +170728,7 @@ teF
 wwp
 uYv
 iir
-iir
+qRe
 hpF
 kfj
 nvW
@@ -169191,7 +170792,7 @@ eha
 ylm
 agM
 dhg
-oLo
+pru
 aUv
 wvR
 tOO
@@ -169215,9 +170816,9 @@ qfz
 xlx
 vOK
 sCG
+qHa
 jvj
-jvj
-jvj
+qHa
 aPU
 sdW
 gKl
@@ -169389,7 +170990,7 @@ seG
 krX
 evA
 bnF
-iir
+qRe
 kHU
 plf
 plf
@@ -169457,7 +171058,7 @@ iIg
 pxu
 vra
 uqN
-oLo
+pru
 gpZ
 pTV
 vZU
@@ -169701,13 +171302,13 @@ fgF
 eha
 aAz
 eha
-eha
+pDu
 kgj
 agM
 oHf
 eha
 aaK
-oLo
+pru
 ucF
 mtH
 cEN
@@ -169717,10 +171318,10 @@ bUP
 oLo
 iWj
 xgy
-iWj
+jne
 ucd
 eWl
-eWl
+xOl
 uIi
 erJ
 sCd
@@ -169744,7 +171345,7 @@ vNi
 iwE
 wov
 pkz
-uhI
+tRm
 cgJ
 wbi
 aeR
@@ -169904,7 +171505,7 @@ bQe
 hoG
 hoG
 daq
-xyJ
+iUL
 plf
 plf
 kHU
@@ -169977,9 +171578,9 @@ rKi
 uvt
 xPb
 xPb
-ucd
+gsE
 ksZ
-ksZ
+spR
 ksZ
 ksZ
 ksZ
@@ -170005,11 +171606,11 @@ uhI
 iwE
 pkz
 pkz
-uhI
+tRm
 rrv
 pkz
 lQf
-vNi
+vgW
 kHU
 kHU
 kHU
@@ -170161,7 +171762,7 @@ jNz
 iCg
 wbF
 fRB
-xyJ
+iUL
 plf
 plf
 kHU
@@ -170171,15 +171772,15 @@ kHU
 plf
 jIl
 hLl
-ilW
-ilW
+iFG
+iFG
 jIl
-ilW
-ilW
+iFG
+iFG
 jIl
 jIl
 jIl
-ilW
+iFG
 jIl
 jIl
 kHU
@@ -170219,12 +171820,12 @@ eha
 fJL
 qsG
 vIv
-eha
+pDu
 oVt
 mWs
 qoZ
 jRd
-oLo
+pru
 aZY
 tKp
 jNc
@@ -170254,7 +171855,7 @@ hue
 hue
 eha
 kHU
-vNi
+vgW
 nCI
 hPw
 wov
@@ -170418,7 +172019,7 @@ gjC
 iFv
 jHY
 gxo
-xyJ
+iUL
 plf
 plf
 kHU
@@ -170485,7 +172086,7 @@ oLo
 tNr
 sWR
 bnh
-oLo
+pru
 ikm
 lLH
 wDZ
@@ -170497,7 +172098,7 @@ rrN
 whL
 kDo
 ieS
-aPU
+rrb
 aPU
 aPU
 aPU
@@ -170514,7 +172115,7 @@ plf
 vNi
 vNi
 vNi
-vNi
+vgW
 vNi
 nCI
 jbi
@@ -170522,7 +172123,7 @@ pkz
 vNi
 vNi
 vNi
-vNi
+vgW
 oYD
 kHU
 plf
@@ -170674,7 +172275,7 @@ jtN
 igw
 eRi
 igw
-iir
+qRe
 iir
 plf
 plf
@@ -170773,7 +172374,7 @@ kHU
 plf
 kHU
 vNi
-oYD
+evo
 vNi
 vNi
 vNi
@@ -170917,7 +172518,7 @@ iir
 fzL
 cZs
 cWA
-iir
+qRe
 odG
 brm
 wRA
@@ -170925,7 +172526,7 @@ iir
 vvB
 upf
 jDU
-iir
+qRe
 iir
 iir
 rdf
@@ -170998,7 +172599,7 @@ uCj
 ucd
 ucd
 ucd
-ucd
+gsE
 ucd
 pzn
 vDW
@@ -171422,7 +173023,7 @@ iir
 cDk
 iir
 iir
-iir
+qRe
 iir
 cTJ
 kHU
@@ -171521,7 +173122,7 @@ ikm
 lLH
 wLK
 ksZ
-ksZ
+spR
 ksZ
 cMk
 cMk
@@ -171743,13 +173344,13 @@ iQs
 plf
 kHU
 dXc
-eGJ
+laz
 eha
 eha
 eha
 eha
 eha
-eGJ
+laz
 lJe
 eha
 eha
@@ -171780,7 +173381,7 @@ ecb
 xuC
 nda
 ucd
-ucd
+gsE
 ucd
 ucd
 ucd
@@ -172025,7 +173626,7 @@ gVJ
 ahZ
 ucd
 kSK
-ucd
+gsE
 pWR
 cKj
 lIF
@@ -172541,7 +174142,7 @@ cqH
 eha
 uIO
 xqd
-ucd
+gsE
 aLJ
 tDB
 lIF
@@ -173058,12 +174659,12 @@ twb
 ucd
 ucd
 ucd
-ucd
+gsE
 ucd
 ucd
 edA
 ucd
-ucd
+gsE
 kHU
 kHU
 kHU
@@ -174090,7 +175691,7 @@ jyb
 skJ
 skJ
 pMr
-skJ
+rqr
 skJ
 skJ
 skJ
@@ -174342,7 +175943,7 @@ eha
 wMm
 wOr
 wSz
-skJ
+rqr
 cPk
 eKO
 aOo
@@ -175575,7 +177176,7 @@ aAw
 hZG
 mMf
 mMf
-gDh
+vLY
 mMf
 mMf
 mMf
@@ -175584,7 +177185,7 @@ bcr
 bRq
 msS
 mMf
-gDh
+vLY
 ktp
 xTH
 iIM
@@ -175592,7 +177193,7 @@ iIM
 cPp
 wnd
 tan
-gDh
+vLY
 mMf
 mMf
 grT
@@ -175828,7 +177429,7 @@ ybL
 sCv
 inm
 hZG
-gDh
+vLY
 plf
 plf
 gDh
@@ -176106,7 +177707,7 @@ gca
 jbQ
 qqs
 aYb
-hyV
+eTP
 gBq
 pOR
 nHd
@@ -176114,7 +177715,7 @@ hyV
 plf
 plf
 mMf
-gDh
+vLY
 mMf
 nOa
 mdt
@@ -176367,7 +177968,7 @@ hyV
 uMm
 vGb
 dFt
-hyV
+eTP
 plf
 plf
 plf
@@ -176376,7 +177977,7 @@ plf
 plf
 mMf
 mMf
-gDh
+vLY
 mMf
 nOa
 oEj
@@ -176863,7 +178464,7 @@ lbo
 lbo
 lbo
 lbo
-lbo
+mXu
 lbo
 lbo
 lbo
@@ -176884,7 +178485,7 @@ ugT
 hyV
 umi
 umi
-umi
+fPw
 umi
 umi
 umi
@@ -177111,46 +178712,46 @@ plf
 lgc
 wwS
 xiA
-gDh
+vLY
 gDh
 lbo
 plf
 lbo
 lbo
-lbo
+mXu
 tuk
 iOI
 ckI
 eOB
 eHU
-lbo
+mXu
 lbo
 lbo
 plf
-gca
+bvH
 sVq
 obJ
 gca
 nYt
 ror
 shk
+eTP
 hyV
 hyV
 hyV
-hyV
-hyV
+eTP
 umi
 nAB
 uyD
 mea
 cDp
-umi
+fPw
 umi
 umi
 umi
 umi
 gDh
-gDh
+vLY
 kQa
 cea
 lgc
@@ -177396,7 +178997,7 @@ uef
 oPY
 aSP
 aRJ
-umi
+fPw
 lXA
 lXA
 mYk
@@ -177630,7 +179231,7 @@ gDh
 lbo
 plf
 lbo
-lbo
+cKU
 epr
 kMz
 lbo
@@ -177641,14 +179242,14 @@ gEl
 iEv
 lbo
 lbo
-lbo
+mXu
 iuh
 lIM
 eNY
 yce
 tnp
 vZa
-uef
+ech
 xYw
 xnc
 teT
@@ -177661,7 +179262,7 @@ leC
 pdO
 lXA
 kpr
-umi
+fPw
 umi
 plf
 ybL
@@ -177896,7 +179497,7 @@ lbo
 rUL
 iQE
 tuk
-lbo
+cKU
 lbo
 lbo
 fRg
@@ -178139,7 +179740,7 @@ plf
 lgc
 wwS
 bvx
-gDh
+vLY
 gDh
 lbo
 dey
@@ -178178,7 +179779,7 @@ lXA
 ujF
 umi
 gDh
-gDh
+vLY
 rxF
 cea
 lgc
@@ -178404,7 +180005,7 @@ lbo
 lbo
 tYu
 fjd
-lbo
+cKU
 lbo
 lbo
 tcf
@@ -178412,7 +180013,7 @@ tHU
 ieg
 pSp
 lbo
-lbo
+mXu
 tpg
 vdS
 eNY
@@ -178658,7 +180259,7 @@ gDh
 lbo
 plf
 lbo
-lbo
+mXu
 epr
 fJr
 lbo
@@ -178689,7 +180290,7 @@ jtu
 ibb
 mXf
 bpN
-umi
+fPw
 umi
 plf
 ybL
@@ -178928,17 +180529,17 @@ awB
 pAG
 oim
 fxe
-anO
+ifD
 anO
 lfh
 ugr
 iAV
 anO
-uef
+ech
 gQn
 rbv
 oRJ
-umi
+fPw
 lXA
 lXA
 coD
@@ -179167,7 +180768,7 @@ plf
 lgc
 wwS
 xiA
-gDh
+vLY
 gDh
 lbo
 plf
@@ -179179,7 +180780,7 @@ kze
 tUu
 yhH
 hwE
-lbo
+mXu
 lbo
 lbo
 plf
@@ -179202,11 +180803,11 @@ oOa
 nBb
 umi
 umi
-umi
+fPw
 umi
 umi
 gDh
-gDh
+vLY
 kQa
 cea
 lgc
@@ -179235,7 +180836,7 @@ kHU
 plf
 kHU
 plf
-tzH
+wYv
 eBV
 wTk
 pRg
@@ -179431,10 +181032,10 @@ plf
 plf
 lbo
 lbo
+mXu
 lbo
-lbo
-lbo
-lbo
+cKU
+mXu
 lbo
 lbo
 lbo
@@ -179447,7 +181048,7 @@ gje
 inH
 dzf
 vZD
-anO
+ifD
 uef
 uef
 uef
@@ -179455,7 +181056,7 @@ uef
 umi
 umi
 umi
-umi
+fPw
 umi
 umi
 plf
@@ -179697,7 +181298,7 @@ lbo
 kSo
 kSo
 lbo
-anO
+ifD
 mcD
 sDj
 dHv
@@ -179743,7 +181344,7 @@ tzH
 qLb
 qLb
 jWs
-tzH
+wYv
 kHU
 kHU
 plf
@@ -179974,7 +181575,7 @@ plf
 plf
 pBv
 pBv
-gDh
+vLY
 pBv
 eoA
 ssl
@@ -180215,7 +181816,7 @@ anO
 plf
 tmJ
 plf
-anO
+ifD
 plf
 plf
 gDh
@@ -180226,7 +181827,7 @@ gDh
 plf
 plf
 pBv
-gDh
+vLY
 pBv
 eoA
 ssl
@@ -180454,7 +182055,7 @@ ybL
 vEr
 foI
 jTV
-gDh
+vLY
 plf
 plf
 gDh
@@ -180479,7 +182080,7 @@ gDh
 plf
 plf
 plf
-gDh
+vLY
 pBv
 eoA
 ssl
@@ -180715,7 +182316,7 @@ rDT
 jTV
 pBv
 pBv
-gDh
+vLY
 pBv
 pBv
 pBv
@@ -180724,7 +182325,7 @@ vKv
 hbu
 nWP
 igm
-gDh
+vLY
 pBv
 pBv
 pBv
@@ -180732,7 +182333,7 @@ pBv
 pBv
 pBv
 pBv
-gDh
+vLY
 pBv
 pBv
 eoA

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -47536,7 +47536,7 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/obj/item/decoration/snowman,
+/obj/machinery/vending/newyearmate,
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -121876,11 +121876,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "xvG" = (
-/obj/item/weapon/flora/pottedplant/orientaltree,
 /obj/effect/decal/turf_decal{
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/machinery/vending/newyearmate,
 /turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
 "xvI" = (

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -4769,7 +4769,7 @@
 /turf/simulated/wall,
 /area/station/civilian/chapel/altar)
 "aBf" = (
-/obj/structure/closet,
+/obj/machinery/vending/newyearmate,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -23,6 +23,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "aad" = (
@@ -790,6 +791,7 @@
 	dir = 4;
 	name = "Medbay"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -804,6 +806,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -942,6 +945,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -994,6 +998,7 @@
 	name = "Brig Medical Checkpoint";
 	req_one_access = list(1,4)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1523,6 +1528,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Docks"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -1680,6 +1686,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -1815,6 +1822,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/effect/decal/turf_decal/set_burned,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "acL" = (
@@ -2047,6 +2055,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "adm" = (
@@ -2382,6 +2391,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2402,6 +2412,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "adU" = (
@@ -2503,6 +2514,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "aea" = (
@@ -2898,6 +2910,7 @@
 	id = "Captain_private"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "age" = (
@@ -3065,6 +3078,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry{
 	name = "Research Shuttle Dock"
@@ -3104,6 +3118,7 @@
 	layer = 2.8;
 	name = "doorway barricade"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/maintenance/brig)
 "aiK" = (
@@ -3235,6 +3250,7 @@
 	name = "Medbay Maintenance";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "ajR" = (
@@ -3265,6 +3281,7 @@
 	name = "CE Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor,
 /area/station/engineering/chiefs_office)
 "akt" = (
@@ -3387,6 +3404,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3419,6 +3437,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/prison)
 "amV" = (
@@ -3743,6 +3762,7 @@
 	name = "Brig Reception";
 	req_access = list(63)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3870,6 +3890,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4208,6 +4229,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "avD" = (
@@ -4290,6 +4312,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "awz" = (
@@ -4460,6 +4483,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"ayv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "ayx" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/machinery/alarm{
@@ -4498,6 +4525,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4544,6 +4572,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -4619,6 +4648,7 @@
 	pixel_x = -28;
 	req_access = list(55)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -4815,6 +4845,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4854,6 +4885,7 @@
 	name = "Medbay Maintenance";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aCC" = (
@@ -4925,6 +4957,7 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4996,6 +5029,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5054,6 +5088,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5133,6 +5168,7 @@
 /obj/machinery/telescience_jammer{
 	radius = 5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "aGd" = (
@@ -5296,6 +5332,10 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/medical/virology)
+"aHn" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/fitness)
 "aHp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -5371,6 +5411,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -5416,6 +5457,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5494,6 +5536,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5593,6 +5636,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "aLm" = (
@@ -5608,6 +5652,7 @@
 	dir = 5;
 	network = list("SS13","Medical")
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -5640,6 +5685,7 @@
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5683,6 +5729,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5776,6 +5823,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aNB" = (
@@ -6102,6 +6150,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -6388,6 +6437,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6419,6 +6469,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aXc" = (
@@ -6441,6 +6492,10 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"aXe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/checkpoint)
 "aXg" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -6484,6 +6539,10 @@
 /obj/machinery/power/rad_collector,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"aXE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/escape)
 "aXG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6562,6 +6621,7 @@
 	name = "Chemistry Lab";
 	req_access = list(33)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6694,6 +6754,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bbM" = (
@@ -6754,6 +6815,10 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
+"bcl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/range)
 "bdF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
@@ -6873,6 +6938,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -6918,6 +6984,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "bfz" = (
@@ -6975,6 +7042,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
 "bgq" = (
@@ -7133,16 +7201,12 @@
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
 "biC" = (
-/obj/structure/table/woodentable,
-/obj/item/ashtray/glass,
-/obj/item/weapon/lighter/zippo{
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/machinery/light/small,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -28
 	},
+/obj/item/device/flashlight/lamp/fir/special,
+/obj/item/weapon/present,
 /turf/simulated/floor/carpet,
 /area/station/civilian/bar)
 "biG" = (
@@ -7724,6 +7788,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bpx" = (
@@ -7898,6 +7963,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "bqW" = (
@@ -7969,6 +8035,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/station/security/lobby)
+"brN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/robotics)
 "brT" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/firealarm{
@@ -8076,6 +8146,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "bsP" = (
@@ -8245,6 +8316,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8280,6 +8352,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"bvu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/library)
 "bvK" = (
 /obj/machinery/vending/donut,
 /obj/machinery/status_display{
@@ -8365,6 +8441,7 @@
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "bws" = (
@@ -8453,6 +8530,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"bxK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/lobby)
 "bxR" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -8488,6 +8569,7 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn_corner"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8638,6 +8720,10 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/hos)
+"bAl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/ai_monitored/eva)
 "bAp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9006,6 +9092,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "bFm" = (
@@ -9028,6 +9115,10 @@
 "bFv" = (
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
+"bFA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/teleport)
 "bFE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9219,6 +9310,7 @@
 	dir = 5;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -9537,6 +9629,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat)
 "bMc" = (
@@ -9792,6 +9885,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/crematorium)
 "bPc" = (
@@ -9820,6 +9914,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "bPo" = (
@@ -10136,6 +10231,7 @@
 	name = "Science Maintenance";
 	req_access = list(7)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "bTm" = (
@@ -10166,6 +10262,7 @@
 	pixel_x = -32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10259,6 +10356,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bUT" = (
@@ -10278,6 +10376,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -10405,6 +10504,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
 "bXG" = (
@@ -10484,6 +10584,7 @@
 	name = "Medbay Maintenance";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "bZz" = (
@@ -11040,6 +11141,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11721,6 +11823,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11807,6 +11910,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11912,6 +12016,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Theatre"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -12077,6 +12182,10 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"cwz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/range)
 "cwA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -12252,6 +12361,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -12327,10 +12437,15 @@
 /obj/structure/closet,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"cAb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/storage/primary)
 "cAj" = (
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -12365,6 +12480,7 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "cAB" = (
@@ -12740,6 +12856,10 @@
 "cFy" = (
 /turf/environment/space,
 /area/shuttle/syndicate/northwest)
+"cFM" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/brig)
 "cFS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -12774,6 +12894,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "cGR" = (
@@ -12812,6 +12933,7 @@
 /area/station/security/secconfhall)
 "cHf" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -12838,6 +12960,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "cHJ" = (
@@ -12909,6 +13032,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "cIT" = (
@@ -13119,6 +13243,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -13395,6 +13520,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/bar)
+"cPY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/storage/tech)
 "cQe" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/snacks/ghostburger{
@@ -13436,6 +13565,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "cQx" = (
@@ -13455,6 +13585,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "cQz" = (
@@ -13572,6 +13703,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "cTd" = (
@@ -13589,6 +13721,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -13750,6 +13883,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -13791,6 +13925,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "cVd" = (
@@ -14305,6 +14440,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "dbE" = (
@@ -14356,6 +14492,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "dbT" = (
@@ -14388,6 +14525,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14604,6 +14742,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14886,6 +15025,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "dhs" = (
@@ -14968,6 +15108,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -15165,6 +15306,7 @@
 	pixel_x = -32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -15215,6 +15357,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "dkV" = (
@@ -15334,6 +15477,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
 "dmR" = (
@@ -15622,6 +15766,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -15671,6 +15816,7 @@
 	name = "Gateway Chamber Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "dsb" = (
@@ -15991,6 +16137,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "dvS" = (
@@ -16035,6 +16182,7 @@
 	name = "Science Maintenance";
 	req_access = list(47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/brainstorm_center)
 "dwv" = (
@@ -16393,6 +16541,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "dAd" = (
@@ -16533,6 +16682,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -16662,6 +16812,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "dCx" = (
@@ -16680,6 +16831,10 @@
 "dCA" = (
 /turf/environment/space,
 /area/shuttle/syndicate/north)
+"dCM" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/storage/primary)
 "dCN" = (
 /obj/item/stack/rods,
 /turf/environment/space,
@@ -16704,6 +16859,7 @@
 /obj/structure/flora/ausbushes/sparsegrass{
 	layer = 2.7
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "dDo" = (
@@ -16797,6 +16953,7 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkred"
@@ -16951,6 +17108,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery{
 	name = "Operating Theatre"
@@ -17078,6 +17236,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "dIf" = (
@@ -17094,6 +17253,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "dIk" = (
@@ -17167,6 +17327,7 @@
 	dir = 8;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17397,6 +17558,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17416,6 +17578,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17621,6 +17784,7 @@
 /area/station/rnd/server)
 "dMI" = (
 /obj/machinery/computer/centrifuge,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17694,6 +17858,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "dNt" = (
@@ -17729,6 +17894,7 @@
 	pixel_x = -32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17963,6 +18129,7 @@
 	dock_tag = "pod4";
 	name = "Escape Pod 4"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "dQw" = (
@@ -18142,6 +18309,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"dSK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/chargebay)
 "dSZ" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -18356,6 +18527,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "dVI" = (
@@ -18408,6 +18580,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "dWb" = (
@@ -18417,6 +18590,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -18434,6 +18608,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -18580,6 +18755,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"dYb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/captain_quarters)
 "dYo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18607,6 +18786,7 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "dYA" = (
@@ -18765,6 +18945,7 @@
 /area/station/security/prison)
 "eaJ" = (
 /obj/machinery/disease2/diseaseanalyser,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -18871,6 +19052,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19047,6 +19229,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19192,6 +19375,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "ehN" = (
@@ -19217,6 +19401,7 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19397,6 +19582,7 @@
 	name = "Forensic";
 	req_one_access = list(4,68)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19901,6 +20087,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -19922,6 +20109,14 @@
 /area/station/bridge/comms{
 	name = "Cyborg Station"
 	})
+"epB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/mine_sci_shuttle)
+"epG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/incinerator)
 "epH" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/light_switch{
@@ -19960,6 +20155,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "epS" = (
@@ -20011,6 +20207,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "equ" = (
@@ -20352,6 +20549,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -20447,6 +20645,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -20566,6 +20765,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -20912,6 +21112,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -20984,6 +21185,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "eCm" = (
@@ -20998,6 +21200,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -21165,6 +21368,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "eDM" = (
@@ -21255,6 +21459,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "eEA" = (
@@ -21351,6 +21556,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/engine,
 /area/station/rnd/misc_lab)
 "eGm" = (
@@ -21507,6 +21713,10 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
+"eIc" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hallway)
 "eId" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21772,6 +21982,7 @@
 	name = "Chapel Office";
 	req_access = list(22)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "eLT" = (
@@ -21949,6 +22160,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -21983,6 +22195,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22030,6 +22243,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "ePi" = (
@@ -22169,6 +22383,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -22307,6 +22522,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22338,6 +22554,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/office)
 "eSL" = (
@@ -22379,6 +22596,7 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22433,6 +22651,7 @@
 	dir = 4;
 	name = "Toilet"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -22450,6 +22669,10 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
+"eTS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "eUi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22495,6 +22718,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkredfull"
 	},
@@ -22577,6 +22801,7 @@
 	req_access = list(37)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "cult"
 	},
@@ -22723,6 +22948,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"eWR" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/toilet)
 "eXa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -22852,6 +23081,7 @@
 	name = "Research Director";
 	req_access = list(30)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -22939,6 +23169,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "eZb" = (
@@ -23062,6 +23293,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "fbl" = (
@@ -23281,6 +23513,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Docks"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -23419,6 +23652,10 @@
 	icon_state = "freezerfloor2"
 	},
 /area/station/bridge/captain_quarters)
+"ffA" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/morgue)
 "ffT" = (
 /obj/structure/flora/junglebush{
 	layer = 2.7
@@ -23524,6 +23761,7 @@
 	name = "Medbay Maintenance";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "fho" = (
@@ -23640,6 +23878,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -23678,6 +23917,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
+"fiL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/mixing)
 "fiU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23942,6 +24185,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "flT" = (
@@ -24055,6 +24299,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"fnf" = (
+/obj/item/decoration/garland,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "fnt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -24102,6 +24350,7 @@
 	name = "Mining Shuttle Dock";
 	req_one_access = list(48,65)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry{
 	name = "Research Shuttle Dock"
@@ -24161,6 +24410,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "fon" = (
@@ -24236,6 +24486,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
 "foN" = (
@@ -24333,6 +24584,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -24372,6 +24624,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -24612,6 +24865,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "fsW" = (
@@ -24678,6 +24932,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -24820,6 +25075,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -24986,6 +25242,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "fwY" = (
@@ -24993,6 +25250,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/cryo)
 "fxb" = (
@@ -25212,6 +25470,7 @@
 	name = "Atmospherics Monitoring";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -25428,6 +25687,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "fCq" = (
@@ -25707,6 +25967,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkredfull"
 	},
@@ -25833,6 +26094,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26064,10 +26326,15 @@
 /obj/machinery/camera{
 	c_tag = "Escape Hall North"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/secondary/exit)
+"fJo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/bar)
 "fJu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26096,6 +26363,25 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
+"fJx" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/weapon/pen{
+	pixel_y = 6
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/wood,
+/area/station/civilian/library)
 "fJI" = (
 /obj/structure/closet,
 /obj/item/clothing/head/gnome_hat,
@@ -26144,6 +26430,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "fKn" = (
@@ -26291,6 +26578,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26310,8 +26598,13 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/engine,
 /area/station/rnd/misc_lab)
+"fMx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/primary/aft)
 "fMC" = (
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -26367,6 +26660,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26460,6 +26754,7 @@
 /area/station/aisat/antechamber_interior)
 "fOp" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -26486,6 +26781,7 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26633,6 +26929,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26954,6 +27251,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -27155,6 +27453,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "fVV" = (
@@ -27319,6 +27618,17 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"fXZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "fYd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -27370,6 +27680,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -27412,6 +27723,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "fYG" = (
@@ -27582,6 +27894,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/iaa_office)
+"gbX" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/janitor)
 "gcs" = (
 /obj/machinery/camera{
 	c_tag = "RnD Containment Cell 2";
@@ -27649,6 +27965,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -27846,6 +28163,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "gfB" = (
@@ -27909,6 +28227,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Docks"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -28167,6 +28486,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -28177,6 +28497,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "git" = (
@@ -28353,6 +28674,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "gjV" = (
@@ -28615,9 +28937,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "gnz" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 28;
@@ -28626,7 +28945,7 @@
 /obj/machinery/atm{
 	pixel_y = -28
 	},
-/obj/effect/landmark/start/assistant,
+/obj/item/weapon/present,
 /turf/simulated/floor/carpet,
 /area/station/civilian/bar)
 "gnH" = (
@@ -28635,6 +28954,10 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"goh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/brig)
 "gom" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Solar Array";
@@ -28697,6 +29020,7 @@
 	dir = 4;
 	pixel_x = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkred"
@@ -28717,6 +29041,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "gpb" = (
@@ -28909,6 +29234,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"grx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/psych)
 "grA" = (
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 1
@@ -28944,6 +29273,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "grU" = (
@@ -29147,6 +29477,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29184,6 +29515,7 @@
 	name = "Chief Engineer";
 	req_access = list(56)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29342,6 +29674,10 @@
 "gww" = (
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/port)
+"gwy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/forensic_office)
 "gwz" = (
 /obj/item/device/multitool{
 	pixel_x = 10
@@ -29463,6 +29799,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "gxE" = (
@@ -29500,6 +29837,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29564,6 +29902,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "gyW" = (
@@ -29669,6 +30008,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29688,6 +30028,7 @@
 	dir = 4;
 	name = "Escape Hall"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29713,6 +30054,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29728,6 +30070,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29944,6 +30287,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "gEj" = (
@@ -29997,6 +30341,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -30171,6 +30516,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "gFY" = (
@@ -30215,6 +30561,7 @@
 	req_access = list(24)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30298,6 +30645,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -30552,6 +30900,10 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
+"gKY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/computer)
 "gLh" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -30674,6 +31026,7 @@
 	pixel_y = 28;
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30775,6 +31128,7 @@
 	pixel_y = 28;
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30849,6 +31203,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "gNN" = (
@@ -31010,6 +31365,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -31039,6 +31395,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"gQi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/drone_fabrication)
 "gQo" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/weapon/shard,
@@ -31311,6 +31671,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31438,6 +31799,7 @@
 	name = "Cargo Bay Warehouse Maintenance";
 	req_access = list(31)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "gVo" = (
@@ -31623,6 +31985,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"gWV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/vacantoffice{
+	name = "Tribunal"
+	})
 "gXb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/razor,
@@ -32056,6 +32424,7 @@
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -32121,6 +32490,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cryogenic Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -32156,6 +32526,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/brainstorm_center)
 "hcu" = (
@@ -32243,6 +32614,7 @@
 	},
 /obj/structure/mineral_door/wood,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
 "hdD" = (
@@ -32404,6 +32776,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"hfk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/cryo)
 "hfm" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Solitary Confinement Locker"
@@ -32555,6 +32931,7 @@
 /area/station/maintenance/medbay)
 "hha" = (
 /obj/structure/table/reinforced,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -32587,6 +32964,7 @@
 	pixel_y = 4
 	},
 /obj/structure/table,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -33129,6 +33507,7 @@
 	name = "Private AI Channel";
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -33273,6 +33652,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "hoS" = (
@@ -33299,6 +33679,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "hpx" = (
@@ -33425,6 +33806,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/cafeteria)
 "hsh" = (
@@ -33514,6 +33896,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -33568,6 +33951,7 @@
 	locked = 1;
 	name = "Escape Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "htL" = (
@@ -33673,6 +34057,7 @@
 	dir = 4;
 	name = "Docks"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -33799,6 +34184,7 @@
 	pixel_x = 6;
 	pixel_y = 2
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "hxQ" = (
@@ -34019,6 +34405,7 @@
 	req_access = list(19,23)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -34057,6 +34444,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "hBn" = (
@@ -34185,6 +34573,7 @@
 	name = "Chief Medical Officer";
 	req_access = list(40)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -34237,6 +34626,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"hDx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/decoration/snowman,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "hDy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34259,6 +34653,10 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/eva)
+"hDY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/office)
 "hEb" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder{
@@ -34407,6 +34805,7 @@
 	name = "Gateway Chamber Blast Doors";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "hGv" = (
@@ -34491,6 +34890,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "hHB" = (
@@ -34540,6 +34940,10 @@
 /obj/effect/landmark/start/clown,
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
+"hIa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/misc_lab)
 "hIe" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small{
@@ -35381,6 +35785,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -36242,6 +36647,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -36326,6 +36732,7 @@
 /obj/structure/transit_tube{
 	icon_state = "N-S"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -36512,6 +36919,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "ihg" = (
@@ -37048,6 +37456,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "inz" = (
@@ -37220,6 +37629,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "iqA" = (
@@ -37272,6 +37682,7 @@
 	name = "Distribution Loop";
 	req_access = list(24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "irZ" = (
@@ -37321,6 +37732,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -37415,6 +37827,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"iva" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/cold_room)
 "ivm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -37597,6 +38013,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -37697,6 +38114,7 @@
 /obj/machinery/camera{
 	c_tag = "Bridge Captain's Quarters"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "ixc" = (
@@ -37862,6 +38280,7 @@
 	c_tag = "Arrival Dock's Enter";
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -38152,6 +38571,7 @@
 	dir = 8;
 	network = list("RD","MiniSat")
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -38191,6 +38611,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -38288,6 +38709,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "brown"
@@ -38308,6 +38730,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "iDK" = (
@@ -38335,6 +38758,10 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"iEy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/engineering)
 "iEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -38359,8 +38786,7 @@
 	},
 /area/station/cargo/storage)
 "iFt" = (
-/obj/structure/stool/bed/chair/comfy/black,
-/obj/effect/landmark/start/assistant,
+/obj/item/weapon/present,
 /turf/simulated/floor/carpet,
 /area/station/civilian/bar)
 "iFD" = (
@@ -38945,6 +39371,7 @@
 /obj/item/station_map/prometheus{
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -39217,6 +39644,10 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/storage)
+"iQT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "iQU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -39263,6 +39694,10 @@
 "iRy" = (
 /turf/environment/space,
 /area/space)
+"iRE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/secconfhall)
 "iRM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -39312,6 +39747,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "iSE" = (
@@ -39322,6 +39758,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -39480,6 +39917,7 @@
 	dir = 4;
 	name = "Central Access"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -39613,6 +40051,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "iWu" = (
@@ -39819,6 +40258,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "iYM" = (
@@ -39927,6 +40367,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -40051,6 +40492,10 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
+"jbQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/brig)
 "jbT" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/office)
@@ -40220,6 +40665,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "jdr" = (
@@ -40448,6 +40894,7 @@
 /obj/structure/disposalpipe/sortjunction/wildcard{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -40562,6 +41009,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
+"jjo" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/central)
 "jjs" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber";
@@ -40575,6 +41026,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -40675,6 +41127,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -40836,6 +41289,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41322,6 +41776,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
 "jte" = (
@@ -41419,6 +41874,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "jtV" = (
@@ -41501,6 +41957,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41554,6 +42011,10 @@
 /area/station/security/vacantoffice{
 	name = "Tribunal"
 	})
+"jvQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/ai_chamber)
 "jwi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41743,6 +42204,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "jza" = (
@@ -41827,6 +42289,7 @@
 	name = "Mech Bay";
 	req_access = list(29)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "jzL" = (
@@ -41904,6 +42367,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "jAG" = (
@@ -41931,6 +42395,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkredfull"
 	},
@@ -42108,6 +42573,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42175,6 +42641,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42279,6 +42746,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43211,6 +43679,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43382,6 +43851,7 @@
 	id = "op2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43453,10 +43923,15 @@
 /obj/machinery/door/airlock/virology/glass{
 	name = "Patients room"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"jVW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/exit)
 "jWe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -43567,6 +44042,7 @@
 /obj/machinery/telescience_jammer{
 	radius = 5
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "jXL" = (
@@ -43847,6 +44323,10 @@
 	},
 /turf/simulated/floor/engine/nitrogen,
 /area/station/engineering/atmos)
+"kaU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/medbay)
 "kaW" = (
 /turf/simulated/floor{
 	icon_state = "darkblue"
@@ -43959,6 +44439,7 @@
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "kcs" = (
@@ -44147,6 +44628,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"kfi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/equip)
 "kfl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -44444,6 +44929,7 @@
 	name = "Monkey Pen";
 	req_access = list(39)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -44630,12 +45116,17 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"knN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/barbershop)
 "knP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "koe" = (
@@ -44768,6 +45259,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
 "kqd" = (
@@ -44831,6 +45323,7 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -44842,6 +45335,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "privateoffice"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lawyer_office)
 "kqT" = (
@@ -44910,6 +45404,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "krN" = (
@@ -44973,6 +45468,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "ksy" = (
@@ -45282,6 +45778,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "kxv" = (
@@ -45501,6 +45998,13 @@
 /area/station/medical/surgery{
 	name = "Operating Theatre"
 	})
+"kzl" = (
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/station/rnd/xenobiology)
 "kzn" = (
 /obj/item/weapon/storage/box/syndie_kit/posters,
 /obj/structure/sign/poster/contraband/syndicate_recruitment{
@@ -45541,6 +46045,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/rnd/mixing)
 "kzC" = (
@@ -45819,6 +46324,7 @@
 /obj/machinery/atm{
 	pixel_y = 28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -45901,6 +46407,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -46016,6 +46523,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -46061,6 +46569,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -46178,6 +46687,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -46258,6 +46768,7 @@
 	name = "Recycler's workplace";
 	req_access = list(67)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -46425,8 +46936,9 @@
 /turf/simulated/floor/plating,
 /area/station/construction)
 "kLa" = (
-/turf/simulated/floor/carpet,
-/area/station/civilian/bar)
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/crematorium)
 "kLl" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -46444,6 +46956,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "kLo" = (
@@ -46454,6 +46967,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkgreen"
@@ -46502,6 +47016,10 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"kMf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/disposal)
 "kMq" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -46574,6 +47092,7 @@
 	req_access = list(13);
 	req_one_access = list(11,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat/teleport)
 "kNc" = (
@@ -46648,6 +47167,10 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/brainstorm_center)
+"kOJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos)
 "kOQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46970,6 +47493,7 @@
 	name = "Theatre"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -47023,6 +47547,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -47088,6 +47613,7 @@
 	name = "Engineering Storage";
 	req_access = list(71)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -47327,6 +47853,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/entry{
 	name = "Research Shuttle Dock"
@@ -47530,6 +48057,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "kYJ" = (
@@ -47906,6 +48434,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -48110,6 +48639,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -48367,6 +48897,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "lhC" = (
@@ -48386,6 +48917,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -48947,6 +49479,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "loZ" = (
@@ -49014,6 +49547,15 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"lpQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/civilian/garden)
 "lpR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/syringe{
@@ -49092,6 +49634,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "lqI" = (
@@ -49143,6 +49686,7 @@
 /obj/structure/flora/ausbushes/sparsegrass{
 	layer = 2.7
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "lrJ" = (
@@ -49178,6 +49722,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
 "lrW" = (
@@ -49194,6 +49739,7 @@
 /obj/structure/transit_tube{
 	icon_state = "N-S"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "lse" = (
@@ -49315,6 +49861,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "ltp" = (
@@ -49333,6 +49880,7 @@
 	dir = 4;
 	name = "Primary Tool Storage"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -49346,6 +49894,7 @@
 	dir = 8;
 	network = list("SS13","Medical")
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -49370,6 +49919,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -49401,6 +49951,7 @@
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "luw" = (
@@ -49417,6 +49968,10 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
+"luK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/hos)
 "luL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -49495,6 +50050,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "lwo" = (
@@ -49634,6 +50190,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -49660,6 +50217,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "lzb" = (
@@ -49694,6 +50252,7 @@
 	name = "Security Maintenance";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "lzG" = (
@@ -49729,6 +50288,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -49751,6 +50311,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "lzV" = (
@@ -49948,6 +50509,7 @@
 	name = "CE Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor,
 /area/station/engineering/chiefs_office)
 "lCv" = (
@@ -49982,6 +50544,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "lCZ" = (
@@ -50277,6 +50840,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "lGH" = (
@@ -50383,6 +50947,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -50467,6 +51032,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"lHz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/xenobiology)
 "lHL" = (
 /obj/structure/table,
 /obj/item/device/t_scanner,
@@ -50510,6 +51079,12 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"lIj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/comms{
+	name = "Cyborg Station"
+	})
 "lIk" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/engine/airmix,
@@ -50804,6 +51379,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -50959,6 +51535,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "lOP" = (
@@ -51033,6 +51610,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "lPD" = (
@@ -51041,6 +51619,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"lPE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/gym)
 "lPG" = (
 /obj/structure/displaycase/captain,
 /obj/effect/decal/turf_decal/set_damaged,
@@ -51078,8 +51660,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
+"lQy" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/secconfhall)
 "lQN" = (
 /obj/machinery/computer/aifixer,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -51159,6 +51746,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -51212,6 +51800,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -51367,6 +51956,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/scibreak)
 "lUf" = (
@@ -51527,6 +52117,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -51608,6 +52199,7 @@
 	dir = 4;
 	name = "Docks"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -51636,6 +52228,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "lXM" = (
@@ -51801,6 +52394,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "lZS" = (
@@ -52212,6 +52806,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -52223,6 +52818,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cafe"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -52338,6 +52934,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "mfL" = (
@@ -52365,6 +52962,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -52442,6 +53040,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "mhJ" = (
@@ -53203,6 +53802,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "mqg" = (
@@ -53273,6 +53873,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -53406,6 +54007,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
+"mta" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/telesci)
 "mtt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/smart{
@@ -53605,6 +54210,7 @@
 	name = "Chemistry Lab";
 	req_access = list(33)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -53651,6 +54257,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/medical/cryo)
 "mxc" = (
@@ -53903,6 +54510,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -53914,6 +54522,10 @@
 "mAd" = (
 /turf/simulated/wall,
 /area/station/maintenance/dormitory)
+"mAf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/main)
 "mAg" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/item/clothing/under/patient_gown,
@@ -54313,6 +54925,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -54518,6 +55131,7 @@
 	name = "Privacy Shutters";
 	pixel_x = -28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "mGd" = (
@@ -54525,6 +55139,7 @@
 	dir = 1
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "mGh" = (
@@ -54593,6 +55208,7 @@
 	req_access = list(10)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -54672,6 +55288,7 @@
 	pixel_y = -5
 	},
 /obj/structure/closet/secure_closet/psycho,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "mGY" = (
@@ -55575,6 +56192,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "mTX" = (
@@ -55662,6 +56280,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "mUT" = (
@@ -55834,6 +56453,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
 "mXq" = (
@@ -56601,6 +57221,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -57084,6 +57705,10 @@
 	},
 /turf/simulated/floor/engine/nitrogen,
 /area/station/engineering/atmos)
+"nna" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/garden)
 "nnq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -57238,6 +57863,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -57380,6 +58006,10 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"nra" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/dormitories)
 "nrb" = (
 /obj/item/weapon/scrap_lump,
 /obj/effect/landmark{
@@ -57523,6 +58153,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"ntb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/kitchen)
 "ntn" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/turf_decal/set_burned,
@@ -57553,6 +58187,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
+"ntW" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/decoration/tinsel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/science)
 "nuc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -57647,6 +58296,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "nvO" = (
@@ -57723,6 +58373,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "nwq" = (
@@ -57767,6 +58418,7 @@
 	name = "Common Channel";
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "nwG" = (
@@ -57787,6 +58439,10 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
+"nwP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/lab)
 "nwU" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -57797,6 +58453,7 @@
 	req_access = list(13);
 	req_one_access = list(11,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/aisat/teleport)
 "nwV" = (
@@ -57832,6 +58489,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/secconfhall)
 "nxp" = (
@@ -57931,6 +58589,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "nzl" = (
@@ -58346,6 +59005,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "nEk" = (
@@ -58414,6 +59074,7 @@
 	pixel_x = 28;
 	req_access = list(55)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -58777,6 +59438,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -58823,6 +59485,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"nKb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/tcommsat/chamber)
 "nKh" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
@@ -58875,6 +59541,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -58938,6 +59605,10 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/simulated/floor,
 /area/station/medical/cryo)
+"nMf" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/storage)
 "nMm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -58989,6 +59660,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "nNi" = (
@@ -59005,6 +59677,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
 "nNs" = (
@@ -59083,6 +59756,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "nOw" = (
@@ -59235,6 +59909,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -59349,6 +60024,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "nTb" = (
@@ -59682,6 +60358,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "nWQ" = (
@@ -59729,6 +60406,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "nWZ" = (
@@ -59787,6 +60465,7 @@
 	req_access = list(10,13);
 	req_one_access = list(11,24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "nXY" = (
@@ -60133,6 +60812,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "odc" = (
@@ -60143,6 +60823,7 @@
 	dir = 4;
 	name = "Play Room"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -60250,6 +60931,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"oeB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/server)
 "oeC" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/requests_console/science{
@@ -60259,6 +60944,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/brainstorm_center)
+"oeD" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/medbay)
 "oeG" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/open,
 /turf/simulated/floor{
@@ -60631,6 +61324,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -60688,6 +61382,7 @@
 	name = "Medbay Maintenance";
 	req_access = list(5)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
 "ojQ" = (
@@ -61095,6 +61790,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/lawyer_office)
+"opa" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/cargo)
 "opA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61272,6 +61971,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "orq" = (
@@ -61416,6 +62116,7 @@
 	c_tag = "Arrival Dock's North";
 	dir = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -61428,6 +62129,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "privateoffice"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "osX" = (
@@ -61444,6 +62146,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "otj" = (
@@ -61563,6 +62266,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "ouu" = (
@@ -61655,6 +62359,10 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"ove" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/chemistry)
 "ovf" = (
 /obj/machinery/door/window/eastleft{
 	dir = 1;
@@ -61724,6 +62432,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
 "ovR" = (
@@ -61747,6 +62456,10 @@
 "owd" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hallway)
+"owg" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/interrogation)
 "owq" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -61863,6 +62576,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/monitoring)
+"oxu" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/hydroponics)
 "oxJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -61928,6 +62645,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/civilian/cold_room)
 "oza" = (
@@ -61979,6 +62697,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "ozB" = (
@@ -62133,6 +62852,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -62482,6 +63202,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -62561,6 +63282,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "oHi" = (
@@ -62582,6 +63304,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "oHU" = (
@@ -62743,6 +63466,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -62773,6 +63497,7 @@
 	pixel_x = 28;
 	req_access = list(55)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -62833,6 +63558,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"oKv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/miningoffice)
 "oKA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -62852,6 +63581,10 @@
 	},
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
+"oKW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/warden)
 "oLb" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge/server)
@@ -62980,6 +63713,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -63001,6 +63735,25 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/medbay)
+"oMR" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	opacity = 0
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/engine,
+/area/station/rnd/xenobiology)
 "oNd" = (
 /obj/random/foods/food_trash,
 /obj/effect/decal/cleanable/dirt,
@@ -63315,6 +64068,10 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"oRn" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/incinerator)
 "oRp" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -63353,6 +64110,7 @@
 	pixel_x = 32;
 	pixel_y = 8
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -63479,6 +64237,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -63558,6 +64317,10 @@
 	icon_state = "freezerfloor2"
 	},
 /area/station/bridge/captain_quarters)
+"oUZ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/morgue)
 "oVa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63722,6 +64485,7 @@
 	name = "Barbershop"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -63910,6 +64674,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"oYN" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/genetics)
 "oZh" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
@@ -63989,6 +64757,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkredfull"
 	},
@@ -64047,6 +64816,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "pbA" = (
@@ -64119,6 +64889,10 @@
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"pcB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/brainstorm_center)
 "pdd" = (
 /obj/structure/object_wall/mining{
 	icon_state = "2-9"
@@ -64280,6 +65054,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -64300,6 +65075,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -64380,6 +65156,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "pfZ" = (
@@ -64615,6 +65392,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"piU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/chapel)
 "piW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65176,6 +65957,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -65382,6 +66164,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -65436,6 +66219,10 @@
 "puU" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"puV" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/monitoring)
 "pvj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -65705,6 +66492,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
 	name = "Server Walkway";
@@ -65743,6 +66531,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access = list(47,12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "pzz" = (
@@ -65754,6 +66543,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "pzD" = (
@@ -65778,6 +66568,22 @@
 	icon_state = "black"
 	},
 /area/station/civilian/playroom)
+"pzP" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	opacity = 0
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/engine,
+/area/station/rnd/xenobiology)
 "pzT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -65934,6 +66740,7 @@
 	name = "CE Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "pBl" = (
@@ -66007,6 +66814,15 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/equip)
+"pBF" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/rnd/robotics)
 "pBY" = (
 /obj/structure/altar_of_gods,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -66082,6 +66898,10 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/port)
+"pDi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/misc_lab)
 "pDq" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -66171,6 +66991,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -66213,6 +67034,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "pFp" = (
@@ -66290,6 +67112,7 @@
 /area/station/engineering/drone_fabrication)
 "pGR" = (
 /obj/machinery/computer/station_alert,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -66543,6 +67366,15 @@
 "pJO" = (
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"pJR" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "pJV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66654,6 +67486,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -66750,6 +67583,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "pMp" = (
@@ -67035,6 +67869,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/whitegreed,
 /area/station/bridge/ai_upload)
 "pQh" = (
@@ -67044,6 +67879,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/security/brig)
 "pQk" = (
@@ -67258,6 +68094,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkblue"
 	},
@@ -67270,6 +68107,10 @@
 	icon_state = "dark"
 	},
 /area/station/security/checkpoint)
+"pTP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/cmo)
 "pTZ" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay";
@@ -67278,6 +68119,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -67343,6 +68185,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "pUD" = (
@@ -67393,6 +68236,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
 "pVe" = (
@@ -67507,6 +68351,7 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "pWa" = (
@@ -67535,6 +68380,10 @@
 	icon_state = "red"
 	},
 /area/station/security/lobby)
+"pWs" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/ai_upload)
 "pWt" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -68004,6 +68853,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "qbP" = (
@@ -68171,6 +69021,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -68362,6 +69213,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "qgz" = (
@@ -68759,6 +69611,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "qln" = (
@@ -68812,6 +69665,14 @@
 	icon_state = "brown"
 	},
 /area/station/hallway/secondary/entry)
+"qmv" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/item/decoration/snowman,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "qmx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -68925,6 +69786,10 @@
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"qoz" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/hop_office)
 "qoB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -68974,6 +69839,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
+"qpx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/drone_fabrication)
+"qpG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/bridge/nuke_storage)
 "qqa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69209,6 +70082,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -69565,6 +70439,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"qwd" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/port)
 "qwh" = (
 /obj/item/device/radio/intercom/pod{
 	dir = 4;
@@ -69586,6 +70464,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "qwq" = (
@@ -69651,6 +70530,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "qxU" = (
@@ -69662,6 +70542,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70124,6 +71005,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -70160,6 +71042,16 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"qDe" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/sign/directions/dock_tablo/tablo2,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "qDk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70305,6 +71197,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/dormthree)
 "qFI" = (
@@ -70381,6 +71274,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70433,6 +71327,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70628,6 +71523,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "qKm" = (
@@ -70658,6 +71554,7 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70675,6 +71572,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70725,6 +71623,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
 	name = "Server Walkway";
@@ -70745,12 +71644,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"qMi" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/ai_monitored/eva)
 "qMs" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "qMz" = (
@@ -70779,6 +71683,7 @@
 	name = "Internal Affairs";
 	req_access = list(38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70929,6 +71834,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "qOY" = (
@@ -71095,6 +72001,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
 "qRL" = (
@@ -71118,6 +72025,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
 "qSg" = (
@@ -71151,6 +72059,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "qSL" = (
@@ -71246,6 +72155,13 @@
 /area/station/bridge/comms{
 	name = "Cyborg Station"
 	})
+"qUe" = (
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "qUi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71331,6 +72247,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "qVa" = (
@@ -71381,6 +72298,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -71589,6 +72507,7 @@
 	name = "Robotics Maintenance";
 	req_access = list(29)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "qYB" = (
@@ -71908,6 +72827,12 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"rbU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/surgery{
+	name = "Operating Theatre"
+	})
 "rbZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -72016,6 +72941,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/drone_fabrication)
 "rdC" = (
@@ -72093,6 +73019,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72117,6 +73044,7 @@
 	name = "Escape Airlock";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "rer" = (
@@ -72200,6 +73128,7 @@
 	dir = 8;
 	icon_state = "warn_corner"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72712,6 +73641,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "rmy" = (
@@ -72824,6 +73754,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"rom" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/science)
 "rot" = (
 /obj/item/weapon/book/manual/wiki/possible_threats,
 /obj/structure/table/glass,
@@ -72846,11 +73780,31 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"rpk" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry)
 "rpu" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/environment/space,
 /area/space)
+"rpE" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio4";
+	name = "Containment Blast Doors";
+	opacity = 0
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/engine,
+/area/station/rnd/xenobiology)
 "rpO" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -72996,6 +73950,12 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
+"rro" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/asteroid/research_outpost/entry{
+	name = "Research Shuttle Dock"
+	})
 "rry" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -73015,6 +73975,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "rrM" = (
@@ -73103,6 +74064,7 @@
 	name = "Medbay External Access";
 	req_one_access = list(13,45,1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "rsy" = (
@@ -73532,6 +74494,7 @@
 /area/station/hallway/secondary/exit)
 "rxF" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -73570,6 +74533,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"rxU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/space)
 "rxY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -73618,6 +74585,7 @@
 	name = "Bridge";
 	req_one_access = list(19,38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74009,6 +74977,7 @@
 	name = "Xenoarchaeologist office";
 	req_access = list(65)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74035,6 +75004,16 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"rDK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry)
 "rDT" = (
 /obj/machinery/power/smes,
 /obj/structure/extinguisher_cabinet{
@@ -74269,6 +75248,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "rHg" = (
@@ -74510,6 +75490,10 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"rKv" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "rKK" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -74816,6 +75800,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74913,6 +75898,7 @@
 	name = "Bridge";
 	req_one_access = list(19,38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74974,6 +75960,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74987,6 +75974,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"rQt" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/storage)
 "rQC" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/telesci)
@@ -75359,6 +76350,7 @@
 	name = "Cargo Bay";
 	req_one_access = list(31,48,67)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -75385,6 +76377,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "rVw" = (
@@ -75403,6 +76396,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/secconfhall)
+"rVE" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/gateway)
 "rVG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/farmbot_arm_assembly,
@@ -75423,6 +76420,7 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -75504,10 +76502,15 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"rWP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/prison)
 "rWQ" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -75559,6 +76562,14 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/lab)
+"rXI" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/science)
 "rXJ" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -75700,6 +76711,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "rYT" = (
@@ -75919,6 +76931,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
+"sbR" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/server)
 "sca" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -75942,6 +76958,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "scA" = (
@@ -76152,6 +77169,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -76189,6 +77207,7 @@
 	name = "Science Maintenance";
 	req_access = list(47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "seO" = (
@@ -76236,16 +77255,13 @@
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "sfA" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 4
-	},
 /obj/machinery/newscaster{
 	pixel_x = -28
 	},
 /obj/machinery/alarm{
 	pixel_y = -32
 	},
-/obj/effect/landmark/start/assistant,
+/obj/item/weapon/present,
 /turf/simulated/floor/carpet,
 /area/station/civilian/bar)
 "sfL" = (
@@ -76261,6 +77277,7 @@
 	name = "Cafe"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -76459,12 +77476,14 @@
 	name = "CE Shutters";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "sjw" = (
 /obj/structure/mineral_door/wood,
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/maintenance/brig)
 "sjF" = (
@@ -76575,6 +77594,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -76603,10 +77623,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/rnd/lab)
+"slG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/locker)
 "slU" = (
 /obj/machinery/scrap/stacking_machine,
 /obj/machinery/conveyor{
@@ -76621,6 +77646,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "Detective"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "smc" = (
@@ -76807,6 +77833,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "soH" = (
@@ -76953,6 +77980,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "spW" = (
@@ -77109,6 +78137,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "ssl" = (
@@ -77419,6 +78448,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycleroffice)
+"swg" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/break_room)
 "swi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -77514,6 +78547,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "swC" = (
@@ -77637,6 +78671,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry{
 	name = "Research Shuttle Dock"
@@ -77729,6 +78764,10 @@
 	icon_state = "white"
 	},
 /area/station/hallway/secondary/exit)
+"syY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/bridge/hop_office)
 "szr" = (
 /obj/random/scrap/safe_even,
 /obj/effect/decal/turf_decal/set_damaged,
@@ -77826,6 +78865,7 @@
 	name = "Internal Affairs";
 	req_access = list(38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -78151,6 +79191,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/cargo/office)
+"sDC" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "sDI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/turf_decal{
@@ -78267,6 +79320,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "sFB" = (
@@ -78387,6 +79441,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "sGE" = (
@@ -78543,6 +79598,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -78654,6 +79710,10 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/hor)
+"sJP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/arrival)
 "sJX" = (
 /obj/machinery/disposal,
 /obj/structure/sign/warning/morgue_disposal{
@@ -78740,6 +79800,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -78774,6 +79835,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "sLX" = (
@@ -79064,6 +80126,7 @@
 	name = "apc left";
 	pixel_x = -28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "sRl" = (
@@ -79117,6 +80180,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "sRO" = (
@@ -79274,6 +80338,7 @@
 	name = "Forensic Maintenance";
 	req_one_access = list(4,68)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/forensic_office)
 "sSZ" = (
@@ -79484,6 +80549,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "sUT" = (
@@ -79637,6 +80703,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -79770,6 +80837,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "sZs" = (
@@ -79784,6 +80852,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -80085,6 +81154,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"tdM" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/interrogation)
 "tei" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -80111,6 +81184,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Docks"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -80171,6 +81245,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
 "tfc" = (
@@ -80189,6 +81264,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"tfl" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/antechamber)
 "tfs" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -80458,6 +81537,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "thV" = (
@@ -80561,6 +81641,10 @@
 /area/station/security/vacantoffice{
 	name = "Tribunal"
 	})
+"tiW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/primary/fore)
 "tiX" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -80578,6 +81662,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry{
 	name = "Research Shuttle Dock"
@@ -80644,6 +81729,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -80697,6 +81783,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkyellow"
@@ -80756,6 +81843,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -81018,6 +82106,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -81273,6 +82362,7 @@
 	name = "Cargo Office Maintenance";
 	req_access = list(50)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "tuD" = (
@@ -81531,6 +82621,10 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/arrival)
+"tzh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycleroffice)
 "tzn" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/purple,
@@ -81685,6 +82779,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -81915,6 +83010,12 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/robotics)
+"tDL" = (
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/bar)
 "tDP" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -82229,6 +83330,10 @@
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"tGG" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/storage)
 "tHc" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/book/manual/wiki/sop{
@@ -82360,6 +83465,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "tIJ" = (
@@ -82450,6 +83556,7 @@
 	dir = 4;
 	network = list("RD","MiniSat")
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -82557,6 +83664,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkredfull"
 	},
@@ -82621,10 +83729,15 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/altar)
+"tKt" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel)
 "tKN" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
@@ -82648,6 +83761,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "tKX" = (
@@ -82732,6 +83846,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "tLU" = (
@@ -83367,6 +84482,7 @@
 	name = "Detective Maintenance";
 	req_one_access = list(4,68)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "tUk" = (
@@ -83566,6 +84682,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "tWJ" = (
@@ -83861,6 +84978,7 @@
 	req_access = list(71)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84019,6 +85137,10 @@
 /area/asteroid/research_outpost/entry{
 	name = "Research Shuttle Dock"
 	})
+"uel" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/atmos)
 "uem" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -84282,6 +85404,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "privateoffice"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice{
 	name = "Tribunal"
@@ -84415,6 +85538,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "ujC" = (
@@ -84437,6 +85561,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84478,6 +85603,10 @@
 	icon_state = "black"
 	},
 /area/station/civilian/fitness)
+"ukb" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/ai_monitored/storage_secure)
 "ukg" = (
 /obj/effect/decal/cleanable/generic,
 /obj/random/scrap/safe_even,
@@ -84571,6 +85700,7 @@
 	name = "Morgue";
 	req_access = list(6)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84636,6 +85766,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84771,6 +85902,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "unp" = (
@@ -84825,6 +85957,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "upb" = (
@@ -85117,6 +86250,12 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"usm" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/medical/reception)
 "usp" = (
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
@@ -85228,6 +86367,7 @@
 /area/station/ai_monitored/eva)
 "utx" = (
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -85312,6 +86452,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "uuv" = (
@@ -85359,6 +86500,7 @@
 	name = "Escape Airlock";
 	req_access = list(1)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "uuT" = (
@@ -85443,6 +86585,10 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"uwx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/office)
 "uwG" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/flora/pottedplant/aquatic{
@@ -85492,6 +86638,7 @@
 /area/station/engineering/monitoring)
 "uxH" = (
 /obj/machinery/computer/arcade,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -85566,6 +86713,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkred"
 	},
@@ -85818,6 +86966,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -85871,6 +87020,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice{
 	name = "Tribunal"
@@ -86136,6 +87286,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "uGR" = (
@@ -86234,6 +87385,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "uHD" = (
@@ -86440,6 +87592,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced/stall,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "uJQ" = (
@@ -86508,6 +87661,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"uKx" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/medical/virology)
 "uKA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86785,6 +87942,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"uNJ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/theatre)
 "uNL" = (
 /obj/decal/boxingrope{
 	density = 0;
@@ -86830,6 +87991,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "uOj" = (
@@ -86857,6 +88019,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -87498,6 +88661,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -87653,6 +88817,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
 "uZx" = (
@@ -87678,6 +88843,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "uZI" = (
@@ -87785,6 +88951,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/server)
 "vaA" = (
@@ -87996,6 +89163,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
 "vdb" = (
@@ -88274,6 +89442,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "vgE" = (
@@ -88410,6 +89579,7 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -88540,6 +89710,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/lobby)
+"vjK" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/rnd/hor)
 "vjO" = (
 /turf/simulated/floor{
 	icon_state = "whitehall"
@@ -88603,6 +89777,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -88703,6 +89878,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "vlC" = (
@@ -88796,6 +89972,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -88866,6 +90043,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "vnM" = (
@@ -88957,6 +90135,7 @@
 	name = "Gym"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -88991,6 +90170,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -89119,6 +90299,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
 "vrw" = (
@@ -89153,6 +90334,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "vrZ" = (
@@ -89307,6 +90489,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "vtZ" = (
@@ -89353,6 +90536,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "vva" = (
@@ -89385,6 +90569,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "vvu" = (
@@ -89416,6 +90601,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"vwj" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/armoury)
 "vwn" = (
 /turf/simulated/floor{
 	icon_state = "red"
@@ -89476,6 +90665,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "vwP" = (
@@ -89573,6 +90763,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -89655,6 +90846,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "vyP" = (
@@ -89735,6 +90927,7 @@
 	name = "Cooling Room";
 	req_access = list(72)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -89981,6 +91174,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -90059,6 +91253,7 @@
 	req_access = list(10)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "vDg" = (
@@ -90079,6 +91274,7 @@
 /obj/structure/flora/ausbushes/fullgrass{
 	layer = 2.7
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "vDn" = (
@@ -90102,6 +91298,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "vDS" = (
@@ -90124,6 +91321,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "vDW" = (
@@ -90340,10 +91538,19 @@
 	name = "Bridge";
 	req_one_access = list(19,38)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/bridge)
+"vFP" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/maintenance/portsolar)
 "vGn" = (
 /obj/structure/closet/toolcloset,
 /obj/item/weapon/module/power_control,
@@ -90627,6 +91834,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
 "vKA" = (
@@ -90768,6 +91976,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -90892,6 +92101,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -91045,6 +92255,7 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -91403,6 +92614,7 @@
 	icon_state = "gr_window_reinforced_polarized";
 	id = "chapel"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "vUY" = (
@@ -91478,6 +92690,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "vVO" = (
@@ -91495,6 +92708,10 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"vWe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/bridge/captain_quarters)
 "vWl" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Crematorium";
@@ -91781,6 +92998,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "vZe" = (
@@ -92035,6 +93253,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -92318,6 +93537,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/computer)
 "weK" = (
@@ -92418,6 +93638,10 @@
 	icon_state = "solarpanel"
 	},
 /area/station/solar/port)
+"wfe" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/altar)
 "wfl" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/machinery/light_switch{
@@ -92702,6 +93926,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -92887,6 +94112,10 @@
 	icon_state = "arcade_carpet"
 	},
 /area/station/civilian/playroom)
+"wlU" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/hallway)
 "wmg" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "0,2"
@@ -93365,6 +94594,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"wsa" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "xenobio5";
+	name = "Containment Blast Doors";
+	opacity = 0
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/engine,
+/area/station/rnd/xenobiology)
 "wsA" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/libraryconsole/old,
@@ -93373,6 +94621,7 @@
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "wsM" = (
@@ -93513,6 +94762,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "wuk" = (
@@ -93833,6 +95083,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "wyd" = (
@@ -94186,6 +95437,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "wDS" = (
@@ -94372,6 +95624,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -94503,6 +95756,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -94699,6 +95953,10 @@
 	},
 /turf/environment/space,
 /area/space)
+"wKC" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/security/detectives_office)
 "wKQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -94726,6 +95984,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "wKS" = (
@@ -94746,6 +96005,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "wLa" = (
@@ -94884,6 +96144,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -94902,6 +96163,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "wMp" = (
@@ -94924,6 +96186,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -95280,6 +96543,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -95595,6 +96859,10 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/lobby)
+"wUX" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/security/execution)
 "wVb" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -95648,6 +96916,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -95860,6 +97129,7 @@
 	name = "Mining Equpment";
 	req_access = list(48)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -95949,6 +97219,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -95963,6 +97234,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "wZG" = (
@@ -96130,6 +97402,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "xcc" = (
@@ -96204,6 +97477,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/civilian/janitor)
 "xdc" = (
@@ -96296,6 +97570,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "xeb" = (
@@ -96316,6 +97591,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -96557,6 +97833,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "xgz" = (
@@ -96612,6 +97889,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "xhq" = (
@@ -96653,6 +97931,7 @@
 /obj/machinery/keycard_auth{
 	pixel_y = 28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "xih" = (
@@ -96781,6 +98060,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "xjt" = (
@@ -97009,6 +98289,7 @@
 	name = "Docks"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brown"
@@ -97045,6 +98326,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -97197,6 +98479,10 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"xpr" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/antechamber_interior)
 "xpt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97488,6 +98774,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -97504,6 +98791,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"xuh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/civilian/chapel/mass_driver)
 "xuj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97611,6 +98902,7 @@
 	dir = 4;
 	req_one_access = list(47,12)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "xvI" = (
@@ -97749,6 +99041,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/entry{
 	name = "Research Shuttle Dock"
@@ -97759,6 +99052,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "xxb" = (
@@ -97802,6 +99096,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "xxv" = (
@@ -97987,6 +99282,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -98327,6 +99623,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "xGa" = (
@@ -98663,6 +99960,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "xKV" = (
@@ -98706,6 +100004,10 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/entry)
+"xLh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/medical/genetics)
 "xLk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -98925,6 +100227,7 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -99201,6 +100504,7 @@
 	opacity = 0
 	},
 /obj/structure/cable/yellow,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "xSb" = (
@@ -99226,6 +100530,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -99658,6 +100963,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "xXv" = (
@@ -99797,6 +101103,7 @@
 	dir = 9;
 	icon_state = "warn"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -100124,6 +101431,7 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -100220,6 +101528,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -100361,6 +101670,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "ygv" = (
@@ -100435,6 +101745,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
+"yhm" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/engine)
 "yhz" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
@@ -100487,6 +101801,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -100650,6 +101965,7 @@
 	name = "Security Maintenance";
 	req_one_access = list(1,4)
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/security/secconfhall)
 "yjy" = (
@@ -115051,7 +116367,7 @@ iRy
 iRy
 cJy
 qZw
-hpJ
+vFP
 eEk
 uxP
 iRy
@@ -115310,7 +116626,7 @@ cJy
 qZw
 kuO
 kar
-hpJ
+vFP
 cJy
 cJy
 cJy
@@ -115320,7 +116636,7 @@ vaI
 vyG
 nSO
 vaI
-vaI
+uKx
 cJy
 cJy
 cJy
@@ -115571,7 +116887,7 @@ hpJ
 iRy
 iRy
 cJy
-vaI
+uKx
 vaI
 etC
 eVt
@@ -115580,7 +116896,7 @@ hdK
 vaI
 vyG
 vyG
-vaI
+uKx
 cJy
 dYE
 dYE
@@ -116342,7 +117658,7 @@ diT
 qle
 uxP
 cJy
-vaI
+uKx
 eaJ
 uMK
 yeP
@@ -116590,7 +117906,7 @@ lbA
 xnx
 pnr
 feK
-xnx
+kaU
 tTj
 uxP
 sOq
@@ -116618,7 +117934,7 @@ jeg
 gyS
 gyS
 gyS
-jeg
+jVW
 jeg
 qwk
 qwk
@@ -116631,7 +117947,7 @@ jeg
 uuQ
 jeg
 gSs
-gSs
+aXe
 gSs
 gSs
 cJy
@@ -116890,7 +118206,7 @@ xih
 jDO
 foD
 foD
-gSs
+aXe
 gSs
 eAP
 eAP
@@ -117346,7 +118662,7 @@ iRy
 cJy
 xVs
 dIw
-uPx
+oeD
 uPx
 dIw
 rSS
@@ -117382,7 +118698,7 @@ lNY
 lsG
 vaI
 cJy
-jeg
+jVW
 uxH
 fJw
 pnq
@@ -117397,7 +118713,7 @@ mcK
 dAY
 kpz
 iwI
-gSs
+aXe
 lJo
 tLy
 vZC
@@ -117637,7 +118953,7 @@ soF
 kKG
 lPk
 mBr
-vaI
+uKx
 cJy
 jeg
 fJm
@@ -117859,7 +119175,7 @@ cJy
 iRy
 cJy
 eAP
-uPx
+oeD
 fDn
 vSB
 dIw
@@ -117874,7 +119190,7 @@ dlz
 mZc
 mZc
 hah
-mZc
+oUZ
 mZc
 vvG
 bHf
@@ -118133,7 +119449,7 @@ gzH
 hif
 lys
 mZc
-mZc
+oUZ
 mZc
 mZc
 mZc
@@ -118149,7 +119465,7 @@ cmS
 iCa
 vaI
 vaI
-vaI
+uKx
 vaI
 cJy
 cJy
@@ -118174,7 +119490,7 @@ paq
 awq
 gSs
 gSs
-gSs
+aXe
 gSs
 xxo
 mIg
@@ -118199,7 +119515,7 @@ rKO
 rKO
 hGN
 cJy
-vlL
+rpk
 adA
 otf
 mfJ
@@ -118382,9 +119698,9 @@ oVV
 dIw
 ggT
 xSD
+xLh
 xSD
-xSD
-mZc
+oUZ
 hcM
 vga
 xXb
@@ -118394,7 +119710,7 @@ ejP
 aqg
 vTD
 aqg
-mZc
+oUZ
 mZc
 hgZ
 dIw
@@ -118975,7 +120291,7 @@ acR
 cOE
 kCc
 adB
-vlL
+rpk
 vlL
 vlL
 xBl
@@ -119151,7 +120467,7 @@ fgT
 vLL
 kOQ
 nNv
-xSD
+xLh
 rtu
 nbn
 eEA
@@ -119185,7 +120501,7 @@ ufi
 dIw
 dIw
 dhj
-jeg
+jVW
 jeg
 jeg
 jeg
@@ -119423,7 +120739,7 @@ tSh
 iCi
 aoR
 mVd
-mZc
+oUZ
 cuM
 tad
 tPv
@@ -119671,14 +120987,14 @@ gxy
 dKR
 blV
 blV
-blV
+ffA
 mZc
 ukK
 mZc
 mZc
 mZc
 mqg
-mZc
+oUZ
 mZc
 mZc
 aMO
@@ -119998,7 +121314,7 @@ rKO
 rKO
 hGN
 cJy
-adz
+qDe
 riZ
 acZ
 izf
@@ -120200,18 +121516,18 @@ atz
 kjq
 qHi
 aMO
-aMO
+wlU
 yim
 aMO
 aMO
 aMO
-aMO
+wlU
 aMO
 aMO
 aMO
 ajQ
 aMO
-aMO
+wlU
 aMO
 qul
 pvt
@@ -120516,7 +121832,7 @@ vlL
 uem
 enF
 eGP
-vlL
+rpk
 xBl
 xBl
 xBl
@@ -120745,7 +122061,7 @@ gSs
 gSs
 niF
 niF
-niF
+aXE
 vqT
 niF
 niF
@@ -120759,7 +122075,7 @@ vTK
 apD
 nCx
 adZ
-apD
+epB
 apD
 iRy
 iRy
@@ -121007,7 +122323,7 @@ ptc
 fmw
 vlL
 vlL
-vlL
+rpk
 vlL
 pUB
 pUB
@@ -121019,14 +122335,14 @@ aea
 mjv
 vlL
 pUB
-vlL
+rpk
 adz
 otf
 lqA
 vlL
 pUB
 pUB
-vlL
+rpk
 uem
 enF
 eGP
@@ -121227,7 +122543,7 @@ eQK
 abg
 gEn
 aMO
-ngU
+pTP
 ngU
 vuJ
 lGu
@@ -121256,7 +122572,7 @@ iwx
 sNT
 jhd
 jxo
-ecV
+rDK
 tWQ
 jxo
 jxo
@@ -121466,7 +122782,7 @@ dIw
 mAP
 sYU
 dNx
-dNx
+oYN
 dNx
 avv
 dNx
@@ -121491,18 +122807,18 @@ rot
 gIV
 ngU
 ngU
-ngU
+pTP
 hiT
 oqi
 bmU
 xpt
 peQ
 hiT
-hiT
+grx
 jeg
 fhh
 jeg
-jeg
+jVW
 jeg
 tJy
 aLm
@@ -121769,7 +123085,7 @@ pyq
 pyq
 pyq
 pyq
-pyq
+bvu
 pyq
 pyq
 oAw
@@ -121779,17 +123095,17 @@ vgG
 vlL
 vlL
 vlL
-vlL
+rpk
 vlL
 oIb
 cTb
 oIb
 vlL
+rpk
 vlL
 vlL
 vlL
-vlL
-vlL
+rpk
 oAw
 vlM
 act
@@ -121797,12 +123113,12 @@ gho
 vlL
 hvU
 oAw
-oIb
+opa
 oIb
 rkj
+opa
 oIb
-oIb
-cDK
+kMf
 cDK
 hpf
 cDK
@@ -121812,7 +123128,7 @@ oAw
 vlM
 vlL
 vlL
-vlL
+rpk
 vlL
 rbr
 rbr
@@ -122022,17 +123338,17 @@ gQM
 jRR
 nSy
 pyq
-pyq
+bvu
 nUW
 olz
 hCY
 aPe
 kXC
 pyq
-pyq
+bvu
 oIb
 nGb
-oIb
+opa
 oIb
 kkU
 pZT
@@ -122048,7 +123364,7 @@ tfs
 acl
 oIb
 oIb
-oIb
+opa
 oIb
 rim
 oIb
@@ -122535,7 +123851,7 @@ xLg
 txG
 auj
 xVD
-pyq
+bvu
 jpM
 vBj
 swq
@@ -122570,7 +123886,7 @@ acB
 vlN
 aco
 ubL
-tfs
+rKv
 tfs
 adm
 cDK
@@ -122727,11 +124043,11 @@ ool
 adx
 gUB
 kzA
-adx
+fiL
 iIm
 mdw
 akB
-iDo
+nMf
 iyO
 xQI
 bTW
@@ -122755,7 +124071,7 @@ aoG
 dIw
 eSb
 eSb
-wAI
+ove
 wAI
 wAI
 pFn
@@ -122780,14 +124096,14 @@ lxh
 rPQ
 vbg
 hiT
-hiT
+grx
 hiT
 hiT
 rsJ
 ljt
 pyq
 pyq
-pyq
+bvu
 pyq
 wLX
 faY
@@ -122809,7 +124125,7 @@ drr
 vlN
 juX
 oDy
-oDy
+eTS
 svI
 svI
 oDy
@@ -123070,9 +124386,9 @@ dlW
 vVO
 diZ
 llG
+eTS
 oDy
-oDy
-oDy
+eTS
 oDy
 drr
 ubL
@@ -123298,7 +124614,7 @@ acd
 qxb
 kly
 iVG
-pyq
+bvu
 jFS
 olz
 jNy
@@ -123320,7 +124636,7 @@ qHJ
 ntn
 kkU
 oDy
-oDy
+eTS
 dmm
 unI
 tXz
@@ -123513,7 +124829,7 @@ aoY
 laI
 djO
 fko
-cbf
+sbR
 cbf
 lcA
 nBc
@@ -123524,7 +124840,7 @@ dIw
 tXj
 dIw
 xXq
-eSb
+rQt
 faa
 cKl
 sJf
@@ -123570,7 +124886,7 @@ kyW
 eBf
 pyq
 pyq
-pyq
+bvu
 pyq
 lCv
 jhv
@@ -123763,7 +125079,7 @@ iDo
 uDe
 iwP
 pCm
-cbf
+sbR
 iTi
 qij
 vbW
@@ -123978,7 +125294,7 @@ cJy
 cJy
 bsl
 bsl
-bsl
+lHz
 bsl
 bsl
 cJy
@@ -124008,7 +125324,7 @@ nID
 kVU
 wVc
 adx
-adx
+fiL
 adx
 qwq
 eZz
@@ -124016,7 +125332,7 @@ hbq
 rqU
 idV
 xBU
-iDo
+nMf
 uDe
 blp
 pCm
@@ -124031,7 +125347,7 @@ peI
 cbf
 unB
 unB
-unB
+brN
 unB
 unB
 afo
@@ -124082,7 +125398,7 @@ sgo
 lRJ
 byk
 cEF
-pyq
+bvu
 pyq
 pyq
 pyq
@@ -124276,13 +125592,13 @@ lRk
 iDo
 uua
 uua
-uua
+vjK
 uua
 uua
 uua
 fMh
 uua
-uua
+vjK
 ehp
 cbf
 unB
@@ -124342,7 +125658,7 @@ hEb
 pyq
 tBq
 rOi
-pyq
+bvu
 jrx
 aQi
 tfb
@@ -124490,7 +125806,7 @@ cJy
 iRy
 cJy
 iRy
-bsl
+lHz
 qkG
 eyL
 hab
@@ -124540,7 +125856,7 @@ dHV
 mnr
 emI
 uua
-uua
+vjK
 unB
 cYQ
 imv
@@ -124592,7 +125908,7 @@ vSi
 bEv
 cGe
 tnn
-ono
+fJx
 aCu
 lIr
 jNy
@@ -124788,7 +126104,7 @@ rqU
 idV
 efU
 rym
-uua
+vjK
 fGi
 vVx
 vNx
@@ -124841,7 +126157,7 @@ sgK
 bNr
 mYk
 waE
-pyq
+bvu
 rdN
 cdZ
 acD
@@ -124863,7 +126179,7 @@ tfb
 sfr
 tPp
 bxS
-tcD
+qmv
 sLP
 xPj
 oAg
@@ -125001,16 +126317,16 @@ cJy
 iRy
 cJy
 bsl
+lHz
 bsl
 bsl
 bsl
-bsl
-eLT
+wsa
 ggi
 eLT
 bsl
 bsl
-bsl
+lHz
 bsl
 bsl
 cJy
@@ -125035,7 +126351,7 @@ dwY
 gro
 jXl
 xGB
-adx
+fiL
 ulF
 jsC
 uNu
@@ -125090,7 +126406,7 @@ ack
 nWi
 iWk
 iWk
-iWk
+rbU
 iWk
 iWk
 vIN
@@ -125111,7 +126427,7 @@ aeB
 xsR
 pyq
 pyq
-pyq
+bvu
 pyq
 pyq
 tfs
@@ -125265,7 +126581,7 @@ dbE
 eSa
 cse
 hkP
-jfa
+rpE
 qkG
 qkG
 qkG
@@ -125276,7 +126592,7 @@ cJy
 cJy
 iRy
 eAP
-cit
+rXI
 kBf
 ygv
 nID
@@ -125303,7 +126619,7 @@ adx
 adx
 adx
 uua
-uua
+vjK
 uua
 uZk
 tgZ
@@ -125319,7 +126635,7 @@ cwA
 xuk
 ljF
 ncB
-unB
+brN
 dIw
 uTy
 dIw
@@ -125387,7 +126703,7 @@ naC
 nGI
 nGI
 txf
-oDy
+eTS
 cJy
 iRy
 iRy
@@ -125608,7 +126924,7 @@ jLB
 fvq
 jWK
 jWK
-jWK
+lPE
 jWK
 jWK
 jWK
@@ -125620,7 +126936,7 @@ hcw
 pgg
 usp
 bhn
-oIb
+opa
 rgH
 rPn
 nox
@@ -125635,7 +126951,7 @@ slU
 cYJ
 aaS
 twz
-oDy
+eTS
 xuL
 aFi
 jvx
@@ -125771,7 +127087,7 @@ cJy
 cJy
 cJy
 cJy
-bsl
+lHz
 qkG
 qkG
 qkG
@@ -125783,7 +127099,7 @@ jfa
 qkG
 lYz
 qkG
-bsl
+lHz
 cJy
 cJy
 cJy
@@ -125797,10 +127113,10 @@ cpG
 tND
 uQT
 dOk
+hIa
 dOk
 dOk
-dOk
-dOk
+hIa
 dOk
 fXH
 xOs
@@ -125863,7 +127179,7 @@ qNe
 eGo
 rdo
 jWK
-jWK
+lPE
 xBu
 fVA
 jBw
@@ -125900,7 +127216,7 @@ pVE
 scA
 sME
 rje
-oDy
+eTS
 oDy
 cJy
 cJy
@@ -126031,14 +127347,14 @@ bsl
 bsl
 bsl
 bsl
-bsl
+lHz
 bsl
 egQ
 gEh
 nMQ
 bsl
 bsl
-bsl
+lHz
 bsl
 bsl
 bsl
@@ -126091,7 +127407,7 @@ sJX
 pOV
 rwS
 htn
-htn
+dSK
 htn
 rdg
 irf
@@ -126137,7 +127453,7 @@ bst
 hTs
 hTs
 hTs
-hTs
+uwx
 hTs
 hTs
 hTs
@@ -126151,7 +127467,7 @@ pwJ
 blu
 eAt
 ozg
-ozg
+tzh
 ozg
 spP
 ozg
@@ -126282,7 +127598,7 @@ cJy
 bsl
 bsl
 bsl
-bsl
+lHz
 bsl
 bsl
 blJ
@@ -126367,7 +127683,7 @@ dkq
 wSX
 rsN
 qNe
-qNe
+hfk
 qNe
 vzV
 qNe
@@ -126573,7 +127889,7 @@ wei
 aTL
 jJg
 vbr
-dOk
+hIa
 uLu
 uUf
 gjW
@@ -126601,7 +127917,7 @@ wGJ
 rjC
 wyd
 jZY
-rwS
+pBF
 iaX
 mZl
 gZP
@@ -126649,7 +127965,7 @@ utB
 itW
 pds
 hTs
-hTs
+uwx
 hTs
 mGN
 lXQ
@@ -126659,7 +127975,7 @@ nIe
 nIe
 nIe
 nIe
-ozg
+tzh
 bne
 pFm
 uHj
@@ -126798,7 +128114,7 @@ qkG
 qkG
 qkG
 azi
-fhH
+kzl
 ary
 ary
 cDx
@@ -127093,7 +128409,7 @@ dWh
 dWh
 vBS
 oAY
-owd
+eIc
 iwM
 iHM
 rAZ
@@ -127111,11 +128427,11 @@ eCP
 kOH
 bCc
 bbB
-rwS
+pBF
 xae
 wof
 hoo
-rwS
+pBF
 oQY
 lYK
 sTy
@@ -127148,14 +128464,14 @@ eEa
 jWK
 jWK
 jWK
+lPE
 jWK
 jWK
-jWK
-jWK
+lPE
 ouu
 jWK
 jWK
-kKE
+nra
 kKE
 kKE
 fNg
@@ -127308,7 +128624,7 @@ iRy
 iRy
 cJy
 bsl
-bsl
+lHz
 bsl
 bsl
 bsl
@@ -127328,7 +128644,7 @@ see
 nog
 bsl
 bsl
-bsl
+lHz
 bsl
 bsl
 bsl
@@ -127338,11 +128654,11 @@ tss
 mxR
 hZh
 gus
-gus
+pDi
 jFx
 gus
 gus
-dOk
+hIa
 dOk
 dOk
 dOk
@@ -127397,7 +128713,7 @@ icV
 ioO
 qNe
 qNe
-qNe
+hfk
 qNe
 uJd
 bjZ
@@ -127419,7 +128735,7 @@ uXq
 qXW
 usp
 naQ
-hTs
+uwx
 pbD
 hax
 oJZ
@@ -127573,13 +128889,13 @@ bsl
 bsl
 bsl
 bsl
-bsl
+lHz
 bsl
 nMQ
 gEh
 egQ
 bsl
-bsl
+lHz
 bsl
 bsl
 bsl
@@ -127626,7 +128942,7 @@ fiu
 fxm
 rzD
 dMi
-dMi
+pcB
 dMi
 dMi
 dMi
@@ -127658,7 +128974,7 @@ jRp
 hkA
 wLd
 mUv
-jWK
+lPE
 iXl
 iXl
 iXl
@@ -127696,7 +129012,7 @@ ozg
 dps
 abD
 abI
-lYa
+tGG
 lYa
 cJy
 hGN
@@ -127827,7 +129143,7 @@ iRy
 cJy
 cJy
 cJy
-bsl
+lHz
 qkG
 exh
 qkG
@@ -127860,7 +129176,7 @@ rBm
 nla
 nla
 nla
-dOk
+hIa
 fdX
 lTY
 rQC
@@ -127935,7 +129251,7 @@ jgS
 rKK
 sIb
 lfU
-hTs
+uwx
 sZq
 etV
 buX
@@ -128096,7 +129412,7 @@ kUO
 qkG
 bGI
 eeS
-bsl
+lHz
 cJy
 iRy
 iRy
@@ -128153,7 +129469,7 @@ qsk
 iDK
 iDK
 iDK
-iDK
+qwd
 vrw
 sNR
 xDG
@@ -128161,7 +129477,7 @@ xwK
 osu
 plM
 dPv
-bMc
+usm
 xVh
 ldN
 kIn
@@ -128345,7 +129661,7 @@ bsl
 qkG
 qkG
 qkG
-dww
+pzP
 fDl
 nSE
 jeG
@@ -128430,7 +129746,7 @@ ugh
 hqM
 bHp
 fov
-fov
+knN
 uNL
 uNL
 uNL
@@ -128600,16 +129916,16 @@ cJy
 cJy
 bsl
 bsl
-bsl
+lHz
 bsl
 bsl
 fFa
 gZL
-fFa
+oMR
 bsl
 bsl
 bsl
-bsl
+lHz
 bsl
 cJy
 iRy
@@ -128726,7 +130042,7 @@ vAS
 wyX
 abL
 lYa
-lYa
+tGG
 lYa
 mQc
 dNm
@@ -128877,7 +130193,7 @@ uNS
 bbX
 mTK
 iTz
-dKq
+rro
 dKq
 gtD
 uye
@@ -128888,13 +130204,13 @@ nla
 nla
 nla
 nla
-dOk
+hIa
 sca
 lgc
 dBp
 rQC
 rQC
-rQC
+mta
 rQC
 rQC
 rQC
@@ -129120,7 +130436,7 @@ bsl
 gcs
 qkG
 qkG
-bsl
+lHz
 cJy
 cJy
 cJy
@@ -129373,7 +130689,7 @@ cJy
 cJy
 cJy
 cJy
-bsl
+lHz
 qkG
 qtW
 eyL
@@ -129399,7 +130715,7 @@ moJ
 ryL
 dOk
 dOk
-dOk
+hIa
 dOk
 dOk
 mBC
@@ -129653,7 +130969,7 @@ fCY
 jcz
 pyt
 cxE
-dOk
+hIa
 dOk
 lyi
 izO
@@ -129678,7 +130994,7 @@ nID
 cQz
 nID
 wEk
-wEk
+nwP
 bTi
 wEk
 ach
@@ -129753,7 +131069,7 @@ aqD
 abE
 qfj
 jMH
-lYa
+tGG
 cJy
 hGN
 dVe
@@ -129908,7 +131224,7 @@ uNS
 uNS
 uNS
 dOk
-dOk
+hIa
 seL
 dOk
 qau
@@ -129937,7 +131253,7 @@ mUl
 nID
 ncz
 mDp
-wEk
+nwP
 qyI
 rXA
 rXA
@@ -130163,7 +131479,7 @@ pzD
 oXl
 dxM
 rZu
-dKq
+rro
 mMR
 exp
 flJ
@@ -130207,10 +131523,10 @@ ldp
 iDK
 iDK
 iDK
+qwd
 iDK
 iDK
-iDK
-nJE
+dYb
 nJE
 uIG
 qzT
@@ -130229,14 +131545,14 @@ nbL
 irZ
 hAh
 hAh
-irZ
+bAl
 tuH
 mDK
 uGG
 uGG
 aEc
 dRu
-irZ
+bAl
 gxk
 gxk
 wVk
@@ -130250,7 +131566,7 @@ auD
 jEm
 sFF
 vIu
-fzS
+oKv
 mUD
 mUD
 fzS
@@ -130267,7 +131583,7 @@ iRM
 lYa
 lYa
 lYa
-lYa
+tGG
 hks
 uOe
 uOe
@@ -130453,7 +131769,7 @@ xRI
 aiK
 fOa
 wEk
-wEk
+nwP
 wEk
 wEk
 fUr
@@ -130461,7 +131777,7 @@ evi
 seB
 iUC
 evr
-evi
+slG
 qPC
 aaF
 aaG
@@ -130497,7 +131813,7 @@ iYJ
 rXr
 jLG
 wPe
-gJw
+cAb
 gJw
 gzR
 foG
@@ -130514,7 +131830,7 @@ qYX
 snt
 nFk
 epH
-lYa
+tGG
 nZu
 qbu
 fRI
@@ -130523,7 +131839,7 @@ shM
 fYr
 qqe
 oAr
-lYa
+tGG
 ngb
 mKI
 cDB
@@ -130683,10 +131999,10 @@ kYH
 xJp
 cZf
 rgF
+tiW
 rgF
 rgF
-rgF
-doO
+uNJ
 fFd
 fRT
 tLU
@@ -130695,11 +132011,11 @@ nID
 uwS
 bUI
 sGS
-ncW
+fJo
 pfZ
 lux
 cxV
-ncW
+fJo
 ncW
 ovZ
 uTm
@@ -130714,7 +132030,7 @@ mpw
 pZC
 nID
 nID
-evi
+slG
 mMb
 ttz
 oJT
@@ -130792,7 +132108,7 @@ mEJ
 mEJ
 mEJ
 tmB
-mEJ
+oRn
 cJy
 iRy
 iRy
@@ -130961,7 +132277,7 @@ ncW
 fOI
 lgc
 pZC
-nID
+rom
 nID
 nID
 bfz
@@ -130997,7 +132313,7 @@ uRa
 qnd
 mhC
 aJN
-irZ
+bAl
 pAv
 pAv
 ssj
@@ -131017,7 +132333,7 @@ gsT
 jVj
 jVj
 oeW
-gJw
+cAb
 yeu
 wtc
 uaB
@@ -131033,7 +132349,7 @@ uDl
 fqe
 npX
 poO
-fqe
+hDx
 fqe
 vDS
 sPd
@@ -131214,13 +132530,13 @@ iPg
 mfW
 bqW
 dwE
-ncW
+fJo
 ncW
 rmw
 ncW
 ncW
 euS
-deW
+gbX
 deW
 deW
 deW
@@ -131236,7 +132552,7 @@ mlM
 sRV
 nJE
 nJE
-pRM
+vWe
 oMk
 pRM
 pRM
@@ -131255,7 +132571,7 @@ qML
 dWF
 irZ
 irZ
-irZ
+bAl
 irZ
 irZ
 kxV
@@ -131265,7 +132581,7 @@ cnx
 xXx
 avg
 utu
-utu
+qMi
 utu
 wPe
 wxH
@@ -131279,7 +132595,7 @@ iii
 cVP
 wPW
 fzS
-fzS
+oKv
 vaQ
 xgz
 wBI
@@ -131447,7 +132763,7 @@ dKq
 uea
 bMH
 uOo
-dKq
+rro
 nkP
 dXE
 uZP
@@ -131550,7 +132866,7 @@ pDs
 lAJ
 rvO
 tzo
-lYa
+tGG
 nqn
 hks
 mar
@@ -131708,7 +133024,7 @@ dKq
 aIQ
 jns
 qhE
-rgF
+tiW
 asX
 kxD
 kIk
@@ -131731,7 +133047,7 @@ ncW
 ncW
 wZl
 ejQ
-kLa
+iFt
 sfA
 deW
 xYM
@@ -131741,7 +133057,7 @@ hPW
 qqn
 hju
 eji
-deW
+gbX
 bPJ
 iGW
 bZA
@@ -131749,7 +133065,7 @@ hrL
 hPg
 pCL
 hqT
-nJE
+dYb
 iwW
 oLH
 qdQ
@@ -131767,7 +133083,7 @@ hZZ
 dQi
 hhz
 hhz
-irZ
+bAl
 xXi
 wKS
 rPo
@@ -131809,19 +133125,19 @@ lYa
 lYa
 lYa
 auD
-hks
+epG
 gbn
 mTN
 qYV
 gpr
 pRy
 ksa
-mEJ
+oRn
 mEJ
 mEJ
 pKw
 pKw
-pKw
+kOJ
 pKw
 adk
 adn
@@ -131957,11 +133273,11 @@ lUa
 lUa
 cJy
 cJy
-icY
+sJP
 rUq
 pJV
 jzo
-nID
+rom
 wDq
 iMq
 vYo
@@ -131970,13 +133286,13 @@ rJV
 tBV
 nfy
 doO
-doO
+uNJ
 doO
 auH
 mWu
 pQk
 sfe
-doO
+uNJ
 bsI
 iXP
 ncW
@@ -132010,7 +133326,7 @@ nJE
 dYr
 nDH
 qjv
-pRM
+vWe
 rsr
 lpc
 qjN
@@ -132038,7 +133354,7 @@ npS
 iYJ
 phw
 wIU
-wPe
+dCM
 uir
 rWQ
 gsT
@@ -132046,7 +133362,7 @@ vsw
 jVj
 gLU
 brW
-gJw
+cAb
 bvj
 aGE
 kRS
@@ -132059,7 +133375,7 @@ rIM
 kjL
 giT
 lYa
-lYa
+tGG
 gVn
 lYa
 lYa
@@ -132218,7 +133534,7 @@ kYI
 oPc
 wYa
 aQh
-bHq
+ntW
 qtN
 eHr
 neu
@@ -132245,7 +133561,7 @@ xIW
 wGA
 tJb
 jaK
-kLa
+iFt
 gnz
 deW
 bex
@@ -132265,7 +133581,7 @@ pWH
 jUH
 nJE
 nJE
-nJE
+dYb
 nJE
 nJE
 nJE
@@ -132279,12 +133595,12 @@ pgs
 cpX
 ipA
 hZZ
+iQT
 hZZ
-hZZ
 irZ
 irZ
 irZ
-irZ
+bAl
 irZ
 irZ
 mcT
@@ -132500,7 +133816,7 @@ vJQ
 mEe
 nfO
 ohX
-vJQ
+qUe
 jCI
 uRU
 ncW
@@ -132551,7 +133867,7 @@ wja
 wja
 wja
 wja
-wja
+rVE
 wPe
 qTe
 rWQ
@@ -132733,7 +134049,7 @@ rSg
 lFI
 wox
 pmi
-nID
+rom
 nID
 wFr
 rgF
@@ -132748,7 +134064,7 @@ xQy
 lZh
 wrI
 doO
-doO
+uNJ
 ncW
 ncW
 gHX
@@ -132757,7 +134073,7 @@ klZ
 naD
 teO
 oVc
-dsg
+tDL
 ejQ
 rkn
 cGR
@@ -132767,7 +134083,7 @@ vkc
 sgb
 deW
 deW
-deW
+gbX
 cnp
 cnp
 viC
@@ -132779,11 +134095,11 @@ acc
 cJy
 cJy
 cdk
+pWs
 cdk
 cdk
 cdk
-cdk
-cdk
+pWs
 cdk
 mBB
 lvL
@@ -132795,7 +134111,7 @@ cou
 nYx
 pFp
 qny
-qny
+qpG
 qny
 qny
 qny
@@ -132817,7 +134133,7 @@ dvH
 wPi
 iAF
 nny
-auD
+uel
 qYL
 epS
 fmz
@@ -132827,7 +134143,7 @@ fmz
 fmz
 fmz
 kCN
-pyu
+puV
 pyu
 pyu
 pyu
@@ -132998,7 +134314,7 @@ wDT
 evp
 igY
 sac
-doO
+uNJ
 cjj
 rPM
 sEP
@@ -133014,7 +134330,7 @@ gXv
 dMn
 gXv
 bPR
-vJQ
+qUe
 jCI
 ezR
 cGR
@@ -133075,7 +134391,7 @@ nJI
 gJw
 gJw
 fmz
-fmz
+swg
 sBo
 fmz
 xTf
@@ -133083,7 +134399,7 @@ oMl
 dgF
 eKW
 fmz
-pyu
+puV
 pyu
 rFw
 gNu
@@ -133102,9 +134418,9 @@ gny
 tHO
 fbr
 pKw
-pKw
+kOJ
 xZW
-pKw
+kOJ
 glQ
 neE
 xUY
@@ -133112,7 +134428,7 @@ xRf
 jdr
 jdr
 pZt
-pKw
+kOJ
 cJy
 ozc
 ozc
@@ -133315,7 +134631,7 @@ pjy
 pYq
 qny
 iRy
-wja
+rVE
 bXR
 rEn
 vHO
@@ -133349,7 +134665,7 @@ dmR
 nGJ
 msx
 utL
-pyu
+puV
 gFp
 jCK
 mPF
@@ -133570,7 +134886,7 @@ dOp
 vYV
 haD
 bQK
-qny
+qpG
 cJy
 wja
 sYi
@@ -133607,7 +134923,7 @@ rih
 xbG
 rnv
 pKw
-pKw
+kOJ
 pKw
 pKw
 pKw
@@ -133626,7 +134942,7 @@ tgR
 nDR
 kAK
 cnA
-pKw
+kOJ
 pKw
 pKw
 jpW
@@ -133805,7 +135121,7 @@ sNW
 abZ
 acc
 cJy
-cdk
+pWs
 szP
 fBN
 tpW
@@ -134053,7 +135369,7 @@ fyt
 ioj
 feE
 bRR
-cnp
+jjo
 hJm
 fjW
 bjP
@@ -134321,11 +135637,11 @@ acc
 cJy
 cJy
 cdk
+pWs
 cdk
 cdk
 cdk
-cdk
-cdk
+pWs
 cdk
 okB
 lvL
@@ -134339,7 +135655,7 @@ gDL
 qny
 qny
 qny
-qny
+qpG
 qny
 iRy
 cJy
@@ -134531,7 +135847,7 @@ ozz
 cDu
 otj
 nYK
-nHb
+eWR
 ekI
 jtV
 wbk
@@ -134551,7 +135867,7 @@ tBH
 tBH
 dIA
 nAb
-tBH
+oxu
 pfO
 poQ
 aWw
@@ -134783,13 +136099,13 @@ lUa
 lUa
 lUa
 icY
-icY
+sJP
 icY
 vrH
 hwy
 udU
 nHb
-nHb
+eWR
 nHb
 pGS
 xzI
@@ -134832,10 +136148,10 @@ qsF
 bxo
 pvr
 pzK
+oeB
 oLb
 oLb
-oLb
-oLb
+oeB
 oLb
 ufU
 ufU
@@ -134851,11 +136167,11 @@ kXf
 hRX
 hRX
 hRX
+qoz
 hRX
 hRX
 hRX
-hRX
-hRX
+qoz
 wja
 vVo
 hRO
@@ -134894,7 +136210,7 @@ sWO
 sWO
 oyh
 peu
-pKw
+kOJ
 pKw
 bUJ
 bUJ
@@ -135058,7 +136374,7 @@ woH
 fnJ
 lah
 ues
-woH
+aHn
 rMl
 wVN
 tBH
@@ -135150,13 +136466,13 @@ adR
 tsa
 sWO
 sWO
-pKw
+kOJ
 pKw
 rJR
 sEc
 sEc
 sEc
-pKw
+kOJ
 mfd
 lKX
 tIV
@@ -135300,15 +136616,15 @@ oPI
 tod
 oPI
 woH
+aHn
+woH
+aHn
 woH
 woH
 woH
 woH
 woH
-woH
-woH
-woH
-woH
+aHn
 woH
 woH
 woH
@@ -135318,7 +136634,7 @@ djo
 woH
 edH
 hJf
-tBH
+oxu
 mtt
 san
 hyK
@@ -135556,7 +136872,7 @@ cJy
 oPI
 upp
 ihQ
-woH
+aHn
 mbr
 mbr
 mbr
@@ -135596,7 +136912,7 @@ oCu
 oCu
 tgx
 mms
-rbG
+ntb
 ctE
 qgx
 fKh
@@ -135637,13 +136953,13 @@ wja
 rTa
 orb
 wja
-cPn
+fMx
 xKB
 dKJ
 ouQ
 tkk
 xKB
-fmz
+swg
 irF
 irF
 sLz
@@ -135652,7 +136968,7 @@ bFk
 aaA
 tKW
 irF
-irF
+kfi
 irF
 ggz
 qgz
@@ -135861,7 +137177,7 @@ abo
 kUv
 lgT
 oLb
-oLb
+oeB
 oLb
 oLb
 oLb
@@ -135894,7 +137210,7 @@ wja
 dDK
 laj
 xvZ
-lAq
+lpQ
 rkq
 guE
 klJ
@@ -135911,7 +137227,7 @@ hey
 iOg
 hcu
 irF
-irF
+kfi
 eTM
 sWO
 rRV
@@ -136089,7 +137405,7 @@ cVt
 nWQ
 woH
 syz
-tBH
+oxu
 nAb
 sdw
 wNF
@@ -136109,7 +137425,7 @@ mlw
 fAR
 rbG
 dbD
-rbG
+ntb
 rbG
 rEy
 qgx
@@ -136356,14 +137672,14 @@ ugU
 xpB
 xpB
 xpB
-xpB
+iva
 oyL
 xpB
 rbG
+ntb
 rbG
 rbG
-rbG
-rbG
+ntb
 rbG
 wrZ
 fxg
@@ -136438,7 +137754,7 @@ rOw
 rDT
 pKw
 pKw
-pKw
+kOJ
 pKw
 pKw
 pKw
@@ -136604,7 +137920,7 @@ frQ
 woH
 haO
 cRR
-tBH
+oxu
 tBH
 ocK
 vDg
@@ -136646,12 +137962,12 @@ ufU
 utQ
 lGZ
 nDy
-hRX
+qoz
 hRX
 nfr
 grS
 xeM
-hRX
+qoz
 fpF
 hRX
 hRX
@@ -136699,7 +138015,7 @@ uFR
 tye
 xss
 xss
-pKw
+kOJ
 lKX
 dJO
 eCY
@@ -136841,7 +138157,7 @@ oPI
 fJi
 vQV
 opB
-woH
+aHn
 mbr
 mbr
 mbr
@@ -136889,11 +138205,11 @@ alC
 gdP
 gdP
 gdP
-qUa
+lIj
 ozB
 sea
 vKZ
-qUa
+lIj
 kbK
 chB
 iFT
@@ -136910,7 +138226,7 @@ cVO
 wNT
 cVO
 hSx
-teH
+syY
 cbm
 vNe
 jIb
@@ -137155,7 +138471,7 @@ ufU
 qMz
 psY
 wYY
-ufU
+ayv
 ufU
 wIS
 uge
@@ -137385,14 +138701,14 @@ xpB
 qrz
 gMH
 wwh
-xpB
+iva
 xpB
 dtL
 tru
 tru
 tru
 tru
-tru
+wKC
 tru
 tru
 jKM
@@ -137425,7 +138741,7 @@ dLk
 qXD
 bEF
 biM
-qjD
+bxK
 oiN
 lzu
 bNq
@@ -137468,9 +138784,9 @@ yjO
 iJG
 tye
 tye
+kOJ
 pKw
-pKw
-pKw
+kOJ
 lKX
 hoG
 eYg
@@ -137612,7 +138928,7 @@ vQV
 kqT
 lPs
 wbN
-woH
+aHn
 mbr
 mbr
 mbr
@@ -137633,14 +138949,14 @@ woH
 uow
 qbx
 tBH
-tBH
+oxu
 eWs
 czd
 nfs
 tBH
 xpB
 xpB
-xpB
+iva
 xpB
 xpB
 ufn
@@ -137709,7 +139025,7 @@ irF
 irF
 irF
 irF
-irF
+kfi
 tye
 tye
 tye
@@ -137739,7 +139055,7 @@ vqJ
 ohs
 xUU
 tpx
-pKw
+kOJ
 pKw
 jpW
 jpW
@@ -137880,8 +139196,8 @@ mbr
 mbr
 mbr
 mbr
-qdY
-qdY
+tKt
+tKt
 pud
 pws
 ayW
@@ -138129,11 +139445,11 @@ oPI
 woH
 woH
 woH
-woH
+aHn
 woH
 woH
 qdY
-qdY
+tKt
 qdY
 qdY
 qdY
@@ -138159,7 +139475,7 @@ tzR
 dni
 dpd
 qIn
-tru
+wKC
 jPl
 whj
 kCi
@@ -138238,7 +139554,7 @@ lmA
 vRr
 djn
 lti
-tye
+yhm
 fXk
 pKw
 vTP
@@ -138254,7 +139570,7 @@ xjD
 pKw
 aac
 pKw
-pKw
+kOJ
 cJy
 cJy
 cJy
@@ -138387,7 +139703,7 @@ vla
 uqU
 kUE
 wpQ
-oPI
+piU
 uVM
 qdY
 fOY
@@ -138475,13 +139791,13 @@ mCG
 pGP
 gsa
 xTO
-cmk
+gQi
 mXc
 mXc
 fdY
 fdY
 tye
-tye
+yhm
 rrZ
 dZx
 xde
@@ -138659,11 +139975,11 @@ aEk
 sbC
 dXX
 aBd
+wfe
 aBd
 aBd
 aBd
-aBd
-aBd
+wfe
 aBd
 fJI
 iuZ
@@ -138726,7 +140042,7 @@ upJ
 cqv
 vdJ
 vdJ
-vdJ
+iEy
 czb
 deQ
 xTO
@@ -138753,7 +140069,7 @@ nEw
 gjI
 ayk
 tye
-tye
+yhm
 tye
 cJy
 leR
@@ -138930,7 +140246,7 @@ sQT
 sQT
 hHB
 hpR
-tru
+wKC
 xXj
 lqu
 gfb
@@ -138973,14 +140289,14 @@ sCB
 mYs
 lIW
 aHv
-aHv
+rWP
 pVv
 oQH
 rMc
-vNe
+nna
 vdJ
 swI
-vdJ
+iEy
 vdJ
 nwG
 trF
@@ -139158,7 +140474,7 @@ oPI
 gmi
 cuO
 eQE
-eQE
+kLa
 eQE
 vSl
 qks
@@ -139179,7 +140495,7 @@ eyy
 izJ
 kgK
 qXK
-aBd
+wfe
 pLX
 kVt
 sQT
@@ -139241,7 +140557,7 @@ nZt
 ccu
 vnl
 usv
-czb
+qpx
 iJV
 lIo
 adQ
@@ -139693,7 +141009,7 @@ pku
 jvw
 kgK
 llM
-aBd
+wfe
 cHJ
 sQT
 sQT
@@ -139708,7 +141024,7 @@ eIx
 fUY
 lpS
 vXr
-keP
+gwy
 nPW
 lSo
 nPW
@@ -139959,7 +141275,7 @@ flO
 gSS
 iuK
 bFV
-keP
+gwy
 fGc
 otO
 sQU
@@ -139970,7 +141286,7 @@ jvO
 uJJ
 jvO
 gdP
-gdP
+gWV
 sQT
 sUD
 sQT
@@ -139988,7 +141304,7 @@ gAb
 lmx
 rWI
 lps
-lps
+cFM
 lps
 aqR
 lps
@@ -140203,10 +141519,10 @@ lwq
 aBd
 aBd
 aBd
+wfe
 aBd
 aBd
-aBd
-aBd
+wfe
 gtN
 rqJ
 vHV
@@ -140225,7 +141541,7 @@ uFf
 keP
 gdP
 gdP
-gdP
+gWV
 gdP
 kmW
 jkq
@@ -140279,7 +141595,7 @@ ici
 ici
 toS
 jXS
-tye
+yhm
 gLh
 ube
 tsE
@@ -140478,7 +141794,7 @@ utU
 eja
 wis
 iub
-keP
+gwy
 keP
 ety
 mVL
@@ -140490,7 +141806,7 @@ onR
 vEO
 sje
 lps
-lps
+cFM
 lps
 lps
 lps
@@ -140705,7 +142021,7 @@ jbT
 eSw
 eLP
 jbT
-jbT
+hDY
 dgt
 qdY
 nib
@@ -140964,7 +142280,7 @@ sdW
 agf
 dea
 uBl
-qdY
+tKt
 guU
 iwj
 cIj
@@ -141027,7 +142343,7 @@ aHv
 hHA
 wHl
 dVt
-aHv
+rWP
 iIv
 tjZ
 xdq
@@ -141245,7 +142561,7 @@ elB
 eik
 euL
 keP
-keP
+gwy
 keP
 sSX
 keP
@@ -141254,7 +142570,7 @@ fGH
 oBf
 oBf
 oBf
-oBf
+iRE
 oBf
 abv
 okp
@@ -141262,7 +142578,7 @@ oBf
 sYl
 lps
 tnU
-tnU
+jbQ
 tnU
 tnU
 rWA
@@ -141280,7 +142596,7 @@ bsD
 qKm
 oSn
 sEy
-mlq
+sDC
 pjP
 cFg
 hAP
@@ -141475,7 +142791,7 @@ dnW
 dvm
 dOy
 jbT
-jbT
+hDY
 jbT
 gwT
 pgO
@@ -141516,7 +142832,7 @@ pOd
 fIG
 gNr
 seo
-sYl
+lQy
 mjc
 psT
 dnb
@@ -141525,7 +142841,7 @@ hfm
 bcb
 nYX
 piG
-iWv
+oKW
 lCW
 deC
 lCW
@@ -141542,9 +142858,9 @@ npE
 eWy
 veM
 aHv
-cTH
+fXZ
 ami
-cTH
+fXZ
 vdJ
 vdJ
 oTW
@@ -141578,7 +142894,7 @@ eCm
 cwS
 ptb
 lJy
-tye
+yhm
 tye
 cJy
 cJy
@@ -141765,7 +143081,7 @@ bkE
 edH
 tfV
 euL
-oBf
+iRE
 tUq
 meP
 ehs
@@ -141792,7 +143108,7 @@ vBi
 cAB
 vKF
 aHv
-aHv
+rWP
 aHv
 aHv
 mdZ
@@ -141822,7 +143138,7 @@ cEg
 imc
 xMX
 xMX
-xMX
+cPY
 xMX
 fCk
 xMX
@@ -141992,7 +143308,7 @@ lfi
 nxe
 guU
 guU
-guU
+xuh
 guU
 krv
 cJs
@@ -142025,7 +143341,7 @@ eNr
 eNr
 eNr
 eNr
-eNr
+luK
 eNr
 sYl
 ewJ
@@ -142084,7 +143400,7 @@ tyn
 jBv
 xMX
 xMX
-xMX
+cPY
 uNC
 pgk
 uNC
@@ -142277,7 +143593,7 @@ wtg
 sQT
 qvj
 sQT
-eNr
+luK
 eNr
 ozZ
 pUc
@@ -142308,7 +143624,7 @@ xAD
 qKm
 eiz
 osx
-mlq
+sDC
 bzZ
 hEc
 rOJ
@@ -142317,7 +143633,7 @@ doF
 qsX
 kwJ
 dtS
-vdJ
+iEy
 ndk
 ndk
 dpp
@@ -142333,7 +143649,7 @@ sbx
 vdJ
 kmF
 nPe
-xMX
+cPY
 pKv
 uRN
 uRN
@@ -142504,7 +143820,7 @@ oPI
 oPI
 oPI
 oPI
-guU
+xuh
 oEM
 boe
 elS
@@ -142563,7 +143879,7 @@ lXh
 xzW
 pyO
 aHv
-aHv
+rWP
 aHv
 aHv
 aHv
@@ -142858,7 +144174,7 @@ xKJ
 hAX
 etD
 fvd
-xMX
+cPY
 abM
 rJO
 wvI
@@ -143021,12 +144337,12 @@ aUr
 oPI
 iRy
 cJy
-guU
+xuh
 gpa
 gpa
 gpa
 gpa
-guU
+xuh
 cJy
 iRy
 iRy
@@ -143080,7 +144396,7 @@ vBz
 qKm
 rrh
 ihT
-mlq
+sDC
 aEW
 bri
 kZb
@@ -143338,9 +144654,9 @@ aHv
 aHv
 aHv
 aHv
-aHv
-cTH
-cTH
+rWP
+fXZ
+fXZ
 aHv
 ftA
 jEk
@@ -143361,7 +144677,7 @@ cYU
 avH
 nUe
 vdJ
-xMX
+cPY
 eVZ
 uRN
 uRN
@@ -143594,7 +144910,7 @@ lVa
 qKm
 cky
 iqK
-mlq
+sDC
 waF
 gwq
 rne
@@ -143624,16 +144940,16 @@ kPd
 iYM
 azH
 xMX
-xMX
+cPY
 xMX
 xMX
 cJy
 cJy
-tye
+yhm
 scB
 ikB
 jrq
-wpz
+pJR
 cJy
 iRy
 cJy
@@ -143877,7 +145193,7 @@ cJy
 iRy
 iRy
 xMX
-xMX
+cPY
 xMX
 xMX
 xMX
@@ -144081,7 +145397,7 @@ eNr
 eNr
 eNr
 eNr
-eNr
+luK
 eNr
 xdB
 fkL
@@ -144106,7 +145422,7 @@ jwi
 jMA
 aHv
 aHv
-aHv
+rWP
 aHv
 aHv
 twd
@@ -144347,7 +145663,7 @@ pXN
 emJ
 onv
 aon
-oBf
+iRE
 olO
 cWy
 jSX
@@ -144603,7 +145919,7 @@ kyO
 lXE
 tKb
 vlu
-gTe
+mAf
 wWk
 wWk
 aGK
@@ -144671,7 +145987,7 @@ cJy
 jfk
 wNJ
 wNJ
-igw
+xpr
 igw
 qbL
 vic
@@ -144681,7 +145997,7 @@ bRB
 uKK
 aag
 mMo
-mMo
+ukb
 mMo
 cJy
 cJy
@@ -145185,7 +146501,7 @@ jWN
 gVx
 sOy
 vZk
-igw
+xpr
 igw
 ryN
 lTe
@@ -145392,7 +146708,7 @@ cEZ
 qKm
 wkX
 osx
-mlq
+sDC
 fYZ
 mba
 cMQ
@@ -145632,7 +146948,7 @@ gYj
 ulj
 tbi
 gxo
-wWk
+vwj
 mTa
 xmZ
 lei
@@ -145642,7 +146958,7 @@ hNg
 luf
 jlA
 pJI
-wWk
+vwj
 ehC
 aBM
 ehC
@@ -145650,11 +146966,11 @@ bJw
 bJw
 bJw
 bJw
-bJw
+owg
 bJw
 bJw
 eXv
-jQd
+goh
 jQd
 oJs
 euL
@@ -145697,7 +147013,7 @@ kKl
 aBn
 bLf
 wcN
-xOi
+rxU
 cJy
 cJy
 xOi
@@ -145906,7 +147222,7 @@ pOg
 mEd
 bzj
 fGt
-bJw
+owg
 hdQ
 rOF
 hdQ
@@ -145953,7 +147269,7 @@ tdu
 gVx
 sOy
 vZk
-xOi
+rxU
 xOi
 xOi
 xOi
@@ -146140,7 +147456,7 @@ euL
 wir
 hHS
 eov
-gTe
+mAf
 uqD
 dcO
 odp
@@ -146408,12 +147724,12 @@ mhV
 vYt
 lmO
 jsn
-wWk
+vwj
 ptg
 oYd
 gXm
 lsZ
-wWk
+vwj
 rzi
 cgd
 dNC
@@ -146491,7 +147807,7 @@ myX
 dis
 dZG
 abd
-vVz
+nKb
 cJy
 cJy
 vxR
@@ -146659,7 +147975,7 @@ hiA
 xam
 wFP
 tcT
-wWk
+vwj
 sUe
 rgs
 jAG
@@ -146681,7 +147997,7 @@ xtu
 tAd
 vXE
 eRr
-eXv
+tdM
 euL
 oiM
 tMD
@@ -146725,7 +148041,7 @@ wMp
 igw
 igw
 xOi
-hiU
+fnf
 kTg
 kIr
 vQs
@@ -146737,7 +148053,7 @@ kIr
 kTg
 hiU
 mMo
-bOD
+gKY
 kGY
 yeF
 bOD
@@ -146922,10 +148238,10 @@ rgs
 kBZ
 rgs
 rgs
+vwj
 wWk
 wWk
-wWk
-wWk
+vwj
 wWk
 wWk
 ehC
@@ -146976,11 +148292,11 @@ iRy
 vxR
 cJy
 cJy
-igw
+xpr
 urq
 koo
 pmW
-igw
+xpr
 hiU
 hiU
 raE
@@ -146989,7 +148305,7 @@ hiU
 hiU
 aKD
 hiU
-hiU
+fnf
 obW
 sBM
 hiU
@@ -147169,13 +148485,13 @@ aGo
 sQT
 rsC
 lUY
-qNI
+bcl
 vIk
 wgg
 anR
 wWk
 wWk
-wWk
+vwj
 wWk
 wWk
 wWk
@@ -147187,8 +148503,8 @@ bJw
 muF
 gOd
 ejJ
-bJw
-bJw
+owg
+owg
 bJw
 bJw
 eXv
@@ -147263,7 +148579,7 @@ myX
 myX
 dZG
 tcV
-vVz
+nKb
 vVz
 cJy
 vxR
@@ -147693,7 +149009,7 @@ xGG
 xGG
 xGG
 nGX
-tsP
+cwz
 pwm
 viZ
 mdq
@@ -147954,7 +149270,7 @@ tsP
 iNd
 wDt
 iNd
-bJw
+owg
 kBI
 ttF
 xjh
@@ -148202,19 +149518,19 @@ qNI
 ukH
 eCR
 qNI
+bcl
 qNI
 qNI
+bcl
 qNI
 qNI
-qNI
-qNI
-eXv
+tdM
 nYm
 nYm
 nYm
 nYm
 hSJ
-nYm
+wUX
 nYm
 osg
 tbc
@@ -148472,7 +149788,7 @@ hQK
 upM
 llx
 ksL
-nYm
+wUX
 nYm
 eXv
 eXv
@@ -148518,7 +149834,7 @@ iRy
 vxR
 cJy
 cJy
-igw
+xpr
 jJp
 pyf
 uIs
@@ -148531,11 +149847,11 @@ hiU
 hiU
 ycn
 hiU
-hiU
+fnf
 obW
 xSi
 hiU
-hiU
+jvQ
 bOD
 fqB
 aan
@@ -148548,7 +149864,7 @@ xKW
 jIU
 hEM
 wJr
-vVz
+nKb
 iRy
 cJy
 vxR
@@ -148781,7 +150097,7 @@ wMp
 igw
 igw
 xOi
-hiU
+fnf
 kTg
 kIr
 vQs
@@ -149238,7 +150554,7 @@ sQT
 prq
 rCg
 vwA
-nYm
+wUX
 lhE
 ahL
 kWj
@@ -149304,7 +150620,7 @@ iCe
 lFP
 hiU
 hiU
-hiU
+jvQ
 lNK
 ttW
 wbe
@@ -149551,16 +150867,16 @@ tdu
 gVx
 fXu
 wNJ
+rxU
 xOi
 xOi
 xOi
-xOi
 hiU
 hiU
 hiU
 hiU
 hiU
-cjR
+tfl
 ncl
 mZR
 hXf
@@ -149573,7 +150889,7 @@ czr
 niL
 kqd
 vVz
-vVz
+nKb
 vVz
 cJy
 cJy
@@ -149756,7 +151072,7 @@ xEy
 nYm
 nYm
 nYm
-nYm
+wUX
 nYm
 fPF
 xDt
@@ -149809,7 +151125,7 @@ uuv
 aBn
 weD
 cLW
-xOi
+rxU
 cJy
 cJy
 xOi
@@ -149826,7 +151142,7 @@ hXf
 uql
 cjR
 cjR
-vVz
+nKb
 vVz
 vVz
 vVz
@@ -150073,7 +151389,7 @@ gOL
 gOL
 aUh
 gOL
-cjR
+tfl
 tSP
 rPj
 vAf
@@ -150325,7 +151641,7 @@ gCI
 gVx
 fXu
 wNJ
-igw
+xpr
 igw
 xpY
 lfO
@@ -150839,7 +152155,7 @@ cJy
 fms
 vZk
 vZk
-igw
+xpr
 igw
 pmN
 fld
@@ -150849,7 +152165,7 @@ vLY
 eho
 aaj
 cjR
-cjR
+tfl
 cjR
 cJy
 cJy
@@ -151354,7 +152670,7 @@ iRy
 vxR
 vxR
 vxR
-gOL
+bFA
 ngW
 mWo
 maE
@@ -151362,7 +152678,7 @@ kMW
 xKM
 wrz
 ady
-gOL
+bFA
 cJy
 vxR
 vxR
@@ -151874,7 +153190,7 @@ gOL
 gOL
 gOL
 nwU
-gOL
+bFA
 gOL
 cJy
 iRy

--- a/maps/stroechka/stroechka.dmm
+++ b/maps/stroechka/stroechka.dmm
@@ -93,7 +93,7 @@
 	},
 /area/station/solar/auxport)
 "al" = (
-/obj/item/weapon/flora/random,
+/obj/machinery/vending/newyearmate,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "black"
@@ -487,6 +487,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -501,6 +502,7 @@
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -585,6 +587,7 @@
 /obj/effect/landmark{
 	name = "Observer-Start"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bi" = (
@@ -645,6 +648,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -674,6 +678,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "br" = (
@@ -762,6 +767,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "bA" = (
+/obj/item/decoration/snowflake,
 /turf/simulated/wall/r_wall,
 /area/station/cargo/storage)
 "bB" = (
@@ -859,6 +865,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "bM" = (
@@ -876,6 +883,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "bO" = (
@@ -916,6 +924,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "bQ" = (
@@ -959,6 +968,7 @@
 	req_access = list(71)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1268,6 +1278,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1337,6 +1348,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1723,6 +1735,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "dg" = (
@@ -2180,6 +2193,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2344,6 +2358,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2955,6 +2970,7 @@
 	name = "Recucler Access Button";
 	pixel_y = -28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "fp" = (
@@ -3043,6 +3059,7 @@
 	name = "Recucler Access Button";
 	pixel_x = 28
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "fu" = (
@@ -3136,6 +3153,7 @@
 	req_access = list(71)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "fA" = (
@@ -3376,6 +3394,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -3537,6 +3556,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "gC" = (
@@ -3591,6 +3611,10 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/central)
+"gT" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/chargebay)
 "gX" = (
 /obj/machinery/vending/cigarette,
 /obj/item/device/radio/intercom{
@@ -3609,6 +3633,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "he" = (
@@ -3684,6 +3709,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3712,6 +3738,7 @@
 	req_access = list(71)
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "ic" = (
@@ -3748,6 +3775,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "im" = (
@@ -3766,6 +3794,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3823,6 +3852,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "iJ" = (
@@ -3992,6 +4022,10 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"jO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/engine)
 "jR" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -4136,6 +4170,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "lp" = (
@@ -4217,6 +4252,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "lT" = (
@@ -4245,6 +4281,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "mm" = (
@@ -4298,6 +4335,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
+"mB" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/engineering/equip)
 "mE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4630,6 +4671,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4795,6 +4837,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "rN" = (
@@ -4832,6 +4875,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"sb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "se" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -4885,6 +4937,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "sB" = (
@@ -4938,6 +4991,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "sO" = (
@@ -5008,6 +5062,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -5059,6 +5114,10 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/storage)
+"uv" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/arrival)
 "uA" = (
 /obj/machinery/igniter{
 	icon_state = "igniter0";
@@ -5325,6 +5384,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5484,6 +5544,10 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/storage)
+"xq" = (
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
+/area/space)
 "xx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5566,6 +5630,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"yP" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "yT" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -5575,6 +5643,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "yU" = (
@@ -5585,6 +5654,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
 "yW" = (
@@ -5605,6 +5675,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5622,6 +5693,7 @@
 	},
 /area/station/rnd/lab)
 "zm" = (
+/obj/item/decoration/snowman,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "black"
@@ -5729,6 +5801,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "Ab" = (
@@ -5755,6 +5828,10 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/equip)
+"As" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/secondary/arrival)
 "Au" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -5808,6 +5885,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/equip)
+"AL" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/secondary/exit)
 "AR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/window/thin/reinforced,
@@ -5970,6 +6051,7 @@
 	locked = 1;
 	name = "Solar Internal Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "BA" = (
@@ -6014,6 +6096,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "BS" = (
@@ -6048,6 +6131,7 @@
 	locked = 1;
 	name = "Solar External Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "BY" = (
@@ -6056,6 +6140,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "Cf" = (
@@ -6086,6 +6171,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "Cv" = (
@@ -6383,6 +6469,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6429,6 +6516,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "Eb" = (
@@ -6463,6 +6551,7 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6489,6 +6578,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6509,6 +6599,11 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/lab)
+"Eu" = (
+/obj/item/device/flashlight/lamp/fir/special,
+/obj/item/weapon/present,
+/turf/simulated/floor/wood,
+/area/space)
 "Ew" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -6560,6 +6655,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "EM" = (
@@ -6676,6 +6772,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6697,6 +6794,7 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "FA" = (
@@ -6735,6 +6833,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/device/flashlight/lamp/fir/special/alternative{
+	pixel_x = 16
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blackcorner"
@@ -6850,6 +6951,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "Gr" = (
@@ -6955,6 +7057,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7165,6 +7268,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "Hl" = (
@@ -7368,6 +7472,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"ID" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/rnd/lab)
 "IF" = (
 /obj/machinery/photocopier{
 	anchored = 0
@@ -7525,6 +7633,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "Kb" = (
@@ -7583,6 +7692,10 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"KO" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/maintenance/auxsolarport)
 "KQ" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/alarm{
@@ -7675,6 +7788,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "Mb" = (
@@ -7694,6 +7808,7 @@
 	icon_state = "gr_window"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "Mn" = (
@@ -7767,6 +7882,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"MW" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/hallway/secondary/exit)
 "Na" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/meter,
@@ -7882,6 +8001,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "NP" = (
@@ -8123,6 +8243,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "PS" = (
@@ -8144,6 +8265,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
+"Qk" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "Qo" = (
 /obj/structure/stool/bed/chair/schair/wagon/bench,
 /turf/simulated/floor,
@@ -8231,6 +8361,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"QY" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/chiefs_office)
 "Ra" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -8257,6 +8391,15 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"Rs" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/item/decoration/garland,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "Ru" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1
@@ -8301,6 +8444,10 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
+"RQ" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/space)
 "RU" = (
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_access = list(71)
@@ -8331,6 +8478,9 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"Sb" = (
+/turf/simulated/floor/wood,
+/area/space)
 "Sf" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,6"
@@ -8554,6 +8704,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "TO" = (
@@ -8577,6 +8728,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine/nitrogen,
+/area/station/engineering/atmos)
+"TS" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
 /area/station/engineering/atmos)
 "TX" = (
 /turf/simulated/floor{
@@ -8933,6 +9088,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "Wc" = (
@@ -8942,6 +9098,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"Wh" = (
+/obj/item/decoration/snowflake,
+/turf/simulated/wall,
+/area/station/cargo/storage)
 "Wl" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "0,2"
@@ -8968,6 +9128,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/item/decoration/tinsel,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8978,6 +9139,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "WA" = (
@@ -9042,6 +9204,7 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "Xm" = (
@@ -9074,6 +9237,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "XB" = (
@@ -9149,6 +9313,7 @@
 	name = "Arrival Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/decoration/tinsel,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "XZ" = (
@@ -9213,6 +9378,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"Yz" = (
+/obj/item/decoration/snowman,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "YB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9251,6 +9423,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "YJ" = (
@@ -9320,6 +9493,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/item/decoration/garland,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "Za" = (
@@ -30442,7 +30616,7 @@ MC
 bi
 bi
 bi
-bi
+yP
 bi
 MC
 MC
@@ -30673,7 +30847,7 @@ as
 QW
 vT
 vT
-XB
+MW
 vT
 vT
 Wx
@@ -30695,7 +30869,7 @@ MC
 MC
 bi
 bi
-bi
+yP
 cC
 cX
 dE
@@ -31205,7 +31379,7 @@ ax
 an
 MC
 MC
-bi
+yP
 bw
 bF
 bV
@@ -31441,13 +31615,13 @@ Au
 BN
 Au
 XB
-XB
+MW
 bn
 bn
-XB
+MW
 bn
 bn
-XB
+MW
 XB
 UJ
 gN
@@ -31692,11 +31866,11 @@ MC
 MC
 MC
 MC
-BH
+KO
 JY
 JY
 JY
-BH
+KO
 XB
 aF
 bp
@@ -31718,7 +31892,7 @@ qn
 au
 gN
 gN
-gN
+jO
 gN
 bz
 bJ
@@ -31963,7 +32137,7 @@ Qo
 Qo
 TX
 gC
-FD
+AL
 Gh
 Hz
 aJ
@@ -32234,7 +32408,7 @@ bj
 cP
 aZ
 bk
-gN
+jO
 dY
 bF
 bI
@@ -32495,7 +32669,7 @@ gN
 bN
 bN
 bN
-SY
+Wh
 fu
 eN
 dn
@@ -32719,7 +32893,7 @@ MC
 MC
 BH
 BH
-BH
+KO
 BH
 dR
 tH
@@ -32762,7 +32936,7 @@ eE
 eY
 fe
 aQ
-bi
+yP
 bi
 MC
 MC
@@ -32991,7 +33165,7 @@ jW
 jW
 TX
 JB
-FD
+AL
 HS
 Hh
 KE
@@ -33496,14 +33670,14 @@ Zw
 Zw
 as
 MC
-XB
+MW
 PR
 DJ
 ee
 DJ
 PR
 FD
-FD
+AL
 FD
 gp
 Gw
@@ -33517,7 +33691,7 @@ cT
 cc
 cu
 mq
-gN
+jO
 MC
 SY
 Tj
@@ -33527,11 +33701,11 @@ ur
 ur
 Za
 SY
-SY
+Wh
 SY
 eJ
 bi
-bi
+yP
 bi
 bi
 as
@@ -33759,7 +33933,7 @@ vN
 fG
 es
 eZ
-Ed
+As
 Ek
 Ew
 Uk
@@ -34035,7 +34209,7 @@ gN
 MC
 SY
 bR
-QN
+Yz
 fr
 cG
 cG
@@ -34274,7 +34448,7 @@ fP
 Bk
 Sl
 Ed
-gN
+jO
 ga
 Fu
 gN
@@ -34291,7 +34465,7 @@ gN
 gN
 bs
 SY
-SY
+Wh
 cg
 fp
 cH
@@ -34556,7 +34730,7 @@ lk
 di
 FQ
 IQ
-gs
+Rs
 dS
 lx
 UV
@@ -35038,7 +35212,7 @@ Zw
 Zw
 as
 ST
-yq
+uv
 yq
 DI
 GV
@@ -35327,7 +35501,7 @@ lk
 at
 FQ
 aE
-gs
+Rs
 RH
 EM
 EM
@@ -35558,7 +35732,7 @@ ZG
 Lt
 Bk
 yb
-yq
+uv
 gS
 GH
 ew
@@ -35576,7 +35750,7 @@ aS
 bg
 nI
 bE
-gs
+Rs
 cj
 cx
 cL
@@ -35584,7 +35758,7 @@ lk
 YO
 dx
 xk
-gs
+Rs
 cW
 CV
 Nc
@@ -35823,9 +35997,9 @@ Ro
 jR
 jR
 jR
-Ro
+gT
 qs
-qs
+mB
 Wn
 qs
 yU
@@ -35834,14 +36008,14 @@ yU
 yU
 qs
 qs
-qs
+mB
 Xn
 Xn
 Xn
 Xn
 Xn
 Xn
-Xn
+QY
 SY
 SY
 SY
@@ -36580,7 +36754,7 @@ Zw
 Zw
 as
 MC
-yq
+uv
 yq
 So
 bO
@@ -36595,7 +36769,7 @@ jH
 KU
 mw
 ow
-qs
+mB
 sI
 vJ
 Ah
@@ -36868,7 +37042,7 @@ oR
 pv
 Cw
 fj
-Xn
+QY
 Xn
 MC
 MC
@@ -37357,7 +37531,7 @@ MC
 MC
 MC
 MC
-Zi
+ID
 gv
 hu
 gx
@@ -37896,7 +38070,7 @@ VX
 Nz
 Gz
 fv
-NR
+Qk
 SW
 NR
 NS
@@ -38142,7 +38316,7 @@ tk
 wE
 Bh
 Hi
-rm
+sb
 Jj
 Nv
 VX
@@ -38399,7 +38573,7 @@ ty
 wM
 Bt
 aB
-rm
+sb
 Jn
 Ny
 Qq
@@ -38650,13 +38824,13 @@ VY
 VY
 lS
 Zi
-Zi
+ID
 qs
 Ui
 YB
 av
 qs
-Gl
+TS
 Gl
 NP
 QE
@@ -39438,7 +39612,7 @@ rL
 YI
 NO
 NO
-Gl
+TS
 SW
 VK
 VK
@@ -39938,9 +40112,9 @@ MC
 MC
 MC
 MC
-MC
-MC
-MC
+Sb
+Eu
+xq
 MC
 MC
 MC
@@ -40186,18 +40360,18 @@ MC
 MC
 hz
 hz
+RQ
 hz
 hz
-hz
-hz
+RQ
 hz
 hz
 MC
 MC
 MC
-MC
-MC
-MC
+Sb
+xq
+xq
 MC
 MC
 MC
@@ -40441,14 +40615,14 @@ MC
 MC
 MC
 MC
-hz
+RQ
 IF
 Qi
 bf
 kw
 fL
 fQ
-hz
+RQ
 MC
 MC
 MC
@@ -41212,14 +41386,14 @@ MC
 MC
 MC
 MC
-hz
+RQ
 LI
 Uy
 in
 zw
 fM
 fR
-hz
+RQ
 MC
 MC
 MC
@@ -41471,11 +41645,11 @@ MC
 MC
 hz
 hz
+RQ
 hz
+RQ
 hz
-hz
-hz
-hz
+RQ
 hz
 MC
 MC


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Для ТМ-а.
Добавляет гирлянды, мишуру, елки, декали на Коробку, ЦК, Велосити, зоны спавна мага и нюки. 
upd: Дельта, Гамма и Фалькольн тоже получают новогоднее настроение. 
upd2: Прометей
## Почему и что этот ПР улучшит
Летс ит сноу, падору-падору и далее по списку. С наступающим. 
## Авторство
Ястарк
## Чеинжлог
