### PR TITLE
запрещает емагать створки

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -118,6 +118,9 @@
 			flick("pdoorc1", src)
 	return
 
+/obj/machinery/door/poddoor/emag_act(mob/user)
+	return FALSE
+
 /obj/machinery/door/poddoor/mafia
 	name = "Station Night Shutters"
 	desc = "When it's time to sleep, the lights will go out. Remember - no one in space can hear you scream."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
раньше нельзя этого было делать, после апдейта емага (вроде бы?) это сломалось и теперь можно каким-то образом емагать монолитные железные мегадвери
чуть занерфит нюку, убрав возможность легчайшего проникновения в оружейку, частично уберет абуз обрами створок на ЦК
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- rscdel: Больше нельзя емагать створки.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
