### PR TITLE
fix upload_apc and toilets_x_y

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -33567,6 +33567,10 @@
 "bhF" = (
 /obj/structure/cable,
 /obj/machinery/computer/smartlight,
+/obj/machinery/power/apc{
+	name = "apc down";
+	pixel_y = -28
+	},
 /turf/simulated/floor/whitegreed,
 /area/station/bridge/ai_upload)
 "bhG" = (

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -21106,8 +21106,7 @@
 	dir = 4
 	},
 /obj/structure/toilet{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -21106,7 +21106,8 @@
 	dir = 4
 	},
 /obj/structure/toilet{
-	dir = 8
+	dir = 8;
+	pixel_y = 8
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -30470,6 +30471,10 @@
 	},
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
+	},
+/obj/machinery/power/apc{
+	name = "apc down";
+	pixel_y = -28
 	},
 /turf/simulated/floor{
 	icon_state = "dark"

--- a/tools/dmm-merge-tool/README.md
+++ b/tools/dmm-merge-tool/README.md
@@ -1,4 +1,4 @@
-# JTGMerge
+r# JTGMerge
 
 **JTGMerge** развитие оригинального [JMerge](https://github.com/Baystation12/JMerge), добавляющее ряд фич и поддержку TGM формата.
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Пофиксил летающие унитазы в туалетах бокса и добавил отсутствующей в аплоуде АПЦ.
https://github.com/TauCetiStation/TauCetiClassic/issues/12506
## Почему и что этот ПР улучшит
Удобнее сидеть на унитазах, в аплоаде снова есть АПЦ.
## Авторство
SgtDavidson
## Чеинжлог
🆑 SgtDavidson
- map: Возвращение АПЦ в Аплоад и Гейтвей на боксе.
- map: Посадил унитазы на пол в туалете на боксе. 