### PR TITLE
Fix Donut_Chaos

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -84,15 +84,15 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/donut/choco
 
 /datum/recipe/microwave/donut/chaos
-	reagents = list("sugar" = 5, "sodiumchloride" = 5, "water" = 5, "fuel" = 5, "toxin" = 5, "anti_toxin" = 5, "coffee" = 5, "stoxin" = 5)
+	reagents = list("sugar" = 5, "sodiumchloride" = 5, "fuel" = 5, "toxin" = 5, "anti_toxin" = 5, "coffee" = 5, "stoxin" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/donut/normal,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/classic,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/banana,
+		/obj/item/weapon/reagent_containers/food/snacks/donut/berry,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/ambrosia,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/choco
-
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/donut/chaos
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Был изменён состав рецепта пончика Хаоса. Добавил вишнёвый пончик и убрал воду, потому что вода с некоторыми составными веществами из рецепта, создавала другие два вещества (Plant-B-Gone и Space jenkem) и тем самым рецепт становился не рабочим. 
Сейчас рецепт в микроволновке такой -> 5 унции сахара + 5 унции соли + 5 унции топлива + 5 унции кофе + по 5 унции токсина, слип-токсина и анти-токсина + Все виды пончиков (кроме слаймового!)
## Почему и что этот ПР улучшит
Починили рецепт пончик Хаоса. Можно кушать на страх и риск, ведь состав его Хаотичный и непредсказуемый.
## Авторство
Pufikc
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->
## Чеинжлог
:cl: Pufikc
 - bugfix: Для крафта пончика Хаоса больше не требуется вода, тем самым его стало возможно скрафтить.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
