### PR TITLE
Фикс обычных спрайтов дисков при спавне

### DIFF
--- a/code/game/objects/items/weapons/disks.dm
+++ b/code/game/objects/items/weapons/disks.dm
@@ -5,7 +5,6 @@
 	w_class = SIZE_MINUSCULE
 	cases = list("дискета", "дискеты", "дискете", "дискету", "дискетой", "дискете")
 	icon_state = "datadisk0"
-	item_state = "datadisk0"
 	item_state_world = "datadisk0_world"
 	item_state_inventory = "datadisk0"
 

--- a/code/game/objects/items/weapons/disks.dm
+++ b/code/game/objects/items/weapons/disks.dm
@@ -5,9 +5,6 @@
 	w_class = SIZE_MINUSCULE
 	cases = list("дискета", "дискеты", "дискете", "дискету", "дискетой", "дискете")
 	icon_state = "datadisk0"
-	item_state = "datadisk0"
-	item_state_world = "datadisk0_world"
-	item_state_inventory = "datadisk0"
 
 /obj/item/weapon/disk/nuclear
 	name = "nuclear authentication disk"
@@ -63,9 +60,9 @@
 	. = ..()
 	var/diskcolor = pick(0,1,2,3,4,5,6,7,8)
 	icon_state = "datadisk[diskcolor]"
-	item_state = "datadisk[diskcolor]"
 	item_state_world = "datadisk[diskcolor]_world"
 	item_state_inventory = "datadisk[diskcolor]"
+	update_world_icon()
 
 /obj/item/weapon/disk/data/proc/Initialize()
 	buf = new
@@ -131,11 +128,11 @@
 	. = ..()
 	var/diskcolor = pick(0,1,2,3,4,5,6,7,8)
 	icon_state = "datadisk[diskcolor]"
-	item_state = "datadisk[diskcolor]"
 	item_state_world = "datadisk[diskcolor]_world"
 	item_state_inventory = "datadisk[diskcolor]"
 	pixel_x = rand(-5.0, 5)
 	pixel_y = rand(-5.0, 5)
+	update_world_icon()
 
 /* RND tech disks */
 
@@ -151,11 +148,11 @@
 	. = ..()
 	var/diskcolor = pick(0,1,2,3,4,5,6,7,8)
 	icon_state = "datadisk[diskcolor]"
-	item_state = "datadisk[diskcolor]"
 	item_state_world = "datadisk[diskcolor]_world"
 	item_state_inventory = "datadisk[diskcolor]"
 	pixel_x = rand(-5.0, 5)
 	pixel_y = rand(-5.0, 5)
+	update_world_icon()
 
 /obj/item/weapon/disk/research_points
 	name = "Important Disk"

--- a/code/game/objects/items/weapons/disks.dm
+++ b/code/game/objects/items/weapons/disks.dm
@@ -5,6 +5,9 @@
 	w_class = SIZE_MINUSCULE
 	cases = list("дискета", "дискеты", "дискете", "дискету", "дискетой", "дискете")
 	icon_state = "datadisk0"
+	item_state = "datadisk0"
+	item_state_world = "datadisk0_world"
+	item_state_inventory = "datadisk0"
 
 /obj/item/weapon/disk/nuclear
 	name = "nuclear authentication disk"
@@ -57,12 +60,11 @@
 
 //Disk stuff.
 /obj/item/weapon/disk/data/atom_init()
-	. = ..()
 	var/diskcolor = pick(0,1,2,3,4,5,6,7,8)
 	icon_state = "datadisk[diskcolor]"
 	item_state_world = "datadisk[diskcolor]_world"
 	item_state_inventory = "datadisk[diskcolor]"
-	update_world_icon()
+	. = ..()
 
 /obj/item/weapon/disk/data/proc/Initialize()
 	buf = new
@@ -125,14 +127,13 @@
 	var/datum/design/blueprint
 
 /obj/item/weapon/disk/design_disk/atom_init()
-	. = ..()
 	var/diskcolor = pick(0,1,2,3,4,5,6,7,8)
 	icon_state = "datadisk[diskcolor]"
 	item_state_world = "datadisk[diskcolor]_world"
 	item_state_inventory = "datadisk[diskcolor]"
 	pixel_x = rand(-5.0, 5)
 	pixel_y = rand(-5.0, 5)
-	update_world_icon()
+	. = ..()
 
 /* RND tech disks */
 
@@ -145,14 +146,13 @@
 	var/datum/tech/stored
 
 /obj/item/weapon/disk/tech_disk/atom_init()
-	. = ..()
 	var/diskcolor = pick(0,1,2,3,4,5,6,7,8)
 	icon_state = "datadisk[diskcolor]"
 	item_state_world = "datadisk[diskcolor]_world"
 	item_state_inventory = "datadisk[diskcolor]"
 	pixel_x = rand(-5.0, 5)
 	pixel_y = rand(-5.0, 5)
-	update_world_icon()
+	. = ..()
 
 /obj/item/weapon/disk/research_points
 	name = "Important Disk"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь спрайты обычных дисков не будет на весь тайл, а будут использовать свой ворлд стейт
## Почему и что этот ПР улучшит
fixes https://github.com/TauCetiStation/TauCetiClassic/issues/12943
fixes https://github.com/TauCetiStation/TauCetiClassic/issues/12938
## Дополнительно
Попробовал сократить код чтобы он не был таким страшным, но максимум только можно убрать итем_стейт без дальнейших проблем.
Если убрать айкон стейт, то он будет брать самый первый спрайт в ДМИ файле до первого интеракта с диском
Убирать инвентори - некорректное отображение в руке/инвенторе других предметов
Ну а про ворд стейт не вижу смысла расписывать
(Да... Я только сейчас нашел апдейт ворлд айкон...)
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Slavik2001
 - bugfix: Фикс бага с спрайтами обычных дисков.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
