### PR TITLE
Фикс отваливания кнопок общения при коннекте с русской раскладкой.

### DIFF
--- a/code/__HELPERS/wrappers.dm
+++ b/code/__HELPERS/wrappers.dm
@@ -2,3 +2,28 @@
 
 /proc/_step(ref, dir)
 	step(ref, dir)
+
+// used in hotkeys so that we can call proc instead of winset(src, null, "command=say")
+/mob/proc/say_wrapper()
+	set_typing_indicator(TRUE)
+	var/message = input("","say (text)") as text|null
+	if(message)
+		say_verb(message)
+	set_typing_indicator(FALSE)
+
+/mob/proc/me_wrapper()
+	set_typing_indicator(TRUE)
+	var/message = input("","me (text)") as text|null
+	if(message)
+		me_verb(message)
+	set_typing_indicator(FALSE)
+
+/client/proc/ooc_wrapper()
+	var/message = input("","ooc (text)") as text|null
+	if(message)
+		ooc(message)
+
+/client/proc/looc_wrapper()
+	var/message = input("","looc (text)") as text|null
+	if(message)
+		looc(message)

--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -6,10 +6,18 @@
 	name = "Say"
 	full_name = "IC Say"
 
+/datum/keybinding/client/communication/say/down(client/user)
+	user.mob.say_wrapper()
+	return TRUE
+
 /datum/keybinding/client/communication/ooc
 	hotkey_keys = list("F2", "O")
 	name = "OOC"
 	full_name = "Out Of Character Say (OOC)"
+
+/datum/keybinding/client/communication/ooc/down(client/user)
+	user.ooc_wrapper()
+	return TRUE
 
 /datum/keybinding/client/communication/looc
 	hotkey_keys = list("L")
@@ -17,10 +25,14 @@
 	full_name = "Local Out Of Character Say (LOOC)"
 
 /datum/keybinding/client/communication/looc/down(client/user)
-	user.looc()
+	user.looc_wrapper()
 	return TRUE
 
 /datum/keybinding/client/communication/me
 	hotkey_keys = list("F4", "M")
 	name = "Me"
 	full_name = "Custom Emote (/Me)"
+
+/datum/keybinding/client/communication/me/down(client/user)
+	user.mob.me_wrapper()
+	return TRUE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -770,7 +770,6 @@ var/global/list/blacklisted_builds = list(
 	if(!D?.key_bindings)
 		return
 	movement_keys = list()
-	var/list/testing_hotkeys = list()
 	for(var/key in D.key_bindings)
 		for(var/kb_name in D.key_bindings[key])
 			switch(kb_name)
@@ -782,15 +781,6 @@ var/global/list/blacklisted_builds = list(
 					movement_keys[key] = WEST
 				if("South")
 					movement_keys[key] = SOUTH
-				/*if("Say")
-					winset(src, "default-[key]", "parent=default;name=[key];command=.say")
-					testing_hotkeys += key*/
-
-	// winget() does not work for F1 and F2
-	for(var/key in testing_hotkeys)
-		if(!(key in list("F1","F2")) && !winget(src, "default-[key]", "command"))
-			to_chat(src, "Вероятно Вы вошли в игру с русской раскладкой клавиатуры и у вас поломался [key] хоткей.\nПожалуйста, потыкайте кодеров чем-нибудь на предмет использования winset() для макросов на кнопках.")
-			break
 
 #define MAXIMAZED  (1<<0)
 #define FULLSCREEN (1<<1)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -789,7 +789,7 @@ var/global/list/blacklisted_builds = list(
 	// winget() does not work for F1 and F2
 	for(var/key in testing_hotkeys)
 		if(!(key in list("F1","F2")) && !winget(src, "default-[key]", "command"))
-			to_chat(src, "Вероятно Вы вошли в игру с русской раскладкой клавиатуры и у вас поломался [key] хоткий.\nПожалуйста, потыкайте кодеров чем-нибудь на предмет использования winset() для макросов на кнопках.")
+			to_chat(src, "Вероятно Вы вошли в игру с русской раскладкой клавиатуры и у вас поломался [key] хоткей.\nПожалуйста, потыкайте кодеров чем-нибудь на предмет использования winset() для макросов на кнопках.")
 			break
 
 #define MAXIMAZED  (1<<0)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -770,7 +770,7 @@ var/global/list/blacklisted_builds = list(
 	if(!D?.key_bindings)
 		return
 	movement_keys = list()
-	var/list/communication_hotkeys = list()
+	var/list/testing_hotkeys = list()
 	for(var/key in D.key_bindings)
 		for(var/kb_name in D.key_bindings[key])
 			switch(kb_name)
@@ -782,23 +782,14 @@ var/global/list/blacklisted_builds = list(
 					movement_keys[key] = WEST
 				if("South")
 					movement_keys[key] = SOUTH
-				if("Say")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=.say") // ".say" is wrapper over say, see in code\modules\mob\typing_indicator.dm
-					communication_hotkeys += key
-				if("OOC")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=ooc")
-					communication_hotkeys += key
-				if("Me")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=.me")
-					communication_hotkeys += key
-				if("LOOC")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=looc")
-					communication_hotkeys += key
+				/*if("Say")
+					winset(src, "default-[key]", "parent=default;name=[key];command=.say")
+					testing_hotkeys += key*/
 
 	// winget() does not work for F1 and F2
-	for(var/key in communication_hotkeys)
-		if(!(key in list("F1","F2")) && !winget(src, "default-\ref[key]", "command"))
-			to_chat(src, "Вероятно Вы вошли в игру с русской раскладкой клавиатуры.\n<a href='?src=\ref[src];reset_macros=1'>Пожалуйста, переключитесь на английскую раскладку и кликните сюда, чтобы исправить хоткеи коммуникаций.</a>")
+	for(var/key in testing_hotkeys)
+		if(!(key in list("F1","F2")) && !winget(src, "default-[key]", "command"))
+			to_chat(src, "Вероятно Вы вошли в игру с русской раскладкой клавиатуры и у вас поломался [key] хоткий.\nПожалуйста, потыкайте кодеров чем-нибудь на предмет использования winset() для макросов на кнопках.")
 			break
 
 #define MAXIMAZED  (1<<0)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -12,23 +12,3 @@
 	else
 		vis_contents -= typing_indicator
 		typing = FALSE
-
-/mob/verb/say_wrapper()
-	set name = ".Say"
-	set hidden = TRUE
-
-	set_typing_indicator(TRUE)
-	var/message = input("","say (text)") as text|null
-	if(message)
-		say_verb(message)
-	set_typing_indicator(FALSE)
-
-/mob/verb/emote_wrapper()
-	set name = ".Me"
-	set hidden = TRUE
-
-	set_typing_indicator(TRUE)
-	var/message = input("","me (text)") as text|null
-	if(message)
-		me_verb(message)
-	set_typing_indicator(FALSE)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Вероятно closes #12754 
closes #8319 
closes #9871 
Потыкайте в тесте, оно ли?

Вся эта тема хорошо поломала мне мозг, но если коротко (на форуме бъенда это уже обсуждалось) то система макросов через winset на рантайме по какой-то причине не может добавить макрос в скин на кнопках букв когда у пользователя включена кириллица.

Однако, у вас фактически вся система хоткиейв работает без использования winset для исполнения комманд по кнопкам но по какой-то причине забыли внести код для кнопок комуникации для которых были 4 строки (?костылем?).

В коде можно было обойтись без переноса и ренейма проков с созданием дополнительных врапперов под оок и лоок прописав в датумы кийбиндов winset с вызовом команды, но я подумал пусть и эти последние 4 команды для хоткией станут проками.

Я там оторвал линку по которой кликаешь чтобы сделать резет макросов, если проблема была только с этими 4мя кнопками, то может она и не нужна, но само сообщение оставил. Если что по коду еще убрать/вернуть - напишите.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
