### PR TITLE
Нерф распространения разгерм

### DIFF
--- a/code/modules/clothing/spacesuits/Skafandr_kosmicheskiy.dm
+++ b/code/modules/clothing/spacesuits/Skafandr_kosmicheskiy.dm
@@ -19,6 +19,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 0)
 	slowdown = 2
 	siemens_coefficient = 0.65
+	equip_time = 20
 
 /obj/item/clothing/suit/space/sk/atom_init()
 	. = ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Время надевания евроса упало с 10 до 2 секунд
## Почему и что этот ПР улучшит
Нерф распространения разгерм, так как открыть ломом шлюз занимает 5 сек, а надеть еврос занимает 10 сек, то стратегия "хватаем лом, открываем шлюз, делаем вдох" и повторяем пока незаразгермленых мест не останется - является привлекательной, возможность надеть еврос не за 10 лет должно исправить это
По идее сокращение времени надевания евроса должно стимулировать быстро надеть еврос и ждать помощи, а не распространять вакуум по станции продлевая свою погибель. Но это только на бумаге

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - tweak: еврос надевается не 10, а 2 секунды

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
