### PR TITLE
Остановка сердца от удара током #9642

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -642,6 +642,9 @@
 		if(species.flags[NO_PAIN]) // Because for all intents and purposes, if the mob feels no pain, he was not shocked.
 			. = 0
 		electrocution_animation(40)
+		// heart attack if ~150 free kW in powernet
+		if(. > 50)
+			attack_heart(50, 50)
 
 /mob/living/carbon/human/Topic(href, href_list)
 	if(href_list["skill"])


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
мне и таким как я очень нравилась механика удалённая в https://github.com/TauCetiStation/TauCetiClassic/pull/9642. Возвращение механики остановки сердца. Теперь с шансом 50% и только если в электрической сети много неиспользуемой мощности тока. То есть если смесы выставлены на максимумы выдачи или двигатель подключён напрямую к сети.
## Почему и что этот ПР улучшит
фикс закрытого ишуя с багом https://github.com/TauCetiStation/TauCetiClassic/issues/9690, теперь удар током учтёт изоляцию. Классная механика (что-то на уровне сжигания руки от электроудара, только лайтовее) теперь вернётся в игру, как допустили в этом комментарии https://github.com/TauCetiStation/TauCetiClassic/pull/9642#issuecomment-1193295318
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- add: Остановка сердца от удара током возвращается.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
