### PR TITLE
Fix borg rcd

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -764,7 +764,7 @@
 			return
 
 	// Use tool's fuel, stack sheets or charges if amount is set.
-	if(amount && !use(amount))
+	if(amount && !use(amount, user))
 		return
 
 	// Play tool sound at the end of tool usage,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
в проке `/obj/item/weapon/rcd/borg/use(amount, mob/user)` есть проверка `if(!isrobot(user))`
вместо игрока в user был null, поэтому проверка не проходилась и rcd боргов не работал
## Почему и что этот ПР улучшит
closes #12575
closes #12690
## Авторство

## Чеинжлог
:cl: Kandrey
- bugfix: RCD боргов снова работает
