### PR TITLE
Фикс спавна дисков симптомов вирусов

### DIFF
--- a/code/game/objects/random/random_misc.dm
+++ b/code/game/objects/random/random_misc.dm
@@ -150,7 +150,7 @@
 /obj/random/misc/disk
 	name = "Random Disk"
 	desc = "This is a random disk pack."
-	icon = 'icons/obj/cloning.dmi'
+	icon = 'icons/obj/disks.dmi'
 	icon_state = "datadisk0"
 
 /obj/random/misc/disk/item_to_spawn()

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -97,7 +97,7 @@
 
 /obj/item/weapon/diseasedisk
 	name = "blank GNA disk"
-	icon = 'icons/obj/cloning.dmi'
+	icon = 'icons/obj/disks.dmi'
 	icon_state = "datadisk0"
 	var/datum/disease2/effectholder/effect = null
 	var/list/species = null


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Заменил 1 строчку чтобы диски вирусняков нашли свое истинное обличие(ещё и почему-то рандом имел ссылку на старые спрайты, но при самом спавне всё было норм....)
## Почему и что этот ПР улучшит
fixes https://github.com/TauCetiStation/TauCetiClassic/issues/12995
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Slavik2001
 - bugfix: Пофикшен баг с спрайтом дисков вирусов
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
