### PR TITLE
Revert "Теперь облить кого-то можно только на harm-интенте (#12604)"

### DIFF
--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -20,7 +20,7 @@ var/global/list/cached_icons = list()
 /obj/item/weapon/reagent_containers/glass/paint/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)
 		return
-	if(istype(target, /turf/simulated) && reagents.total_volume > 0 && user.a_intent == INTENT_HARM)
+	if(istype(target, /turf/simulated) && reagents.total_volume > 0)
 		user.visible_message("<span class='notice'>[target] has been splashed by [user] with [src].</span>", "<span class='notice'>You splash [target] with [src].</span>")
 		reagents.standard_splash(target, amount=5, user=user)
 	else

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -78,7 +78,7 @@
 		if(istype(target, type))
 			return
 
-	if(ismob(target) && target.reagents && reagents.total_volume && user.a_intent == INTENT_HARM)
+	if(ismob(target) && target.reagents && reagents.total_volume)
 		to_chat(user, "<span class = 'notice'>Вы разлили содержимое на [CASE(target, ACCUSATIVE_CASE)].</span>")
 
 		var/mob/living/M = target
@@ -141,7 +141,8 @@
 				to_chat(user, "<span class='warning'>You try to fill [user.a_intent == INTENT_GRAB ? "[src] up from a tank" : "a tank up"], but find it is absent.</span>")
 				return
 
-	else if(reagents && reagents.total_volume && user.a_intent == INTENT_HARM)
+
+	else if(reagents && reagents.total_volume)
 		to_chat(user, "<span class = 'notice'>Вы разлили содержимое на [CASE(target, ACCUSATIVE_CASE)].</span>")
 		reagents.standard_splash(target, user=user)
 		return


### PR DESCRIPTION
This reverts commit bd5f1e3cf81220d59ee35e5541a00cba88cd7402.

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Мне не нравится это изменение, его обусловленность и последствия изменения
## Почему и что этот ПР улучшит
откат багов, возвращение работоспособности взаимодействий реагент холдеров
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- del: Теперь облить кого-то можно не только на harm-интенте.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
