### PR TITLE
Чиним исчезающие спрайты соусов

### DIFF
--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -37,6 +37,7 @@
 	icon = 'icons/obj/condiments.dmi'
 	icon_state = "condiment"
 	item_state = "condiment"
+	var/emptystate = "condiment"
 	flags = OPENCONTAINER
 	possible_transfer_amounts = list(1,5,10)
 	volume = 50
@@ -111,13 +112,13 @@
 		to_chat(user, "<span class='notice'> You transfer [trans] units of the condiment to [target].</span>")
 
 /obj/item/weapon/reagent_containers/food/condiment/on_reagent_change()
-	if(!reagents || (reagents && !reagents.reagent_list.len) && ("[initial(icon_state)]_empty" in icon_states(icon)))
-		icon_state = "[initial(icon_state)]_empty"
-		item_state = "[initial(icon_state)]_empty"
+	if((!reagents || (reagents && !reagents.reagent_list.len)) && (emptystate != 0))
+		icon_state = "[emptystate]_empty"
+		item_state = "[emptystate]_empty"
 		update_inv_mob()
 	else
-		icon_state = initial(icon_state)
-		item_state = initial(icon_state)
+		icon_state = "[initial(icon_state)]"
+		item_state = "[initial(item_state)]"
 		update_inv_mob()
 
 	if(reagents.reagent_list.len == 1) // So here we change the desc if condiment contains multiple reagents
@@ -276,6 +277,7 @@
 	desc = "A small bag filled with some flour."
 	icon_state = "flour"
 	item_state = "flour"
+	emptystate = "flour"
 	list_reagents = list("flour" = 30)
 
 /obj/item/weapon/reagent_containers/food/condiment/sugar
@@ -283,6 +285,7 @@
 	desc = "Tastey space sugar!"
 	icon_state = "sugar"
 	item_state = "sugar"
+	emptystate = "sugar"
 	list_reagents = list("sugar" = 40)
 
 /obj/item/weapon/reagent_containers/food/condiment/rice
@@ -290,6 +293,7 @@
 	desc = "Salt. From space oceans, presumably. Good for cooking!"
 	icon_state = "rice"
 	item_state = "rice"
+	emptystate = "rice"
 	list_reagents = list("rice" = 30)
 
 // SAUCES
@@ -298,30 +302,35 @@
 	name = "soy sauce"
 	desc = "A salty soy-based flavoring."
 	icon_state = "soysauce"
+	emptystate = 0
 	list_reagents = list("soysauce" = 40)
 
 /obj/item/weapon/reagent_containers/food/condiment/hotsauce
 	name = "hot sauce"
 	desc = "You can almost TASTE the stomach ulcers now!"
 	icon_state = "hotsauce"
+	emptystate = 0
 	list_reagents = list("capsaicin" = 30)
 
 /obj/item/weapon/reagent_containers/food/condiment/ketchup
 	name = "ketchup"
 	desc = "You feel more American already."
 	icon_state = "ketchup"
+	emptystate = "ketchup"
 	list_reagents = list("ketchup" = 50)
 
 /obj/item/weapon/reagent_containers/food/condiment/coldsauce
 	name = "cold sauce"
 	desc = "Leaves the tongue numb in its passage."
 	icon_state = "coldsauce"
+	emptystate = 0
 	list_reagents = list("frostoil" = 30)
 
 /obj/item/weapon/reagent_containers/food/condiment/cornoil
 	name = "corn oil"
 	desc = "A delicious oil used in cooking. Made from corn."
 	icon_state = "cornoil"
+	emptystate = 0
 	list_reagents = list("cornoil" = 40)
 
 // SUPPLEMENTS
@@ -331,12 +340,14 @@
 	desc = "Used in cooking various dishes."
 	icon_state = "enzyme"
 	item_state = "enzyme"
+	emptystate = "enzyme"
 	list_reagents = list("enzyme" = 50)
 
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker
 	name = "salt shaker"
 	desc = "Salt. From space oceans, presumably."
 	icon_state = "saltshakersmall"
+	emptystate = "saltshakersmall"
 	possible_transfer_amounts = list(1,20) // for the clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 20
@@ -346,6 +357,7 @@
 	name = "pepper mill"
 	desc = "Often used to flavor food or make people sneeze."
 	icon_state = "peppermillsmall"
+	emptystate = 0
 	possible_transfer_amounts = list(1,20) // for the clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 20
@@ -355,4 +367,5 @@
 	name = "honey pot"
 	desc = "Sweet and healthy!"
 	icon_state = "honey"
+	emptystate = 0
 	list_reagents = list("honey" = 40)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -111,7 +111,7 @@
 		to_chat(user, "<span class='notice'> You transfer [trans] units of the condiment to [target].</span>")
 
 /obj/item/weapon/reagent_containers/food/condiment/on_reagent_change()
-	if(!reagents || (reagents && !reagents.reagent_list.len))
+	if(!reagents || (reagents && !reagents.reagent_list.len) && ("[initial(icon_state)]_empty" in icon_states(icon)))
 		icon_state = "[initial(icon_state)]_empty"
 		item_state = "[initial(icon_state)]_empty"
 		update_inv_mob()

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -112,7 +112,7 @@
 		to_chat(user, "<span class='notice'> You transfer [trans] units of the condiment to [target].</span>")
 
 /obj/item/weapon/reagent_containers/food/condiment/on_reagent_change()
-	if((!reagents || (reagents && !reagents.reagent_list.len)) && (emptystate != 0))
+	if(emptystate && (!reagents || reagents.total_volume <= 0))
 		icon_state = "[emptystate]_empty"
 		item_state = "[emptystate]_empty"
 		update_inv_mob()
@@ -302,14 +302,14 @@
 	name = "soy sauce"
 	desc = "A salty soy-based flavoring."
 	icon_state = "soysauce"
-	emptystate = 0
+	emptystate = null
 	list_reagents = list("soysauce" = 40)
 
 /obj/item/weapon/reagent_containers/food/condiment/hotsauce
 	name = "hot sauce"
 	desc = "You can almost TASTE the stomach ulcers now!"
 	icon_state = "hotsauce"
-	emptystate = 0
+	emptystate = null
 	list_reagents = list("capsaicin" = 30)
 
 /obj/item/weapon/reagent_containers/food/condiment/ketchup
@@ -323,14 +323,13 @@
 	name = "cold sauce"
 	desc = "Leaves the tongue numb in its passage."
 	icon_state = "coldsauce"
-	emptystate = 0
+	emptystate = null
 	list_reagents = list("frostoil" = 30)
 
 /obj/item/weapon/reagent_containers/food/condiment/cornoil
 	name = "corn oil"
 	desc = "A delicious oil used in cooking. Made from corn."
 	icon_state = "cornoil"
-	emptystate = 0
 	list_reagents = list("cornoil" = 40)
 
 // SUPPLEMENTS
@@ -357,7 +356,7 @@
 	name = "pepper mill"
 	desc = "Often used to flavor food or make people sneeze."
 	icon_state = "peppermillsmall"
-	emptystate = 0
+	emptystate = null
 	possible_transfer_amounts = list(1,20) // for the clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 20
@@ -367,5 +366,5 @@
 	name = "honey pot"
 	desc = "Sweet and healthy!"
 	icon_state = "honey"
-	emptystate = 0
+	emptystate = null
 	list_reagents = list("honey" = 40)


### PR DESCRIPTION
## Описание изменений
Добавил проверку на наличие пустого спрайта, прежде чем менять стейт и иконку на пустую.

## Почему и что этот ПР улучшит
Кондименты без нарисованных пустых иконок перестанут терять спрайт

## Авторство
Ayaksblack
[Chip11-n](https://github.com/Chip11-n) консультировал

## Чеинжлог
:cl:
 - bugfix: Пофикшено исчезание бутылки перца, острого и холодного соуса и баклажки масла

-->
