### PR TITLE
Kill var/abstract 

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/items.dmi'
 	w_class = SIZE_SMALL
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
-	var/abstract = 0
 	var/lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	var/r_speed = 1.0
@@ -934,7 +933,7 @@
 	set category = "Object"
 
 	var/obj/item/I = get_active_hand()
-	if(I && !I.abstract)
+	if(I && !(I.flags & ABSTRACT))
 		I.showoff(src)
 
 /obj/item/proc/extinguish()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -922,13 +922,13 @@
 
 
 /mob/living/carbon/human/abiotic(full_body = 0)
-	if(full_body && ((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )) || (src.back || src.wear_mask || src.head || src.shoes || src.w_uniform || src.wear_suit || src.glasses || src.l_ear || src.r_ear || src.gloves)))
-		return 1
+	if(full_body && ((l_hand && !(l_hand.flags & ABSTRACT)) || (r_hand && !(r_hand.flags & ABSTRACT)) || (back || wear_mask || head || shoes || w_uniform || wear_suit || glasses || l_ear || r_ear || gloves)))
+		return TRUE
 
-	if( (src.l_hand && !src.l_hand.abstract) || (src.r_hand && !src.r_hand.abstract) )
-		return 1
+	if((l_hand && !(l_hand.flags & ABSTRACT)) || (r_hand && !(r_hand.flags & ABSTRACT)))
+		return TRUE
 
-	return 0
+	return FALSE
 
 
 /mob/living/carbon/human/proc/check_dna()

--- a/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger_playable.dm
+++ b/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger_playable.dm
@@ -178,7 +178,6 @@ This is chestburster mechanic for damaging
 	var/last_bite = 0
 
 	layer = 21
-	abstract = 1
 	item_state = "nothing"
 	w_class = SIZE_BIG
 
@@ -335,7 +334,6 @@ When we finish, facehugger's player will be transfered inside embryo.
 	var/on_cooldown = FALSE
 
 	layer = 21
-	abstract = 1
 	item_state = "nothing"
 	w_class = SIZE_BIG
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -11,7 +11,7 @@
 	name = "grab"
 	icon = 'icons/hud/screen1.dmi'
 	icon_state = "reinforce"
-	flags = DROPDEL|NOBLUDGEON
+	flags = ABSTRACT|DROPDEL|NOBLUDGEON
 	var/atom/movable/screen/grab/hud = null
 	var/mob/living/affecting = null
 	var/mob/living/assailant = null
@@ -23,7 +23,6 @@
 	var/dancing //determines if assailant and affecting keep looking at each other. Basically a wrestling position
 
 	layer = 21
-	abstract = 1
 	item_state = "nothing"
 	w_class = SIZE_BIG
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -391,7 +391,7 @@ var/global/list/cursed_words = list("МРАЧНЫЕ ВРЕМЕНА", "ТЬМА",
 
 
 /mob/proc/abiotic(full_body = 0)
-	if(full_body && ((l_hand.flags & ABSTRACT) || (r_hand && !(r_hand.flags & ABSTRACT)) || (back || wear_mask)))
+	if(full_body && ((l_hand.flags & ABSTRACT) || (r_hand && !(r_hand.flags & ABSTRACT)) || back || wear_mask))
 		return TRUE
 
 	if((l_hand && !(l_hand.flags & ABSTRACT)) || (r_hand && !(r_hand.flags & ABSTRACT)))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -391,16 +391,13 @@ var/global/list/cursed_words = list("МРАЧНЫЕ ВРЕМЕНА", "ТЬМА",
 
 
 /mob/proc/abiotic(full_body = 0)
-	if(full_body && ((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )) || (src.back || src.wear_mask)))
-		return 1
+	if(full_body && ((l_hand.flags & ABSTRACT) || (r_hand && !(r_hand.flags & ABSTRACT)) || (back || wear_mask)))
+		return TRUE
 
-	if((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )))
-		return 1
+	if((l_hand && !(l_hand.flags & ABSTRACT)) || (r_hand && !(r_hand.flags & ABSTRACT)))
+		return TRUE
 
-	if(l_hand && !(l_hand.flags & ABSTRACT) || r_hand && !(r_hand.flags & ABSTRACT))
-		return 1
-
-	return 0
+	return FALSE
 
 //converts intent-strings into numbers and back
 var/global/list/intents = list(INTENT_HELP, INTENT_PUSH, INTENT_GRAB, INTENT_HARM)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -395,10 +395,6 @@
 		return FALSE
 	if(target.flags & ABSTRACT)
 		return FALSE
-	if(isitem(target))
-		var/obj/item/I = target
-		if(I.abstract)
-			return FALSE
 
 	return TRUE
 


### PR DESCRIPTION
## Описание изменений
В билде есть такое недоразумение, как `var/abstract `, т.е. просто старая версия от `flag = ABSTRACT`
Оно было использовано только для граба-предмета (появляется в руке, если схватить человека) или лярва и фейсхаггером 

Дополнительно убрал лишние `src.` и проставил `TRUE` `FALSE`
И ТОЛЬКО если тебя суют в гиббер или сканер
## Почему и что этот ПР улучшит
Полез я с этим разбираться из-за вопросов с зомби, которые не могут быть засунуты в гиббер из-за своих рук, как оказалось гиббер проверяет на абстрактность предмета как переменную, но не на флаг. 
## Авторство

## Чеинжлог
Мелкорефактор