### PR TITLE
revert Ослабление станционных боргов #9312

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -75,7 +75,7 @@
 /datum/robot_component/armour
 	name = "armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour
-	max_damage = 25
+	max_damage = 100
 
 
 // ACTUATOR


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Откат одного из изменений https://github.com/TauCetiStation/TauCetiClassic/pull/9312, а именно понижение брони киборгам с 100 до 25
## Почему и что этот ПР улучшит
https://github.com/TauCetiStation/TauCetiClassic/pull/13013 изменил игру синтетиков и они более не заточены использовать свою броню для зерг-раша всех кто им не нравится. Для повышения мотивации идти на принцип выполнения своих законов (а не быть уничтоженными за один удар) им нужна нормальная выживаемость, которая была у них ранее.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- del: Обычные киборги производятся с выдерживающей до 100 урона бронепластиной
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
