### PR TITLE
x2 перед ионосферной аномалией

### DIFF
--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -3,9 +3,7 @@
 
 /datum/event/communications_blackout/announce()
 	for(var/mob/living/silicon/ai/A in player_list)	//AIs are always aware of communication blackouts.
-		to_chat(A, "<br> ")
-		to_chat(A, "<span class='warning'><b>[announcement.message]</b></span>")
-		to_chat(A, "<br>  ")
+		to_chat(A, " <br><span class='warning'><b>[announcement.message]</b></span><br> ")
 
 	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
 		announcement.play()

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -3,7 +3,7 @@
 
 /datum/event/communications_blackout/announce()
 	for(var/mob/living/silicon/ai/A in player_list)	//AIs are always aware of communication blackouts.
-		to_chat(A, " <br><span class='warning'><b>[announcement.message]</b></span><br> ")
+		to_chat(A, "<br><span class='warning'><b>[announcement.message]</b></span><br>")
 
 	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
 		announcement.play()

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -3,9 +3,9 @@
 
 /datum/event/communications_blackout/announce()
 	for(var/mob/living/silicon/ai/A in player_list)	//AIs are always aware of communication blackouts.
-		to_chat(A, "<br>")
+		to_chat(A, "<br> ")
 		to_chat(A, "<span class='warning'><b>[announcement.message]</b></span>")
-		to_chat(A, "<br>")
+		to_chat(A, "<br>  ")
 
 	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
 		announcement.play()


### PR DESCRIPTION
## Описание изменений
### Было:
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/115452414/a9d60599-78dc-472a-b2bf-d21f1bd4d135)
### Стало:
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/115452414/58310b69-d867-425b-b950-a7af5f32b783)
### Надеюсь, найдёте разницу.
## Почему и что этот ПР улучшит
Избавит чат от x2 непонятно чего.
## Авторство
Кнопка пробела.
## Чеинжлог

:cl:Basia
 - bugfix: Удалён х2 при оповещении ИИ о ионосферной аномалии
