### PR TITLE
Bridge Communication Console easier unlock

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -68,6 +68,29 @@
 
 	return ..()
 
+/obj/machinery/computer/communications/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	try_log_in(W, user)
+
+/obj/machinery/computer/communications/proc/try_log_in(obj/item/A, mob/user)
+	var/obj/item/weapon/card/id/I
+	if(A)
+		if(!istype(A, /obj/item/weapon/card/id))
+			return FALSE
+		I = A
+	else
+		I = user.get_active_hand()
+		if(istype(I, /obj/item/device/pda))
+			var/obj/item/device/pda/pda = I
+			I = pda.id
+		if(!istype(I))
+			return FALSE
+	if(check_access(I))
+		authenticated = 1
+	if((access_captain in I.access) || (access_hop in I.access) || (access_hos in I.access))
+		authenticated = 2
+	return TRUE
+
 /obj/machinery/computer/communications/Topic(href, href_list)
 	. = ..()
 	if(!.)
@@ -89,15 +112,12 @@
 			if(isobserver(M))
 				authenticated = 2
 			else
-				var/obj/item/weapon/card/id/I = M.get_active_hand()
-				if (istype(I, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = I
-					I = pda.id
-				if (I && istype(I))
-					if(check_access(I))
-						authenticated = 1
-					if((access_captain in I.access) || (access_hop in I.access) || (access_hos in I.access))
-						authenticated = 2
+				if(!try_log_in(null, M))
+					if(iscarbon(M))
+						var/mob/living/carbon/C = M
+						try_log_in(C.get_slot_ref(SLOT_WEAR_ID), C)
+			updateUsrDialog()
+			return
 		if("logout")
 			authenticated = 0
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Клик картой по консоли оповещений на мостике теперь открывает её. Клик по кнопке Log In не держа в руке карту теперь открывает её, если карта находится в своём ID слоте.
## Почему и что этот ПР улучшит
удобнее оперировать с компуктером без уи. Быстрее и проще взаимодействие через юзер интерфейс 
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- tweak: Консоль оповещений мостика теперь не требует кликов картой по кнопкам в интерфейсе для разблокировки.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
