### PR TITLE
Update chemsmoke.dm lighting

### DIFF
--- a/code/game/objects/effects/chemsmoke.dm
+++ b/code/game/objects/effects/chemsmoke.dm
@@ -197,9 +197,9 @@
 	smoke.pixel_x = -32 + rand(-8,8)
 	smoke.pixel_y = -32 + rand(-8,8)
 	walk_to(smoke, T)
-	smoke.opacity = 1		//switching opacity on after the smoke has spawned, and then
+	smoke.set_opacity(1)	//switching opacity on after the smoke has spawned, and then
 	sleep(150+rand(0,20))	// turning it off before it is deleted results in cleaner
-	smoke.opacity = 0		// lighting and view range updates
+	smoke.set_opacity(0)	// lighting and view range updates
 	fadeOut(smoke)
 	qdel(smoke)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Обновил старые процедуры световых эффектов химических дымов в соответствии с https://github.com/TauCetiStation/TauCetiClassic/pull/11943
## Почему и что этот ПР улучшит
Фикс тёмных непрозрачных пятен после хим дыма
![smokeshadow](https://github.com/TauCetiStation/TauCetiClassic/assets/100795636/df53fad1-7326-40b4-9c01-286fda5dc345)

## Авторство
me
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Фикс тёмных пятен после дыма
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
