### PR TITLE
Conveyors

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -83,6 +83,8 @@ var/global/list/datum/autolathe_recipe/autolathe_recipes = list(
 	R(/obj/item/weapon/firealarm_electronics,        CATEGORY_ENGINEERING),
 	R(/obj/item/weapon/rcd_ammo,                     CATEGORY_ENGINEERING),
 	R(/obj/item/weapon/camera_assembly,              CATEGORY_ENGINEERING),
+	R(/obj/item/conveyor_construct,                  CATEGORY_ENGINEERING),
+	R(/obj/item/conveyor_switch_construct,           CATEGORY_ENGINEERING),
 	R(/obj/item/weapon/table_parts/stall,            CATEGORY_ENGINEERING),
 	R(/obj/item/weapon/stock_parts/console_screen,  CATEGORY_ENGINEERING),
 	R(/obj/item/weapon/stock_parts/matter_bin,      CATEGORY_ENGINEERING),

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -306,6 +306,8 @@
 	name = "conveyor belt assembly"
 	desc = "A conveyor belt assembly."
 	w_class = SIZE_NORMAL
+	m_amt = 1200
+	g_amt = 300
 	var/id = "" //inherited by the belt
 
 /obj/item/conveyor_construct/attackby(obj/item/I, mob/user, params)
@@ -335,6 +337,8 @@
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
 	w_class = SIZE_NORMAL
+	m_amt = 700
+	g_amt = 500
 	var/id = "" //inherited by the switch
 
 /obj/item/conveyor_switch_construct/atom_init()


### PR DESCRIPTION

## Описание изменений
В автолатах появилась возможность печатать конвейеры и рычаги к ним.
## Почему и что этот ПР улучшит
Конвейеры прямо сейчас можно получить только через карго или только украв откуда-то. 
Первый вариант очень сложен, иногда долгий, иногда недоступен (нет никого в карго, нет денег у тебя или в карго), а иногда могут и отказать (мол за свои деньги покупай, а ты бедный ассистент), а второй ограничен в количестве нужного. В итоге, что бы построить прикол, тебе нужно изгаляться с 6 конвейерами находящимися в свободном доступе или устраивать войнушку за них у мусорщиков.

В дополнение, это как-то глупо, что конвейеры можно только заказать. Они и так используются примерно никогда, а тут ещё и усложнения в их получении. В карго на моей памяти конвейеры заказывали лишь в двух раундах и оба для приколов-абузов через шаттл для самого же карго.
## Авторство

## Чеинжлог
:cl:
 - tweak: В автолатах можно печатать конвейеры