### PR TITLE
возвращает фосфорную кислоту в крапиву

### DIFF
--- a/code/defines/obj/hydro.dm
+++ b/code/defines/obj/hydro.dm
@@ -1328,7 +1328,7 @@
 	. = ..()
 	spawn(5)
 		reagents.add_reagent("nutriment", 1 + round((potency / 50), 1))
-		reagents.add_reagent("sanguisacid", round(potency, 1))
+		reagents.add_reagent("pacid", round(potency, 1))
 		force = round((5 + potency / 2.5), 1)
 
 /obj/item/weapon/grown/deathnettle/suicide_act(mob/user)

--- a/code/defines/obj/hydro.dm
+++ b/code/defines/obj/hydro.dm
@@ -1329,6 +1329,7 @@
 	spawn(5)
 		reagents.add_reagent("nutriment", 1 + round((potency / 50), 1))
 		reagents.add_reagent("pacid", round(potency, 1))
+		reagents.add_reagent("sanguisacid", round(potency, 1))
 		force = round((5 + potency / 2.5), 1)
 
 /obj/item/weapon/grown/deathnettle/suicide_act(mob/user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
см. название
## Почему и что этот ПР улучшит
Я когда-то давно выпиливал фосфорную кислоту из крапивы чтобы добавить вместо неё новый реагент...
но
Как оказывается, фосфорная кислота в крапиве имела невероятно важное предназначение, а точнее - она нужна для создания гетто бомб из разных измельченных растений.  
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
🆑 Simbaka
- rem: Крапива-убийца снова содержит фосфорную кислоту.