### PR TITLE
Логгирование для эссенций генокрада

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/essences.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/essences.dm
@@ -126,6 +126,7 @@
 		host.say(message, TRUE)
 		H.special_voice = saved_special_voice
 		return
+	log_say("Essence [name]/[key] via changeling body: [message]")
 	host.say(message)
 
 /mob/living/parasite/essence/whisper(message as text)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/essences.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/essences.dm
@@ -147,6 +147,7 @@
 		H.special_voice = saved_special_voice
 		return
 
+	log_whisper("Essence [name]/[key] via changeling body: [message]")
 	return host.whisper(message)
 
 /mob/living/parasite/essence/me_emote(message, message_type = SHOWMSG_VISUAL, intentional=FALSE)
@@ -161,6 +162,7 @@
 		to_chat(src, "<span class='userdanger'>Your host forbade you emoting!</span>")
 		return
 
+	log_emote("Essence [name]/[key] with changeling body: [message]")
 	return host.me_emote(message, message_type, intentional)
 
 /mob/living/parasite/essence/say_understands(mob/other, datum/language/speaking)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Речь, шёпот и эмоуты эссенций через тело генокрада теперь дополнительно логируются с указанием имени и сикея эссенции.
## Почему и что этот ПР улучшит
fix #12586
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: информация о говорящих от лица генокрада эссенциях не логировалась
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
