### PR TITLE
RCD floor build fix

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -214,9 +214,7 @@ RCD
 	return TRUE
 
 /obj/item/weapon/rcd/tool_start_check(mob/user, amount)
-	. = ..()
-	if(.)
-		return matter >= amount
+	return matter >= amount
 
 /obj/item/weapon/rcd/borg/use(amount, mob/user)
 	if(!isrobot(user))
@@ -224,11 +222,9 @@ RCD
 	return user:cell:use(amount * 30)
 
 /obj/item/weapon/rcd/borg/tool_start_check(mob/user, amount)
-	. = ..()
-	if(.)
-		if(!isrobot(user))
-			return FALSE
-		return user:cell:charge >= (amount * 30)
+	if(!isrobot(user))
+		return FALSE
+	return user:cell:charge >= (amount * 30)
 
 /obj/item/weapon/rcd/borg/atom_init()
 	. = ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
`/obj/item/weapon/rcd/borg/tool_start_check` вызывал прок родителя. Тот смотрел на `matter`, которого у борговского rcd нет (оно от энергии работает) -> проверка не проходилась.

это не мешало боргам строить стены/шлюзы, т.к там  `delay > 0`, а в случае с полом `delay = 0`, и вот эта проверка не проходилась https://github.com/TauCetiStation/TauCetiClassic/blob/master/code/game/objects/items.dm#L724

ещё, поднявшись в проке `/obj/item/weapon/rcd/tool_start_check` на несколько уровней вверх, я не нашёл каких-либо проверок (его родитель всегда TRUE будет возвращать, если я не пропустил ничего)
## Почему и что этот ПР улучшит
fixes #12776 
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Kandrey
- bugfix: RCD боргов снова могут строить plating в космосе
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
