### PR TITLE
[DNM] Проблемы рофлореверов, вариант с логгированием

### DIFF
--- a/code/game/gamemodes/factions/revolution.dm
+++ b/code/game/gamemodes/factions/revolution.dm
@@ -340,6 +340,8 @@
 	if(add_faction_member(src, user, TRUE))
 		reasons[user.mind.key] = reason_string
 		to_chat(user, "<span class='notice'>You join the revolution!</span>")
+		message_admins("[user] ([user.client.key]) has joined the revolution with the reason: [reason_string]")
+		log_admin("[user] ([user.client.key]) has joined the revolution with the reason: [reason_string]")
 		return TRUE
 	return FALSE
 

--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -394,6 +394,7 @@
 	if (admin_edit)
 		text += " - <a href='?src=\ref[M];role_edit=\ref[src];remove_role=1'>(remove)</a> - <a href='?src=\ref[M];greet_role=\ref[src]'>(greet)</a>[extraPanelButtons(M)]"
 
+	text += getExtraInfo()
 	if(objectives.objectives.len)
 		text += "<br><ul><b>Personal objectives:</b><br>"
 	else
@@ -497,4 +498,7 @@
 	return
 
 /datum/role/proc/remove_ui(datum/hud/hud)
+	return
+
+/datum/role/proc/getExtraInfo()
 	return

--- a/code/game/gamemodes/roles/revolution.dm
+++ b/code/game/gamemodes/roles/revolution.dm
@@ -23,6 +23,12 @@
 	SEND_SIGNAL(antag.current, COMSIG_CLEAR_MOOD_EVENT, "rev_convert")
 	..()
 
+/datum/role/rev/getExtraInfo()
+	if(!istype(faction, /datum/faction/revolution))
+		return
+	var/datum/faction/revolution/R = faction
+	return "<br>Reason for joining: " + R.reasons[antag.key]
+
 /datum/role/rev/Greet(greeting, custom)
 	. = ..()
 	to_chat(antag.current, "<span class='warning'><FONT size = 3>С этого момента вы - Революционер! Распространяйте всюду ваше освободительное движение. Не вредите своим товарищам в борьбе за свободу. Вы можете определить своих союзников по красному ярлыку \"R\", а также своих лидеров по синему ярлыку \"R\". Помогайте им в вербовке, захвате или убийстве глав станции для достижения победы Революции!</FONT></span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Сделано в связи с поднятым [тут](https://forum.taucetistation.org/t/vvedenie-pravila-o-nonrp-rizonah-vstupleniya-v-revu-i-otygrysha-revy/) вопросом.
Причины для вступления в реву теперь записываются в логи сервера. Администраторы получают соответствующее уведомление, а так же могут посмотреть ризон в тритор панели.
![пук](https://github.com/TauCetiStation/TauCetiClassic/assets/25509546/17d9ad93-eedb-4821-aedb-0f5dc40e6e6f)
![среньк](https://github.com/TauCetiStation/TauCetiClassic/assets/25509546/5151e605-5ba6-4c8e-b9ad-856c1182965d)
## Почему и что этот ПР улучшит
Администрации станет намного проще отслеживать реверов, которые вступили в реву по причине "а вот анекдот!"
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - tweak: причины присоединения к революции логируются и доступны из меню Traitor Panel
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
