### PR TITLE
revert Смазка видима #8773

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -54,12 +54,10 @@
 	if(wet < severity)
 		wet = severity
 		UpdateSlip()
-		if(!wet_overlay)
-			var/current_type = "wet_floor"
-			if(severity == LUBE_FLOOR)
-				current_type = "wet_floor_static"
-			wet_overlay = image('icons/effects/water.dmi', current_type, src)
-			add_overlay(wet_overlay)
+		if(wet_overlay || severity >= LUBE_FLOOR)
+			return
+		wet_overlay = image('icons/effects/water.dmi', "wet_floor", src)
+		add_overlay(wet_overlay)
 
 /turf/simulated/proc/make_dry_floor()
 	if(wet)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
До https://github.com/TauCetiStation/TauCetiClassic/pull/8773 смазка не светилась на тайле при разливе. Добавлял это для баланса увеличения времени оглушения от неё. Оглушение тогда ещё не предполагало передвижение лёжа. На изменение ополчился дырэктор Eldern и мейнтейнеры и предложили убрать всё кроме свечения на тайле. Я не хотел закрывать свою попытку в код и сделал то, что было приемлемо для мержа.

С респрайтом полов люди вспомнили про это изменение и то что оно устарело. Решил откатить ввиду бесполезности.
## Почему и что этот ПР улучшит
фикс появившегося бага старого оверлея смазки на новых плитках. Не прийдётся думать каким образом давать картинкам метки с подходящей размазнёй смазки (а её ещё и рисовать Вальтеру прийдётся)
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- del: Смазка больше не использует спрайты намоченного пола при разливании на плитках
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
