### PR TITLE
Восстановление поставки игрушечного двойного лазерного меча

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -16,6 +16,7 @@
 							/obj/item/toy/blink								= 2,
 							/obj/item/clothing/under/syndicate/tacticool	= 2,
 							/obj/item/toy/sword								= 2,
+							/obj/item/toy/dualsword							= 2,
 							/obj/item/toy/gun								= 2,
 							/obj/item/toy/crossbow							= 2,
 							/obj/item/clothing/suit/syndicatefake			= 2,

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -512,6 +512,18 @@
 	add_fingerprint(user)
 	return
 
+/obj/item/toy/sword/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/toy/sword))
+		to_chat(user, "<span class='notice'>You attach the ends of the two \
+			toy energy swords, making a single double-bladed toy weapon! \
+			You're cool.</span>")
+		var/obj/item/toy/dualsword/newsword = new(user.loc)
+		user.unEquip(I)
+		user.unEquip(src)
+		qdel(I)
+		qdel(src)
+		user.put_in_hands(newsword)
+
 /obj/item/toy/katana
 	name = "replica katana"
 	desc = "Woefully underpowered in D20."
@@ -525,6 +537,60 @@
 	throwforce = 5
 	w_class = SIZE_SMALL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
+
+/obj/item/toy/dualsword
+	name = "double-bladed energy sword"
+	desc = "Handle with care"
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "dualsaber0"
+	item_state = "dualsaber0"
+	var/active = FALSE
+	w_class = SIZE_TINY
+	attack_verb = list("attacked", "struck", "hit")
+	var/blade_color = "blue"
+
+/obj/item/toy/dualsword/atom_init()
+	. = ..()
+	blade_color = pick("red", "blue", "green", "purple", "yellow", "pink", "black")
+	switch(blade_color)
+		if("red")
+			light_color = COLOR_RED
+		if("blue")
+			light_color = COLOR_BLUE
+		if("green")
+			light_color = COLOR_GREEN
+		if("purple")
+			light_color = COLOR_PURPLE
+		if("yellow")
+			light_color = COLOR_YELLOW
+		if("pink")
+			light_color = COLOR_PINK
+		if("black")
+			light_color = COLOR_GRAY
+
+/obj/item/toy/dualsword/attack_self(mob/user)
+	active = !active
+	if (active)
+		to_chat(user, "<span class='notice'>You extend the plastic blade with a quick flick of your wrist.</span>")
+		playsound(user, 'sound/weapons/saberon.ogg', VOL_EFFECTS_MASTER)
+		icon_state = "dualsaber[blade_color]1"
+		item_state = icon_state
+		w_class = SIZE_NORMAL
+		hitsound = list('sound/weapons/blade1.ogg')
+		set_light(2)
+	else
+		to_chat(user, "<span class='notice'>You push the plastic blade back down into the handle.</span>")
+		playsound(user, 'sound/weapons/saberoff.ogg', VOL_EFFECTS_MASTER)
+		icon_state = "dualsaber0"
+		item_state = "dualsaber0"
+		w_class = SIZE_TINY
+		hitsound = initial(hitsound)
+		set_light(0)
+
+	update_inv_mob()
+
+	add_fingerprint(user)
+	return
 
 /*
  * Snap pops

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -103,6 +103,7 @@
 		/obj/item/toy/prize/seraph,
 		/obj/item/toy/spinningtoy,
 		/obj/item/toy/sword,
+		/obj/item/toy/dualsword,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiadeus,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris,
 		/obj/item/device/paicard,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1844,6 +1844,7 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 	num_contained = 5
 	contains = list(/obj/item/toy/spinningtoy,
 	                /obj/item/toy/sword,
+					/obj/item/toy/dualsword,
 	                /obj/item/toy/owl,
 	                /obj/item/toy/griffin,
 	                /obj/item/toy/nuke,

--- a/code/modules/holidays/new_year/presents.dm
+++ b/code/modules/holidays/new_year/presents.dm
@@ -17,6 +17,7 @@
 						/obj/item/toy/blink								= 2,
 						/obj/item/clothing/under/syndicate/tacticool	= 1,
 						/obj/item/toy/sword								= 2,
+						/obj/item/toy/dualsword							= 2,
 						/obj/item/toy/gun								= 2,
 						/obj/item/toy/crossbow							= 2,
 						/obj/item/clothing/suit/syndicatefake			= 1,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавляет игрушку даблы
## Почему и что этот ПР улучшит
У нас есть обычный лазерный меч, тогда должна быть и дабла + в идентификации говорится что есть игрушечный аналог
## Авторство
Я
## Чеинжлог
:cl: Slavik2001
 - add: На станцию восстановили поставки игрушечного двойного лазерного меча