### PR TITLE
бафф самодельного арбалета

### DIFF
--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -31,8 +31,8 @@
 	w_class = SIZE_SMALL
 
 	var/tension = 0                       // Current draw on the bow.
-	var/max_tension = 3                   // Highest possible tension.
-	var/release_speed = 4                 // Speed per unit of tension.
+	var/max_tension = 5                   // Highest possible tension.
+	var/release_speed = 5                 // Speed per unit of tension.
 	var/mob/living/current_user = null    // Used to see if the person drawing the bow started drawing it.
 	var/obj/item/weapon/arrow = null      // Nocked arrow.
 	var/obj/item/weapon/stock_parts/cell/cell = null  // Used for firing special projectiles like rods.
@@ -209,7 +209,3 @@
 	desc = "Чтобы завершить, вам нужно: затянуть болты с помощью отвертки."
 	icon_state = "crossbowframe6"
 	item_state = "crossbow-solid"
-
-/obj/item/weapon/crossbow/vox
-	max_tension = 5
-	release_speed = 5

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -2265,7 +2265,7 @@
 /area/centcom/evac)
 "afM" = (
 /obj/structure/rack,
-/obj/item/weapon/crossbow/vox,
+/obj/item/weapon/crossbow,
 /obj/item/weapon/arrow,
 /obj/item/weapon/arrow,
 /obj/item/weapon/arrow,
@@ -21395,7 +21395,7 @@
 /area/shuttle/vox/arkship_hold)
 "aZQ" = (
 /obj/structure/rack,
-/obj/item/weapon/crossbow/vox,
+/obj/item/weapon/crossbow,
 /obj/item/weapon/arrow,
 /obj/item/weapon/arrow,
 /obj/item/weapon/arrow,

--- a/maps/templates/space_structures/broken_breacher.dmm
+++ b/maps/templates/space_structures/broken_breacher.dmm
@@ -1235,7 +1235,7 @@
 /turf/environment/space,
 /area/space)
 "Vk" = (
-/obj/item/weapon/crossbow/vox,
+/obj/item/weapon/crossbow,
 /obj/item/weapon/arrow,
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating/airless,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Самодельный арбалет стал таким же мощным как и воксовской арбалет
Убрал отдельный подтип воксовского арбалета (ведь они отличались только мощью выстрела)
## Почему и что этот ПР улучшит
баланс
Не вижу ни одной причины по которой однозарядный арбалет с очень долгой зарядкой и без возможности переносить его в заряженном состоянии в рюкзаке должен быть ОЧЕНЬ СЛАБЫМ (настолько слабым, что болт не может прибить врага к стене, а без батарейки вообще сломать кость с одного попадания!!!)
## Авторство

## Чеинжлог
🆑 Simbaka
- balance: Самодельный арбалет стал намного мощнее!