### PR TITLE
Cardboard cutouts are now tactical

### DIFF
--- a/code/game/objects/items/devices/cardboard.dm
+++ b/code/game/objects/items/devices/cardboard.dm
@@ -10,6 +10,15 @@
 	var/painting = FALSE
 	var/static/list/coloring
 
+/obj/item/cardboard_cutout/atom_init()
+	. = ..()
+	AddComponent(/datum/component/tactical, null, TRUE)
+	var/datum/twohanded_component_builder/TCB = new
+	TCB.require_twohands = TRUE
+	TCB.force_wielded = 5
+	TCB.force_unwielded = 2
+	AddComponent(/datum/component/twohanded, TCB)
+
 /obj/item/cardboard_cutout/attack_hand(mob/living/user)
 	if(user.a_intent == INTENT_HELP || pushed_over)
 		return ..()
@@ -91,7 +100,7 @@
 		return
 	if(!user.Adjacent(src))
 		return
-	if(!do_after(user, 10, FALSE, src, FALSE))
+	if(!do_after(user, 10, FALSE, src))
 		return
 	user.visible_message("<span class='notice'>[user] gives [src] a new look.</span>", "<span class='notice'>Voila! You give [src] a new look.</span>")
 	alpha = 255


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Basically, this means players holding cardboard cutouts will now assume their appearance, just like for potted plants. Good for pranking.

Супер ржака
## Почему и что этот ПР улучшит
![68747470733a2f2f6d65646961312e74656e6f722e636f6d2f6d2f583147696d586d7542795941414141642f746f6d2d6372756973652d646f6f7262656c6c2e676966](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/78a94179-aa24-4eee-8f94-765fc0080de3)
## Авторство
https://github.com/tgstation/tgstation/pull/81245
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Ghommie
- image: Картонные фигуры трейторов теперь имеют отображение в руках
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
