### PR TITLE
Емагнутую игрушечную сингу может надуть кто угодно

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -176,7 +176,7 @@
 		add_fingerprint(user)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
-			if(H.job == "Clown")
+			if(H.job == "Clown" || stage_of_effect == 2)
 				to_chat(user, "<span class = 'notice'>You concentrate your power into a one big bad joke and make the [src] much stronger.</span>")
 				on = TRUE
 


### PR DESCRIPTION

## Описание изменений
Когда в последний раз перерисовывали сингу, право надувать её игрушечную версию оставили только клоуну, независимо от емагнутости. В предыдущей итерации емагнутую могли надувать все. Возвращает эту интеракцию. Не-емагнутую всё ещё может надувать только клоун.

## Почему и что этот ПР улучшит
FUN! 

## Авторство

## Чеинжлог

:cl:
 - rscadd: Емагните игрушечную сингулярность и альт-кликните на неё для безумной шутки!
