### PR TITLE
Camera integrity decrease (больше разрушений камер)

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -7,7 +7,9 @@
 	idle_power_usage = 5
 	active_power_usage = 10
 	layer = 5
-
+	max_integrity = 25
+	damage_deflection = 5
+	integrity_failure = 0.2
 	var/list/network = list("SS13")
 	var/c_tag = null
 	var/c_tag_order = 999

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -459,6 +459,5 @@
 	return cam
 
 /obj/machinery/camera/atom_religify(datum/religion/R)
-	if(!status)
-		return
 	deconstruct(FALSE)
+	return TRUE

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -457,3 +457,8 @@
 	cam["z"] = z
 	cam["isonstation"] = is_station_level(z)
 	return cam
+
+/obj/machinery/camera/atom_religify(datum/religion/R)
+	if(!status)
+		return
+	deconstruct(FALSE)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
это атомарная часть https://github.com/TauCetiStation/TauCetiClassic/pull/9853
там уже всё было сделано кроме этого (и дыма, идея реализации которого уже не вспоминается так легко)

Прочность камер снижена до 25, порог дефлекта урона по камере снижен до 5, выключение камеры наступает с 5 интегрити.
Захват зоны Культа разрушает камеры.
## Почему и что этот ПР улучшит
`
Цель ПРа это дать возможность ролям бесплатно локально ломать камеры, чтобы защититься от слежки ИИ и СБ, так как это очень большой фактор в планировании и совершении любых антажных действий (от телепорта до включения способности). Труднее ролькохантить - меньше скатывания в: увидел, чекнул мету на режим, пришёл, пострелял/наэлектризовал шлюзы, победил.
`
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- tweak: Камеры стали разрушаться от прямого выстрела из боевого оружия.
- tweak: Порог защиты от урона предметов для камер был понижен в три раза.
- add: Камеры будут ломаться в процессе захвата отсека Культом 
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
