### PR TITLE
анрестриктед сайдс фор медбей аирлокс

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -32115,7 +32115,8 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerIn";
 	name = "Medbay";
-	req_access = list(5)
+	req_access = list(5);
+	unres_sides = 2
 	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
@@ -48319,18 +48320,6 @@
 	icon_state = "white"
 	},
 /area/station/civilian/dormitories)
-"bHX" = (
-/obj/machinery/door_control{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyerIn";
-	name = "Medbay Doors Control";
-	pixel_y = 28
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitebluecorner"
-	},
-/area/station/medical/hallway)
 "bHY" = (
 /turf/simulated/wall,
 /area/station/medical/medbreak)
@@ -81597,12 +81586,6 @@
 	c_tag = "Medbay North";
 	network = list("SS13","Medical")
 	},
-/obj/machinery/door_control{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyerOut";
-	name = "Medbay Doors Control";
-	pixel_y = 28
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitebluecorner"
@@ -82440,12 +82423,13 @@
 /turf/simulated/floor,
 /area/station/cargo/office)
 "qZb" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyerOut";
-	name = "Medbay";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyerIn";
+	name = "Medbay";
+	req_access = list(5);
+	unres_sides = 2
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -125148,7 +125132,7 @@ gMb
 dxb
 kcb
 bjk
-bHX
+bTK
 ldb
 bjl
 byr

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -74837,12 +74837,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/medical_intern,
-/obj/machinery/door_control{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyerIn";
-	name = "Medbay Doors Control";
-	pixel_y = 28
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whiteblue"
@@ -75615,12 +75609,13 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerIn";
 	name = "Medbay";
-	req_one_access = list(2,5)
+	req_access = list(5);
+	unres_sides = 2
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -103746,7 +103741,8 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerIn";
 	name = "Medbay";
-	req_one_access = list(2,5)
+	req_access = list(5);
+	unres_sides = 2
 	},
 /turf/simulated/floor{
 	icon_state = "bluechoco"
@@ -112894,12 +112890,6 @@
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "ycu" = (
-/obj/machinery/door_control{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyerIn";
-	name = "Medbay Doors Control";
-	pixel_y = 28
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -11316,23 +11316,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"bEB" = (
-/obj/machinery/door_control{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	pixel_x = -28;
-	pixel_y = 28;
-	range = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whiteblue"
-	},
-/area/station/medical/sleeper)
 "bED" = (
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 8
@@ -31602,14 +31585,15 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/dormitories/dormone)
 "fGo" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyerIn";
+	name = "Medbay";
+	req_access = list(5);
+	unres_sides = 2
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -54871,14 +54855,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "klE" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 2
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyerIn";
+	name = "Medbay";
+	req_access = list(5);
+	unres_sides = 2
 	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
@@ -55077,28 +55062,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"knA" = (
-/obj/machinery/door_control{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	pixel_x = 28;
-	pixel_y = 28;
-	range = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whiteblue"
-	},
-/area/station/medical/sleeper)
 "knH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -111888,11 +111851,6 @@
 	},
 /area/station/medical/virology)
 "vJK" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
@@ -111901,6 +111859,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyerIn";
+	name = "Medbay";
+	req_access = list(5);
+	unres_sides = 2
 	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
@@ -158659,7 +158623,7 @@ mSG
 gzu
 vec
 klE
-bEB
+sgh
 sgh
 ivX
 mAI
@@ -159173,7 +159137,7 @@ jzn
 gMv
 gMv
 vJK
-knA
+seX
 seX
 ljS
 ldW

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -795,13 +795,14 @@
 	},
 /area/station/medical/hallway)
 "abh" = (
-/obj/machinery/door/airlock/medical/glass{
-	dir = 4;
-	id_tag = "Medbay";
-	name = "Medbay";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyerIn";
+	name = "Medbay";
+	req_access = list(5);
+	unres_sides = 2;
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -18857,12 +18858,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "ecF" = (
-/obj/machinery/door/airlock/medical/glass{
-	dir = 4;
-	id_tag = "Medbay";
-	name = "Medbay";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
@@ -18871,6 +18866,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4;
+	id_tag = "Medbay";
+	name = "Medbay";
+	req_access = list(5)
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -39916,17 +39917,17 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical/glass{
-	dir = 4;
-	id_tag = "Medbay";
-	name = "Medbay";
-	req_access = list(5)
-	},
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4;
+	id_tag = "Medbay";
+	name = "Medbay";
+	req_access = list(5)
 	},
 /turf/simulated/floor{
 	icon_state = "dark"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
добавляет анрестриктед сайд (общий доступ с одной стороны) для шлюзов у выхода/входа из медбея на всех картах
убирает за ненадобностью кнопки для открытия этих же дверей
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/3509f3ff-8f73-4d30-9c6f-420c3e905c9f)

## Почему и что этот ПР улучшит
удобство
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
🆑 Simbaka
- map: Шлюзы в холле медбея имеют односторонний общий доступ.