### PR TITLE
фикс аспекта

### DIFF
--- a/code/datums/round_aspects/round_aspects.dm
+++ b/code/datums/round_aspects/round_aspects.dm
@@ -90,9 +90,6 @@
 	OOC_lobby_announcement = "<span class='warning'>В качестве эксперимента, НаноТрейзен решило разместить на спутнике станции целых три ядра ИИ.</span>"
 	desc = "Увеличено количество слотов ИИ до трёх."
 
-/datum/round_aspect/ai_trio/after_init()
-	SSticker.triai = TRUE
-
 /datum/round_aspect/elite_sec
 	name = ROUND_ASPECT_ELITE_SECURITY
 	desc = "Изменено снаряжение офицеров охраны. Увеличены цены на оружие в карго и РнД."

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -207,6 +207,7 @@
 
 /obj/structure/AIcore/deactivated/atom_init()
 	. = ..()
+	empty_playable_ai_cores += src
 	aicore_deactivated_list += src
 
 /obj/structure/AIcore/deactivated/Destroy()

--- a/code/game/objects/effects/spawners/aicorespawner.dm
+++ b/code/game/objects/effects/spawners/aicorespawner.dm
@@ -5,7 +5,7 @@
 
 
 /obj/effect/spawner/newai/atom_init()
-	..()
+	. = ..()
 	if(!HAS_ROUND_ASPECT(ROUND_ASPECT_AI_TRIO))
 		qdel(src)
 		return

--- a/code/game/objects/effects/spawners/aicorespawner.dm
+++ b/code/game/objects/effects/spawners/aicorespawner.dm
@@ -1,0 +1,14 @@
+/obj/effect/spawner/newai //only for trioai aspect
+	name = "ai core spawner"
+	icon = 'icons/hud/screen1.dmi'
+	icon_state = "x"
+
+
+/obj/effect/spawner/newai/atom_init()
+	..()
+	if(!HAS_ROUND_ASPECT(ROUND_ASPECT_AI_TRIO))
+		qdel(src)
+		return
+	new /obj/structure/AIcore/deactivated (loc)
+	qdel(src)
+

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -60938,6 +60938,7 @@
 /obj/effect/landmark{
 	name = "tripai"
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "cor" = (
@@ -61512,6 +61513,7 @@
 /obj/effect/landmark{
 	name = "tripai"
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "cpJ" = (

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -20999,6 +20999,7 @@
 /obj/effect/landmark{
 	name = "tripai"
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit"
 	},
@@ -57632,6 +57633,7 @@
 /obj/effect/landmark{
 	name = "tripai"
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit"
 	},

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -8368,6 +8368,7 @@
 	name = "Common Channel";
 	pixel_y = -20
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "apT" = (
@@ -12501,6 +12502,7 @@
 	name = "Custom Channel";
 	pixel_y = 19
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "cYF" = (

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -34402,6 +34402,7 @@
 	pixel_x = -25;
 	pixel_y = -4
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "gfN" = (
@@ -119528,6 +119529,7 @@
 	pixel_x = 27;
 	pixel_y = -3
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "xmF" = (

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -5565,6 +5565,7 @@
 	name = "Private Channel";
 	pixel_y = -31
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "aKN" = (
@@ -100071,6 +100072,7 @@
 	name = "Private Channel";
 	pixel_y = -31
 	},
+/obj/effect/spawner/newai,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "ycC" = (

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -990,6 +990,7 @@
 #include "code\game\objects\effects\decals\Cleanable\misc.dm"
 #include "code\game\objects\effects\decals\Cleanable\robots.dm"
 #include "code\game\objects\effects\decals\Cleanable\tracks.dm"
+#include "code\game\objects\effects\spawners\aicorespawner.dm"
 #include "code\game\objects\effects\spawners\bombspawner.dm"
 #include "code\game\objects\effects\spawners\gibspawner.dm"
 #include "code\game\objects\effects\spawners\lootdrop.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
аспект на 3 ии теперь спавнит пустые ядра ии за которые можно зайти в меню выбора профки
## Почему и что этот ПР улучшит
нельзя было зайти за второго или третьего ии после старта раунда со специальным аспектом
## Авторство

## Чеинжлог
