### PR TITLE
На бьёндотьме не видно оффсетнутые объекты.

### DIFF
--- a/code/__DEFINES/_planes_layers.dm
+++ b/code/__DEFINES/_planes_layers.dm
@@ -71,6 +71,7 @@ What is the naming convention for planes or layers?
   #define SPACE_PARALLAX_2_LAYER 2
   #define SPACE_PARALLAX_3_LAYER 3
   #define SPACE_PARALLAX_PLANET_LAYER 10
+#define PARALLAX_WHITE_RENDER_TARGET "*PARALLAX_WHITE_RENDER_TARGET"
 
 //SINGULARITY EFFECT
 #define SINGULARITY_EFFECT_PLANE_0 -25
@@ -130,6 +131,7 @@ What is the naming convention for planes or layers?
 #define ABOVE_GAME_PLANE  -1
 
 #define BLACKNESS_PLANE   0
+#define BLACKNESS_RENDER_TARGET "*BLACKNESS_RENDER_TARGET"
 
 #define SINGULARITY_PLANE 10
   #define SINGULARITY_LAYER 1

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -94,6 +94,8 @@
 	//byond internal end
 	render_relay_plane = RENDER_PLANE_GAME
 
+	render_target = BLACKNESS_RENDER_TARGET
+
 /atom/movable/screen/plane_master/lighting
 	name = "lighting plane master"
 	plane = LIGHTING_PLANE
@@ -101,6 +103,13 @@
 	blend_mode_override = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	render_relay_plane = RENDER_PLANE_GAME
+
+/atom/movable/screen/plane_master/lighting/apply_effects(mob/mymob)
+	remove_filter("add_blackness")
+	remove_filter("exclude_space")
+
+	add_filter("add_blackness", 1, layering_filter(render_source = BLACKNESS_RENDER_TARGET, blend_mode = BLEND_ADD))
+	add_filter("exclude_space", 1, layering_filter(render_source = PARALLAX_WHITE_RENDER_TARGET, blend_mode = BLEND_OVERLAY))
 
 /atom/movable/screen/plane_master/exposure
 	name = "exposure plane master"
@@ -213,6 +222,8 @@
 	name = "parallax whitifier plane master"
 	plane = PLANE_SPACE
 	render_relay_plane = RENDER_PLANE_GAME
+
+	render_target = PARALLAX_WHITE_RENDER_TARGET
 
 /atom/movable/screen/plane_master/singularity_0
 	name = "singularity_0 plane"


### PR DESCRIPTION
## Описание изменений
На бьёндотьме не видно офсеттнутые объекты. Ценой двух доп. фильтров.

Хотел сделать такое же и с экспожур и пр. фигнёй - но просчитался, блекнесс, оказывается, по умолчанию на всём мониторе лежит. А там где тьма на деле не бьёнд накидывает объекты тьмы, а просто бьёнд удаляет объекты и становится видно тьму.

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/39119cd3-b770-4027-b492-7a7def3d47e8)![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/c4b2725c-a0b4-49df-a688-60d7f14fc02c)![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/1baf4790-1f9b-4a9c-b84d-7da9cbbb3bfd)



## Почему и что этот ПР улучшит
Harder better faster stronger

## Авторство
AndreyGysev

## Чеинжлог
 :cl:
  - tweak: На бьёндотьме не видно офсеттнутые объекты