### PR TITLE
plasma battery vulnerable to EMP

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -521,6 +521,8 @@
 	icon_state = "[initial(icon_state)]-[has_overcharge() ? "oc" : CEIL(power_supply.charge / power_supply.maxcharge * 5) * 20]"
 
 /obj/item/ammo_box/magazine/plasma/emp_act(severity)
+	if(isnull(power_supply))
+		return
 	power_supply.use(round(power_supply.charge / severity))
 	update_icon()
 	..()

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -454,7 +454,7 @@
 
 /obj/item/ammo_box/magazine/plasma
 	name = "plasma weapon battery pack"
-	desc = "Специальный корпус аккумулятора с защитой от ЭМИ. Используется метод быстрой зарядки. Имеет стандартизированные размеры и может использоваться с любым плазмотроном данной серии. Возможна замена элемента питания."
+	desc = "Специальный корпус аккумулятора использующий метод быстрой зарядки. Имеет стандартизированные размеры и может использоваться с любым плазмотроном данной серии. Возможна замена элемента питания."
 	icon_state = "plasma_clip"
 	origin_tech = "combat=2"
 	ammo_type = null // unused, those are inside guns of this type.
@@ -520,8 +520,10 @@
 	// yes, it stops reporting accurate data for icon if its overflowing with energy till it drops charge under certain amount.
 	icon_state = "[initial(icon_state)]-[has_overcharge() ? "oc" : CEIL(power_supply.charge / power_supply.maxcharge * 5) * 20]"
 
-/obj/item/ammo_box/magazine/plasma/emp_act() // just incase if someone adds emp_act in parent.
-	return
+/obj/item/ammo_box/magazine/plasma/emp_act(severity)
+	power_supply.use(round(power_supply.charge / severity))
+	update_icon()
+	..()
 
 /obj/item/ammo_box/magazine/drozd
 	name = "Drozd magazine (12.7mm)"

--- a/code/modules/projectiles/guns/plasma/plasma.dm
+++ b/code/modules/projectiles/guns/plasma/plasma.dm
@@ -66,6 +66,10 @@
 	QDEL_NULL(magazine)
 	return ..()
 
+/obj/item/weapon/gun/plasma/emp_act()
+	update_icon()
+	..()
+
 /obj/item/weapon/gun/plasma/Fire(atom/target, mob/living/user, params, reflex = 0)
 	newshot()
 	..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
батарейка плазмы разряжается от ЭМИ
## Почему и что этот ПР улучшит
Не вижу ни одной причины (дурацкое оправдание в описании магазинов не в счёт) по которой у плазмы отсутствует одна из особенностей вообще всего энергооружия в игре - уязвимость к ЭМИ.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- tweak: Плазменное оружие разряжается от ЭМИ.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
