### PR TITLE
ребаланс боевых инъекторов и адреналин импланта

### DIFF
--- a/code/game/objects/items/weapons/autoinjectors.dm
+++ b/code/game/objects/items/weapons/autoinjectors.dm
@@ -5,7 +5,7 @@
 	icon_state = "stimpen"
 	item_state = "autoinjector_empty"
 	volume = 15
-	list_reagents = list("doctorsdelight" = 5, "stimulants" = 1, "bicaridine" = 2.5, "oxycodone" = 2.5, "kelotane" = 5)
+	list_reagents = list("stimulants" = 10, "oxycodone" = 5)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/bicaridine
 	name = "bicaridine autoinjector"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -322,10 +322,8 @@ Implant Specifics:<BR>"}
 	S.imp_in.SetParalysis(0)
 	S.imp_in.SetStunned(0)
 	S.imp_in.SetWeakened(0)
-	S.imp_in.reagents.add_reagent("tricordrazine", 20)
-	S.imp_in.reagents.add_reagent("doctorsdelight", 25)
 	S.imp_in.reagents.add_reagent("oxycodone", 5)
-	S.imp_in.reagents.add_reagent("stimulants", 4)
+	S.imp_in.reagents.add_reagent("stimulants", 10)
 	if (!S.uses)
 		qdel(S)
 

--- a/code/game/objects/items/weapons/medical.dm
+++ b/code/game/objects/items/weapons/medical.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "combat_hypo"
 	volume = 60
-	list_reagents = list("stimulants" = 30, "oxycodone" = 15, "doctorsdelight" = 15)
+	list_reagents = list("stimulants" = 30, "tricordrazine" = 20, "oxycodone" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/combat/atom_init()
 	. = ..()

--- a/code/game/objects/items/weapons/medical.dm
+++ b/code/game/objects/items/weapons/medical.dm
@@ -5,7 +5,8 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "combat_hypo"
 	volume = 60
-	list_reagents = list("stimulants" = 5, "bicaridine" = 15, "oxycodone" = 15, "kelotane" = 15, "doctorsdelight" = 10)
+	list_reagents = list("stimulants" = 30, "oxycodone" = 15, "doctorsdelight" = 15)
+
 /obj/item/weapon/reagent_containers/hypospray/combat/atom_init()
 	. = ..()
 	if (!possible_transfer_amounts)
@@ -184,7 +185,7 @@
 	icon_state = "pain_hypo"
 	volume = 100
 	list_reagents = list("tramadol" = 25, "paracetamol" = 25, "oxycodone" = 25, "inaprovaline" = 25)
-	
+
 /obj/item/weapon/reagent_containers/hypospray/combat/bone
 	name = "Bone-repair hypospray"
 	desc = "A modified air-needle autoinjector, used by operatives trained in medical practices to quickly heal injuries in the field. This one is filled with reagents which will mend the bones."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
было увеличено количество стимуляторов в одноразовом боевом автоинъекторе и адреналиновом импланте
но теперь они не вводят лекарства для лечения урона, вообще
то же самое и в боевом гипоспрее, но там был оставлен трикордразин для лечения союзников (ведь, судя по описанию, этот гипоспрей как раз для этого и нужен)
## Почему и что этот ПР улучшит
логику и баланс, наверное
адреналин имплант больше не будет универсальным мощным иньектором который и лечит персонажа, и поднимает его с земли
а боевые гипоспреи и автоиньекторы станут полезнее, ведь концентрация полезных веществ в них только увеличилась (сейчас они вводят 100500 разных реагентов которые сами по себе почти ничего не делают)
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
🆑 Simbaka
- balance: Было увеличено количество стимуляторов в боевом автоиньекторе и адреналиновом импланте, но в них больше нет лечебных препаратов.
- balance: Было увеличено количество стимуляторов в боевом гипоспрее, но стало меньше лекарств.