### PR TITLE
ceil() compability fix

### DIFF
--- a/code/__DEFINES/math.dm
+++ b/code/__DEFINES/math.dm
@@ -31,7 +31,7 @@
 
 #define CEILING(x, y) ( -round(-(x) / (y)) * (y) )
 
-#define CEIL(x) (-round(-(x)))
+#define CEIL(x) ceil(x)
 
 // Similar to clamp but the bottom rolls around to the top and vice versa. min is inclusive, max is exclusive
 #define WRAP(val, min, max) ( min == max ? min : (val) - (round(((val) - (min))/((max) - (min))) * ((max) - (min))) )

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -58,3 +58,7 @@
 /// Call by name proc reference, checks if the proc is existing global proc
 #define GLOBAL_PROC_REF(X) (/proc/##X)
 #endif
+
+#if DM_VERSION < 515
+#define ceil(x) (-round(-(x)))
+#endif


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

мысленно я уже в 515, извиняюсь. 

Фаллбек для ``ceil()`` для старый версий, + замена старого макроса на нативный ``ceil()`` для новых версий.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
