### PR TITLE
Disables SSoverlays queue for initialization

### DIFF
--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -135,6 +135,10 @@ SUBSYSTEM_DEF(overlays)
 
 	overlays = build_appearance_list(overlays)
 
+	if(SSticker.current_state <= GAME_STATE_STARTUP) // saves on subsystem overhead at init
+		src.overlays += overlays
+		return
+
 	LAZYINITLIST(add_overlays) //always initialized after this point
 	var/a_len = add_overlays.len
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Экономит ноль целых и хрен десятых секунды на инициализации сабсистемы оверлеев. Для нас сейчас это не критично, но в перспективе может аукнуться. Как на тг: https://github.com/tgstation/tgstation/pull/69696

Причем, я думаю, что сама очередь изменений оверлеев - гуд, так что не стал убирать совсем как на тг, а только отключил  на момент общей инициализации.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
