### PR TITLE
Hide "Modes that will ALWAYS start"

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -253,7 +253,7 @@ SUBSYSTEM_DEF(ticker)
 		SSjob.ResetOccupations()
 		return FALSE
 
-	if(!bundle || !bundle.hidden)
+	if(!bundle || !bundle.hide_mode_announce)
 		mode.announce()
 
 	setup_economy()

--- a/code/game/gamemodes/modesbundle.dm
+++ b/code/game/gamemodes/modesbundle.dm
@@ -1,7 +1,8 @@
 /datum/modesbundle
 	var/name
 	var/votable = TRUE
-	var/hidden = TRUE // for mode annouce
+	var/hide_mode_announce = TRUE
+	var/hide_for_shitspawn = FALSE
 	var/list/possible_gamemodes = list()
 
 /datum/modesbundle/proc/get_gamemodes_name()
@@ -66,7 +67,7 @@
 
 /datum/modesbundle/extended
 	name = "Extended"
-	hidden = FALSE
+	hide_mode_announce = FALSE
 	possible_gamemodes = list(/datum/game_mode/extended, /datum/game_mode/junkyard)
 
 /datum/modesbundle/all
@@ -94,7 +95,8 @@
 /datum/modesbundle/run_anyway
 	name = "Modes that will ALWAYS start"
 	votable = FALSE
-	hidden = FALSE
+	hide_mode_announce = FALSE
+	hide_for_shitspawn = TRUE
 	possible_gamemodes = list(/datum/game_mode/extended)
 
 /datum/modesbundle/run_anyway/get_gamemodes_name()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1118,6 +1118,8 @@
 		dat += "<HR>"
 		for(var/type in subtypesof(/datum/modesbundle))
 			var/datum/modesbundle/bound_type = type
+			if(initial(bound_type.hide_for_shitspawn))
+				continue
 			var/bname = initial(bound_type.name)
 			dat += {"<A href='?src=\ref[src];c_mode2=[bname]'>[bname]</A><br>"}
 		dat += {"Now: [master_mode]"}


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Переименовал hidden в hide_mode_announce, потому что до этого не понятно че это там скрывало.

Ну и новая переменная hide_for_shitspawn, которая скрывает от щитспавна. (на самом деле нет, но мне этот эксплоит нравится и я мне лень фиксить)


Игроки так-то не должны это были видеть, но вышло так.

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/26389417/959c8fb6-315e-4662-bf82-e2cf632f84cb)


## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
