### PR TITLE
Научные борги научились подбирать блюспейс кристаллы

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -167,6 +167,7 @@
 	icon_state = "gripper"
 
 	can_hold = list(
+		/obj/item/bluespace_crystal,
 		/obj/item/weapon/tank,
 		/obj/item/device/assembly/signaler,
 		/obj/item/device/gps,


### PR DESCRIPTION
## Описание изменений
Файл увеличился на 1-у строку
## Почему и что этот ПР улучшит
close #10234
<del>Теперь можно играть в работку не отрываясь на замену батареи РИГа, еду и прочее</del>
## Авторство

## Чеинжлог
:cl:
 - add: Гриппер научного борга теперь может брать блюспейс кристаллы.