### PR TITLE
Mutator: Hos

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -908,8 +908,8 @@
 	desc = "An advanced helmet designed for work in special operations. Created using older design of armored hardsuits."
 	icon_state = "rig0-heavy"
 	item_state = "syndie_helm"
-	combat_armor = list(melee = 75, bullet = 80, laser = 70,energy = 55, bomb = 50, bio = 100, rad = 30)
-	space_armor = list(melee = 60, bullet = 65, laser = 55, energy = 45, bomb = 50, bio = 100, rad = 60)
+	combat_armor = list(melee = 70, bullet = 70, laser = 65,energy = 50, bomb = 50, bio = 100, rad = 30)
+	space_armor = list(melee = 45, bullet = 30, laser = 30, energy = 45, bomb = 50, bio = 100, rad = 60)
 	rig_type = "heavy"
 
 /obj/item/clothing/suit/space/rig/syndi/heavy
@@ -920,7 +920,7 @@
 	rig_variant = "rig-heavy"
 	slowdown = 1.2
 	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair/adv, /obj/item/rig_module/chem_dispenser/combat, /obj/item/rig_module/emp_shield)
-	combat_armor = list(melee = 75, bullet = 80, laser = 70,energy = 55, bomb = 50, bio = 100, rad = 30)
+	combat_armor = list(melee = 70, bullet = 70, laser = 65,energy = 50, bomb = 50, bio = 100, rad = 30)
 	space_armor = list(melee = 45, bullet = 30, laser = 30, energy = 45, bomb = 50, bio = 100, rad = 60)
 	combat_slowdown = 0.5
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -832,7 +832,7 @@
 	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair/adv, /obj/item/rig_module/emp_shield)
 	cell_type = /obj/item/weapon/stock_parts/cell/super
 	var/combat_mode = FALSE
-	var/combat_armor = list(melee = 60, bullet = 65, laser = 55, energy = 45, bomb = 50, bio = 100, rad = 60)
+	var/combat_armor = list(melee = 55, bullet = 60, laser = 50, energy = 40, bomb = 50, bio = 100, rad = 60)
 	var/space_armor = list(melee = 30, bullet = 20, laser = 20, energy = 30, bomb = 50, bio = 100, rad = 60)
 	var/combat_slowdown = 0
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_hardsuit_magboots, /datum/action/item_action/hands_free/toggle_hardsuit_helm,

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -120,7 +120,7 @@
 	item_state = "hos"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	pierce_protection = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
-	armor = list(melee = 80, bullet = 60, laser = 55, energy = 35, bomb = 50, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 45, laser = 40, energy = 25, bomb = 35, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.6
 

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -35,5 +35,5 @@
 	body_parts_covered = HEAD
 	slot_flags = SLOT_FLAGS_HEAD | SLOT_FLAGS_TIE
 	slot = "dermal"
-	armor = list(melee = 80, bullet = 60, laser = 50,energy = 10, bomb = 25, bio = 10, rad = 0)
+	armor = list(melee = 50, bullet = 45, laser = 40, energy = 25, bomb = 35, bio = 0, rad = 0)
 	flashbang_protection = TRUE

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -24,6 +24,11 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/stun, /obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/ion/small)
 	origin_tech = "combat=4;magnets=3"
 
+/obj/item/weapon/gun/energy/gun/hos/atom_init()
+	. = ..()
+	power_supply.maxcharge = 1600
+	power_supply.charge = 1600
+
 /obj/item/weapon/gun/energy/gun/adv
 	name = "Energy Gun Mark II"
 	desc = "Новейшая модель энергетического оружия. Передовая конструкция отличается улучшенной системой охлаждения и внутренней батареей."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
[Пятый из линейки](https://forum.taucetistation.org/t/mutatory-nedelnye-aspekty/41925) недельных аспектов.
Вопрос аспекта:
- А что если бы ХоС был чуть слабее, но всё же офицерик на максималках?

Плащик всё также единственная универсальная броня офицеров, но уже не уровня штурмовой брони синдиката.
Вместо (melee = 80, bullet = 60, laser = 55, energy = 35, bomb = 50, bio = 0, rad = 0)
Стало (melee = 50, bullet = 45, laser = 40, energy = 25, bomb = 35, bio = 0, rad = 0)

Также ревенант ХоСа получил 6 дополнительных выстрелов, что бы хоть как-то скомпенсировать его потери.
## АХТУНГ! ВАРНИНГ! ПРЕДУПРЕЖДЕНИЕ!
Хэви риги также пострадали и получили уменьшение статов в среднем на 5-10%
(хэви риг с меньшей защитой защищает лучше брони с статами выше). 
Сильнее всего пострадал шлем в спейс моде, защищающий как в боевом режиме.
При чём тут они? ХоС едва ли не основной им противовес по броне.

Основное изменение - хэви риг:
combat_armor (melee = 75, bullet = 80, laser = 70,energy = 55, bomb = 50, bio = 100, rad = 30)
space_armor (melee = 60, bullet = 65, laser = 55, energy = 45, bomb = 50, bio = 100, rad = 60)

Может быть, посреди недели уменьшу предельное время для срабатывания ивента, если никто не будет против (условно мажор начнёт срабатывать в 40 минут, а не в 70)
## Почему и что этот ПР улучшит
Цитаты, аргументация прямо в темке, но описывают общую ситуацию с этим:
- То, что половина ГСБ бегает за антагонистами и не уделяет внимание управлению/работе с населением - очень, по моему мнению, грустно.
- так а смысл жаловаться, лол. уже даже в навыках закреплено то, что глава — это такой исполнитель на максималках
- Не, просто антаги всегда летят лутать ХоСа, не потому что он сильный, а потому что у него броня крутая.
## Авторство


## Чеинжлог
