### PR TITLE
Теперь клоуны раундстартом не замедлены

### DIFF
--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -118,6 +118,13 @@
 
 	back = /obj/item/weapon/storage/backpack/clown
 
+/datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(!visualsOnly)
+		ADD_TRAIT(H, TRAIT_CLUMSY, GENETIC_MUTATION_TRAIT)
+	H.real_name = pick(clown_names)
+	H.rename_self("clown")
+
+
 // MIME OUTFIT
 /datum/outfit/job/mime
 	name = OUTFIT_JOB_NAME("Mime")

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -121,9 +121,6 @@
 /datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!visualsOnly)
 		ADD_TRAIT(H, TRAIT_CLUMSY, GENETIC_MUTATION_TRAIT)
-	H.real_name = pick(clown_names)
-	H.rename_self("clown")
-
 
 // MIME OUTFIT
 /datum/outfit/job/mime

--- a/code/datums/outfits/misc/responders.dm
+++ b/code/datums/outfits/misc/responders.dm
@@ -570,8 +570,10 @@
 	/obj/item/weapon/reagent_containers/food/snacks/grown/bluespacetomato
 	)
 
-/datum/outfit/responders/clown/post_equip(mob/living/carbon/human/H)
+/datum/outfit/responders/clown/pre_equip(mob/living/carbon/human/H)
 	ADD_TRAIT(H, TRAIT_CLUMSY, GENETIC_MUTATION_TRAIT)
+
+/datum/outfit/responders/clown/post_equip(mob/living/carbon/human/H)
 	H.real_name = "[pick(clown_names)], Clown That Emags Things"
 	H.name = H.real_name
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -256,8 +256,8 @@
 	flags = JOB_FLAG_CIVIL
 
 /datum/outfit/job/clown/post_equip(mob/living/carbon/human/H)
-		H.real_name = pick(clown_names)
-		H.rename_self("clown")
+	H.real_name = pick(clown_names)
+	H.rename_self("clown")
 
 /datum/job/mime
 	title = "Mime"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -255,12 +255,6 @@
 	restricted_species = list(SKRELL)
 	flags = JOB_FLAG_CIVIL
 
-/datum/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(!visualsOnly)
-		ADD_TRAIT(H, TRAIT_CLUMSY, GENETIC_MUTATION_TRAIT)
-	H.real_name = pick(clown_names)
-	H.rename_self("clown")
-
 /datum/job/mime
 	title = "Mime"
 	flag = MIME

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -255,6 +255,10 @@
 	restricted_species = list(SKRELL)
 	flags = JOB_FLAG_CIVIL
 
+/datum/outfit/job/clown/post_equip(mob/living/carbon/human/H)
+		H.real_name = pick(clown_names)
+		H.rename_self("clown")
+
 /datum/job/mime
 	title = "Mime"
 	flag = MIME

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -74,7 +74,7 @@
 	return ..()
 
 /obj/item/clothing/shoes/clown_shoes/proc/start_waddling(mob/user)
-	if(user.IsClumsy())
+	if(user.IsClumsy() || user.job == "Clown")
 		slowdown = SHOES_SLOWDOWN
 	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_PIXELMOVE))
 


### PR DESCRIPTION
## Описание изменений
У клоуна есть замечательная способность из https://github.com/TauCetiStation/TauCetiClassic/pull/5259 но она не работала при спавне, клоун мог быстро бегать в своей обуви лишь после того как он её переобувал. Фиксит это, теперь клоун раундстартом быстрый как и положено
## Почему и что этот ПР улучшит
closes https://github.com/TauCetiStation/TauCetiClassic/issues/6978
closes https://github.com/TauCetiStation/TauCetiClassic/issues/10366
## Авторство

## Чеинжлог
:cl:
 - bugfix: Теперь клоунам не нужно переобуваться чтоб быстро бегать в своих ботиночках.
 - balance: Клоуны-антагонисты не теряют способности передвигаться с нормальной скоростью в своих ботинках.
