### PR TITLE
Reverts IPC immunity to suits slowdown (#4189)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -93,7 +93,7 @@
 	if(item_slowdown)
 		if(item_slowdown < 0)
 			tally += item_slowdown
-		else if(!(species.flags[IS_SYNTHETIC] || chem_nullify_debuff))
+		else if(!chem_nullify_debuff)
 			weight_tally += item_slowdown
 
 	item_slowdown = back?.slowdown


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

У https://github.com/TauCetiStation/TauCetiClassic/pull/4189/ было так себе обоснование, и автор сам был не уверен на тот момент в целесообразности. По тесту временем выяснилось, что СПУ всё же абузят этот иммунт и бегают в ригах по станции.

К тому же, за последние пару лет мы уже сильно порезали дефолтное замедление, нет смысла его бояться.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - tweak: Убран иммунитет у СПУ для замедления движения от одежды/ригов