### PR TITLE
QoL для любителей крутиться на стульях

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -142,6 +142,11 @@
 	handle_rotation()
 	return
 
+/obj/structure/stool/bed/chair/AltClick(mob/user)
+	if(!Adjacent(user))
+		return ..()
+	rotate()
+
 /obj/structure/stool/bed/chair/post_buckle_mob(mob/living/M)
 	. = ..()
 	if(buckled_mob && behind)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -129,6 +129,8 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(!Adjacent(usr))
+		return
 	if(!config.ghost_interaction && isobserver(usr))
 		return
 	if(ismouse(usr))
@@ -143,8 +145,6 @@
 	return
 
 /obj/structure/stool/bed/chair/AltClick(mob/user)
-	if(!Adjacent(user))
-		return ..()
 	rotate()
 
 /obj/structure/stool/bed/chair/post_buckle_mob(mob/living/M)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -751,7 +751,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 		if(buckled.buckle_lying != -1)
 			lying = buckled.buckle_lying
 		canmove = canmove && buckled.buckle_movable
-		anchored = anchored || buckled.buckle_movable
+		anchored = anchored || !buckled.buckle_movable
 
 		if(istype(buckled, /obj/vehicle))
 			var/obj/vehicle/V = buckled

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -116,29 +116,29 @@
 				buckled_to.propelled = 4
 			step(buckled_to, movementdirection)
 			sleep(1)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 			if(buckled_to)
 				buckled_to.propelled = 3
 			sleep(1)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 			sleep(1)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 			if(buckled_to)
 				buckled_to.propelled = 2
 			sleep(2)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 			if(buckled_to)
 				buckled_to.propelled = 1
 			sleep(2)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 			if(buckled_to)
 				buckled_to.propelled = 0
 			sleep(3)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 			sleep(3)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 			sleep(3)
-			step(buckled_to, buckled_to.dir)
+			step(buckled_to, movementdirection)
 	else if (loc && istype(loc, /obj/item/mecha_parts/mecha_equipment/extinguisher))
 		var/obj/item/mecha_parts/mecha_equipment/extinguisher/ext = loc
 		if (ext.chassis)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -116,29 +116,29 @@
 				buckled_to.propelled = 4
 			step(buckled_to, movementdirection)
 			sleep(1)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 			if(buckled_to)
 				buckled_to.propelled = 3
 			sleep(1)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 			sleep(1)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 			if(buckled_to)
 				buckled_to.propelled = 2
 			sleep(2)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 			if(buckled_to)
 				buckled_to.propelled = 1
 			sleep(2)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 			if(buckled_to)
 				buckled_to.propelled = 0
 			sleep(3)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 			sleep(3)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 			sleep(3)
-			step(buckled_to, movementdirection)
+			step(buckled_to, buckled_to.dir)
 	else if (loc && istype(loc, /obj/item/mecha_parts/mecha_equipment/extinguisher))
 		var/obj/item/mecha_parts/mecha_equipment/extinguisher/ext = loc
 		if (ext.chassis)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Alt+клик поворачивает стулья. Зажатый Ctrl теперь снова позволяет поворачиваться кнопками движения вместе с офисным стулом.
## Почему и что этот ПР улучшит
QoL
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: невозможно было повернуться на офисном стуле с помощью кнопок движения при зажатом Ctrl
 - tweak: стулья можно поворачивать с помощью Alt+ЛКМ
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
