### PR TITLE
Cryopod

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -167,6 +167,10 @@ var/global/list/frozen_items = list()
 		icon_state = "cryosleeper_left"
 	. = ..()
 
+/obj/machinery/cryopod/Destroy()
+	. = ..()
+	QDEL_NULL(announce)
+
 /obj/machinery/cryopod/proc/delete_objective(datum/objective/target/O)
 	if(!O)
 		return
@@ -337,6 +341,18 @@ var/global/list/frozen_items = list()
 			PDA_Manifest.Cut()
 			break
 
+/obj/machinery/cryopod/AltClick(mob/user)
+	. = ..()
+	enter_pod(user)
+
+/obj/machinery/cryopod/relaymove(mob/user)
+	..()
+	go_out()
+
+/obj/machinery/cryopod/MouseDrop_T(mob/target, mob/user)
+	. = ..()
+	enter_pod(user)
+
 /obj/machinery/cryopod/verb/eject()
 	set name = "Eject Pod"
 	set category = "Object"
@@ -359,31 +375,33 @@ var/global/list/frozen_items = list()
 	set name = "Enter Pod"
 	set category = "Object"
 	set src in oview(1)
+	enter_pod(usr)
 
-	if(usr.incapacitated() || !(ishuman(usr)))
+/obj/machinery/cryopod/proc/enter_pod(mob/user)
+	if(user.incapacitated() || !(ishuman(user)))
 		return
 
-	if(!usr.IsAdvancedToolUser())
-		to_chat(usr, "<span class='notice'>You have no idea how to do that.</span>")
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='notice'>You have no idea how to do that.</span>")
 		return
 
 	if(occupant)
-		to_chat(usr, "<span class='notice'><B>The cryo pod is in use.</B></span>")
+		to_chat(user, "<span class='notice'><B>The cryo pod is in use.</B></span>")
 		return
 
-	for(var/mob/living/carbon/slime/M in range(1, usr))
-		if(M.Victim == usr)
-			to_chat(usr, "You're too busy getting your life sucked out of you.")
+	for(var/mob/living/carbon/slime/M in range(1, user))
+		if(M.Victim == user)
+			to_chat(user, "You're too busy getting your life sucked out of you.")
 			return
-	if(usr.is_busy())
+	if(user.is_busy())
 		return
-	visible_message("[usr] starts climbing into the cryo pod.", 3)
+	visible_message("[user] starts climbing into the cryo pod.", 3)
 	if(do_after(usr, 20, target = src))
 		if(occupant)
-			to_chat(usr, "<span class='notice'><B>The cryo pod is in use.</B></span>")
+			to_chat(user, "<span class='notice'><B>The cryo pod is in use.</B></span>")
 			return
-		insert(usr)
-		add_fingerprint(usr)
+		insert(user)
+		add_fingerprint(user)
 
 /obj/machinery/cryopod/proc/go_out()
 	occupant.forceMove(get_turf(src))


### PR DESCRIPTION

## Описание изменений
 Долгожданное обновление. Исправляет 3 ошибки:
1) Можно залезть в криопод через перетаскивание персонажа на оный или альтклик. 
2) Можно вылезти просто "шагнув".
3) Удаление криопода удаляет и радио в нём. Не будет 8 интеркомов на месте криоподов
## Почему и что этот ПР улучшит
И не говорите мне, что это фича. 
## Авторство

## Чеинжлог
🆑 
- tweak: В криопод можно залезть перетягиванием. 