### PR TITLE
Добавлена возможность держать плитку пола в лапках инженерного борга

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -16,6 +16,7 @@
 		/obj/item/stack/sheet/metal,
 		/obj/item/stack/sheet/glass,
 		/obj/item/stack/sheet/plasteel,
+		/obj/item/stack/tile,
 		/obj/item/weapon/stock_parts,
 		/obj/item/light_fixture_frame,
 		/obj/item/apc_frame,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
По мотивам https://github.com/TauCetiStation/TauCetiClassic/pull/12812 , инженерный юнит и дроны смогут брать в лапки различные плитки пола, ковры и т.п. 
## Почему и что этот ПР улучшит
Работу инженерных киборгов(дронов) и возможности ставить ковры и новый пол от Воласа
## Авторство
Я
## Чеинжлог
:cl: Azzy.Dreemurr
- tweak: Инженерный киборг и дрон смогут держать в лапках различного вида плитки для пола и ковры
