### PR TITLE
детонаторы не пропадают в никуда

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -15,8 +15,6 @@
 	var/obj/special_assembly = null
 
 /obj/item/device/assembly_holder/Destroy()
-	a_left.holder = null
-	a_right.holder = null
 	QDEL_NULL(a_left)
 	QDEL_NULL(a_right)
 	return ..()
@@ -168,11 +166,13 @@
 		var/turf/T = get_turf(src)
 		if(!T)	return 0
 		if(a_left)
-			a_left:holder = null
 			a_left.loc = T
+			a_left.holder = null
+			a_left = null
 		if(a_right)
-			a_right:holder = null
 			a_right.loc = T
+			a_right.holder = null
+			a_right = null
 		qdel(src)
 	return
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
closes #12701
closes #12542 
появилось после #12515
ссылки на левую-правую часть не чистились перед ``Destroy()`` из-за этого и удалялись
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
