### PR TITLE
"Morgue" door missing sprites

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -3,6 +3,7 @@ var/global/list/wedge_image_cache = list()
 /obj/machinery/door
 	name = "Door"
 	desc = "It opens and closes."
+	icon_state = "door1"
 	anchored = TRUE
 	opacity = 1
 	density = TRUE

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -3,7 +3,6 @@ var/global/list/wedge_image_cache = list()
 /obj/machinery/door
 	name = "Door"
 	desc = "It opens and closes."
-	icon_state = "door1"
 	anchored = TRUE
 	opacity = 1
 	density = TRUE
@@ -584,5 +583,6 @@ var/global/list/wedge_image_cache = list()
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'
+	icon_state = "door1"
 	door_open_sound  = 'sound/machines/shutter_open.ogg'
 	door_close_sound = 'sound/machines/shutter_close.ogg'


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
https://github.com/TauCetiStation/TauCetiClassic/pull/12851/files#diff-58d1b69b881766e6d8f871a8f027a28512085d30fdf1d96e9c3d1da4cad5be4dL7
удалил айкон стейт для дверей
## Почему и что этот ПР улучшит
фикс бага
closes #13015
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- fix: Двери в библиотеке теперь отображаются корректно
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
