### PR TITLE
Changeling actions fixes 2

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/changeling_power.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/changeling_power.dm
@@ -24,7 +24,7 @@
 		action = new (user)
 		action.button_icon_state = button_icon_state
 		action.name = name
-		action.holder = src
+		action.target = src
 		action.Grant(user)
 
 /obj/effect/proc_holder/changeling/Destroy()
@@ -37,13 +37,13 @@
 /datum/action/innate/changeling
 	button_icon = 'icons/hud/actions_changeling.dmi'
 	background_icon_state = "bg_changeling"
-	var/obj/effect/proc_holder/changeling/holder
 
 /datum/action/innate/changeling/Trigger()
 	. = ..()
 	var/mob/user = owner
 	if(!user || !ischangeling(user))
 		return
+	var/obj/effect/proc_holder/changeling/holder = target
 	holder.on_sting_choose(user)
 
 /obj/effect/proc_holder/changeling/Click()

--- a/code/game/gamemodes/modes_gameplays/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/evolution_menu.dm
@@ -402,6 +402,6 @@ var/global/list/sting_paths
 
 /datum/role/changeling/proc/has_sting(obj/effect/proc_holder/changeling/power)
 	for(var/obj/effect/proc_holder/changeling/P in purchasedpowers)
-		if(power.name == P.name)
+		if(power.type == P.type)
 			return TRUE
 	return FALSE


### PR DESCRIPTION
## Описание изменений
Очередной фикс акшионов генки. 
1) У акшионов если нет `target`, они решают удаляться (происходит при 2-м и 3-м ласт резорте, к примеру)
2) Способности генокрадов проверяются через тип, а не через имя способности
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
 - bugfix: Кнопки генокрадов более не пропадают от перевоплощение в мартышку