### PR TITLE
фикс ритуала возрождения животного

### DIFF
--- a/code/modules/religion/rites/standing/misc.dm
+++ b/code/modules/religion/rites/standing/misc.dm
@@ -366,7 +366,7 @@
 	if(!istype(animal))
 		to_chat(user, "<span class='warning'>Only a animal can go through the ritual.</span>")
 		return FALSE
-	animal.maxHealth = clamp(initial(animal.maxHealth) * divine_power, 0, 300)
+	animal.maxHealth = clamp(initial(animal.maxHealth) * divine_power, 0, max(animal.maxHealth, 300))
 	animal.rejuvenate()
 
 	return TRUE

--- a/code/modules/religion/rites/standing/misc.dm
+++ b/code/modules/religion/rites/standing/misc.dm
@@ -366,11 +366,7 @@
 	if(!istype(animal))
 		to_chat(user, "<span class='warning'>Only a animal can go through the ritual.</span>")
 		return FALSE
-	var/potential_max_health = animal.maxHealth * divine_power
-	if(potential_max_health <= 300)
-		animal.maxHealth = potential_max_health
-	else
-		animal.maxHealth = 300
+	animal.maxHealth = clamp(initial(animal.maxHealth) * divine_power, 0, 300)
 	animal.rejuvenate()
 
 	return TRUE

--- a/code/modules/religion/rites/standing/misc.dm
+++ b/code/modules/religion/rites/standing/misc.dm
@@ -148,7 +148,7 @@
 	ritual_length = (50 SECONDS)
 	ritual_invocations = list("Я обращаюсь к тебе - Всевышний...",
 							  "...свет, дарованный мудростью возвратившихся богов...",
-							  "...Они наделили Анимацию человеческими страстями и чувствами...", 
+							  "...Они наделили Анимацию человеческими страстями и чувствами...",
 							  "...Анимация, пришедшая из Нового Царства, радуйся свету!...",)
 	invoke_msg = "Я обращаюсь к тебе! Я взываю! Очнись ото сна!"
 	favor_cost = 80
@@ -366,7 +366,11 @@
 	if(!istype(animal))
 		to_chat(user, "<span class='warning'>Only a animal can go through the ritual.</span>")
 		return FALSE
-	animal.maxHealth *= divine_power
+	var/potential_max_health = animal.maxHealth * divine_power
+	if(potential_max_health <= 300)
+		animal.maxHealth = potential_max_health
+	else
+		animal.maxHealth = 300
 	animal.rejuvenate()
 
 	return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
ритуал воскрешения животного перестаёт влиять на макс хп моба если оно у него равно 300 или больше
## Почему и что этот ПР улучшит
fixes #12579
fixes #12578
## Авторство

## Чеинжлог
🆑 Simbaka
- fix: Ритуал воскрешения мог увеличивать максимальное здоровье животного до огромных значений.