### PR TITLE
SE transfer fix

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -754,7 +754,7 @@
 					connected.occupant.name = buf.dna.real_name
 				connected.occupant.UpdateAppearance(buf.dna.UI.Copy())
 			else if (buf.types & DNA2_BUF_SE)
-				connected.occupant.dna.SE = buf.dna.SE
+				connected.occupant.dna.SE = buf.dna.Clone()
 				connected.occupant.dna.UpdateSE()
 				domutcheck(connected.occupant,connected)
 			connected.occupant.radiation += rand(15 / (connected.damage_coeff), 40 / connected.damage_coeff)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
При трансфере SE - цель получает новые гены, а не указатель на гены в буффере.
## Почему и что этот ПР улучшит
Теперь после того как ты провёл трансфер - гены в буфере останутся не тронутыми после изменений в кукле.
## Авторство
arygal
## Чеинжлог
