### PR TITLE
Update absorb.dm

### DIFF
--- a/code/game/gamemodes/objectives/absorb.dm
+++ b/code/game/gamemodes/objectives/absorb.dm
@@ -16,7 +16,7 @@
 					n_p ++
 		target_amount = min(target_amount, n_p)
 
-	explanation_text = "Нам нужно поглотить [pluralize_russian(target_amount, "геном", "генома", "геномов")]."
+	explanation_text = "Нам нужно поглотить [target_amount] [pluralize_russian(target_amount, "геном", "генома", "геномов")]."
 	return target_amount
 
 /datum/objective/absorb/check_completion()


### PR DESCRIPTION
## Описание изменений
Фикс забавной ошибки с генокрадами в цельках
## Почему и что этот ПР улучшит
Когда малевич добавлял "геномы", то случайно снёс [target_amount] которое отвечало за число (нужно кол-во геномов) и генокрады перестали понимать сколько им надо
## Авторство
Я
## Чеинжлог
:cl: Azzy.Dreemurr
 - bugfix: Починена цель у генокрадов с количеством геномов.
