### PR TITLE
Робы мага не закрывает его костюм (и ID карту)

### DIFF
--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -182,7 +182,6 @@
 	permeability_coefficient = 0.01
 	armor = list(melee = 30, bullet = 10, laser = 10,energy = 20, bomb = 20, bio = 20, rad = 20)
 	allowed = list(/obj/item/weapon/teleportation_scroll)
-	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.4
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 
@@ -242,7 +241,6 @@
 	icon_state = "holidaypriest"
 	item_state = "holidaypriest"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/wizrobe/serifcoat
 	name = "serif coat"


### PR DESCRIPTION

## Описание изменений
Плак-плак от админа. Типичная ситуация - маг украл золотую карту капитана с полным доступом, мага поймали, у мага изымают карту. Роба закрывает слот jumpsuit, следовательно, надо её снять для изъятия ID карты. Робу магу не возвращают потому что зачем играть в модный приговор с криминальным элементом, маг плачет в ахелп потому что "ролькохант, раздели, не могу заклинания кастовать". 

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - balance: С магов можно снимать ID карту не снимая их робу.
