### PR TITLE
Боргам добавлены новые ландмарки

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -47742,6 +47742,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/effect/landmark/start/cyborg,
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "bGV" = (
@@ -49097,6 +49098,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/effect/landmark/start/cyborg,
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "bJt" = (

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -54275,6 +54275,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/effect/landmark/start/cyborg,
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "keg" = (
@@ -103972,6 +103973,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/effect/landmark/start/cyborg,
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "ueu" = (

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -36031,6 +36031,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/effect/landmark/start/cyborg,
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "ibg" = (
@@ -96886,10 +96887,6 @@
 "xlb" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -22
 	},
 /turf/simulated/floor/bluegrid,
 /area/station/rnd/chargebay)

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -96888,6 +96888,10 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -22
+	},
 /turf/simulated/floor/bluegrid,
 /area/station/rnd/chargebay)
 "xlD" = (


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В отделы робототехниках на станциях были добавлены ландмарки спавна боргов
## Почему и что этот ПР улучшит
скорее всего логично то, что борги будут появляться у места где их собирают?
## Авторство
maleyvich
## Чеинжлог
:cl:
- map: В отдел робототехники станций добавлены ландмарки спавна для боргов.