### PR TITLE
new year tweak

### DIFF
--- a/code/modules/holidays/new_year/decorations.dm
+++ b/code/modules/holidays/new_year/decorations.dm
@@ -8,10 +8,38 @@
 	icon_state = "santa"
 	layer = 4.1
 
-/obj/item/decoration/attack_hand(mob/user)
-	var/choice = input("Do you want to take \the [src]?") in list("Yes", "Cancel")
-	if(choice == "Yes" && get_dist(src, user) <= 1)
+
+/obj/item/decoration/attack_hand(mob/user, flag_ignore = FALSE)
+	if(flag_ignore == TRUE)
 		..()
+
+/obj/item/decoration/verb_pickup()
+	set src in oview(1)
+	set category = "Object"
+	set name = "Pick up"
+
+	if(!(usr)) //BS12 EDIT
+		return
+	if(usr.incapacitated() || !Adjacent(usr))
+		return
+	if((!iscarbon(usr)) || (isbrain(usr)))//Is humanoid, and is not a brain
+		to_chat(usr, "<span class='warning'>You can't pick things up!</span>")
+		return
+	if(src.anchored) //Object isn't anchored
+		to_chat(usr, "<span class='warning'>You can't pick that up!</span>")
+		return
+	if(!usr.hand && usr.r_hand) //Right hand is not full
+		to_chat(usr, "<span class='warning'>Your right hand is full.</span>")
+		return
+	if(usr.hand && usr.l_hand) //Left hand is not full
+		to_chat(usr, "<span class='warning'>Your left hand is full.</span>")
+		return
+	if(!istype(src.loc, /turf)) //Object is on a turf
+		to_chat(usr, "<span class='warning'>You can't pick that up!</span>")
+		return
+	//All checks are done, time to pick it up!
+	attack_hand(usr , TRUE)
+	return
 
 /obj/item/decoration/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Гирлянды и прочая мишура больше не спамят вопросами после клика. Чтобы поднять используйте rmb->pick_up
## Почему и что этот ПР улучшит
Меньше назойливых окон
## Авторство
arygal
## Чеинжлог
:cl:
- tweak: Новогодние украшения поднимаются только через правую кнопку мыши.