### PR TITLE
фикс вечного граба

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -255,7 +255,6 @@
 				qdel(src)
 				return PROCESS_KILL
 			BP.add_autopsy_data("Strangled", 0, BRUISE) //if 0, then unknow
-		affecting.Stun(1)
 		if(isliving(affecting))
 			var/mob/living/L = affecting
 			if(assailant.get_targetzone() == O_MOUTH)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
убирает вечный +1 стан в третьем грабе
## Почему и что этот ПР улучшит
до некоего реворка станов этот +1 граб не работал и всем было весело - 20-30 секунд стана от изначального граба позволяли сделать с жертвой всё, что угодно, а если злодей завтыкал - то можно было сбежать, оттолкнув его от себя или с некоторым шансом зарезистив 
после реворка станов ты просто вечно сидел в стане и эээ ниче делать не мог даа мм не весело
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- tweak: Убран вечный стан в 3 грабе.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
