### PR TITLE
R&D nerf

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1091,7 +1091,7 @@ other types of metals and chemistry for reagents).
 	id = "high_cell"
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
-	build_path = /obj/item/weapon/stock_parts/cell/high
+	build_path = /obj/item/weapon/stock_parts/cell/high/empty
 	construction_time=100
 	category = list("Stock Parts")
 
@@ -1101,7 +1101,7 @@ other types of metals and chemistry for reagents).
 	id = "super_cell"
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
-	build_path = /obj/item/weapon/stock_parts/cell/super
+	build_path = /obj/item/weapon/stock_parts/cell/super/empty
 	construction_time=100
 	category = list("Stock Parts")
 
@@ -1111,7 +1111,7 @@ other types of metals and chemistry for reagents).
 	id = "hyper_cell"
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 400, MAT_GLASS = 70, MAT_SILVER = 150, MAT_GOLD = 150)
-	build_path = /obj/item/weapon/stock_parts/cell/hyper
+	build_path = /obj/item/weapon/stock_parts/cell/hyper/empty
 	construction_time=100
 	category = list("Stock Parts")
 
@@ -1122,7 +1122,7 @@ other types of metals and chemistry for reagents).
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 800, MAT_GLASS = 160, MAT_SILVER = 300, MAT_GOLD = 300, MAT_DIAMOND = 160)
 //	construction_time=100
-	build_path = /obj/item/weapon/stock_parts/cell/bluespace
+	build_path = /obj/item/weapon/stock_parts/cell/bluespace/empty
 	category = list("Stock Parts")
 
 
@@ -1950,7 +1950,7 @@ other types of metals and chemistry for reagents).
 	materials = list (MAT_METAL = 8000, MAT_GLASS = 1000, MAT_URANIUM = 200)
 	build_path = /obj/item/weapon/gun/energy/laser
 	category = list("Weapons")
-	
+
 /datum/design/laserpractice
 	name = "Practice Laser Gun"
 	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Все батарейки кроме базовой на тысячу заряда появляются незаряженными
## Почему и что этот ПР улучшит
исправление логической ошибки с необоснованной заполненностью блюспейс и прочих батареек при их печатании
## Авторство
maleyvich
## Чеинжлог
:cl:
- balance: При печатании батареек в РНД, изначально они будут не заряжены.