### PR TITLE
Возвращение базового доступа в карго парамедикам, перенос автолата

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -174,7 +174,7 @@
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
 	idtype = /obj/item/weapon/card/id/civ
-	access = list(access_janitor, access_maint_tunnels, access_sec_doors, access_research, access_mailsorting, access_medical, access_engineering_lobby)
+	access = list(access_janitor, access_maint_tunnels, access_sec_doors, access_research, access_mailsorting, access_medical, access_engineering_lobby, access_mailsorting)
 	salary = 50
 	minimal_player_ingame_minutes = 120
 	outfit = /datum/outfit/job/janitor

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -76,7 +76,7 @@
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
 	idtype = /obj/item/weapon/card/id/med
-	access = list(access_medical, access_morgue, access_paramedic, access_maint_tunnels, access_external_airlocks, access_sec_doors, access_research, access_medbay_storage, access_engineering_lobby)
+	access = list(access_medical, access_morgue, access_paramedic, access_maint_tunnels, access_external_airlocks, access_sec_doors, access_research, access_medbay_storage, access_engineering_lobby, access_mailsorting)
 	salary = 120
 	minimal_player_ingame_minutes = 1500 //they have too much access, so you have to play more to unlock it
 	outfit = /datum/outfit/job/paramedic

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -13426,15 +13426,6 @@
 /area/station/rnd/xenobiology)
 "awZ" = (
 /obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/device/multitool,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -38962,6 +38953,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
+/obj/machinery/autolathe,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -42581,6 +42573,15 @@
 	pixel_x = -4;
 	pixel_y = 7
 	},
+/obj/item/stack/sheet/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/device/multitool,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"
@@ -71413,7 +71414,6 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "fec" = (
-/obj/machinery/autolathe,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"


### PR DESCRIPTION
## Описание изменений
Как я понял, проект с "Независимой Каргонией" оказался не реализованным до конца и заброшенным. Если это не так - прошу автора связаться. Было принято решение вернуть парамедикам доступ базовый доступ в карго, как оно раньше и было, ибо как-то странно что в всё ещё цивильный отдел станции у парамедов нет доступа. Однако, чтобы не наступать на те же грабли с тем, что парамедики забегали поюзать автолат - автолат был перенесёт за двери, к которым у парамедов уже нет доступа. Также туда же были перенесены сталь, стекло и мультитул.  Локация автолата указана на скрине, ресурсы и мультитул на соседнем столике.
![Screenshot_20240330-001251_1](https://github.com/TauCetiStation/TauCetiClassic/assets/86578193/24b7ddf4-a0f0-49af-8866-108a08a16c94)

## Почему и что этот ПР улучшит
Геймплей парамедиков, за счёт возвращения базового доступа в отдел. Геймплей тех, кого выкинуло в мусорку, за счёт того что к ним сразу могут подойти парамедики.
## Авторство
Unchi
## Чеинжлог
:cl:
 - tweak: Парамедикам возвращён базовый доступ в карго.
 - map: Автолат с ресурсами перенесён вглубь карго, от лап парамедиков.

