### PR TITLE
Weapon serial number

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -90,6 +90,8 @@
 
 	var/dyed_type
 
+	var/serialNumber = null
+
 	var/flash_protection = NONE
 	var/list/flash_protection_slots = list()
 	var/can_get_wet = TRUE
@@ -123,6 +125,9 @@
 		item_actions += B
 
 	return INITIALIZE_HINT_NORMAL
+
+/obj/item/proc/setSerialNumber()
+	serialNumber = rand(0, 999999)
 
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
 	if(((src in target) && !target_self) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)) || is_type_in_list(target, can_be_placed_into))
@@ -205,6 +210,8 @@
 		if(wet)
 			stat_flavor = "<span class='wet'>[stat_flavor]</span>"
 
+		if(serialNumber)
+			to_chat(user, "Серийный номер: [serialNumber]")
 		to_chat(user, stat_flavor)
 
 /obj/item/proc/mob_pickup(mob/user, hand_index=null)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -193,6 +193,10 @@
 	icon_state = "combat_knife"
 	origin_tech = "materials=1;combat=1"
 
+/obj/item/weapon/kitchenknife/combat/atom_init()
+	..()
+	setSerialNumber()
+
 /obj/item/weapon/kitchenknife/throwing
 	name = "throwing knife"
 	desc = "A blade designed to be apparently useless for normal melee combat, but very useful for throwing."

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -18,6 +18,7 @@
 
 /obj/item/weapon/melee/baton/atom_init()
 	. = ..()
+	setSerialNumber()
 	var/datum/swipe_component_builder/SCB = new
 	SCB.interupt_on_sweep_hit_types = list(/turf, /obj/effect/effect/weapon_sweep)
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -158,6 +158,7 @@
 
 /obj/item/weapon/melee/telebaton/atom_init()
 	. = ..()
+	setSerialNumber()
 	var/datum/swipe_component_builder/SCB = new
 	SCB.interupt_on_sweep_hit_types = list(/turf, /obj/effect/effect/weapon_sweep)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -46,6 +46,10 @@
 /datum/action/item_action/hands_free/switch_gun
 	name = "Switch Gun"
 
+/obj/item/weapon/gun/atom_init()
+	..()
+	setSerialNumber()
+
 /obj/item/weapon/gun/examine(mob/user)
 	..()
 	if(two_hand_weapon)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил случайный серийный номер каждому стрелковому и некоторому холодному оружию.
## Почему и что этот ПР улучшит
Геймплей
## Авторство
Я
## Чеинжлог
:cl:
- tweak: При осмотре оружия, виден его серийный номер.