### PR TITLE
Пикетные знаки снова отображаются в руках #12930

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -118,7 +118,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	else if(S.sprite_sheets[sprite_sheet_slot])
 		icon_path = S.sprite_sheets[sprite_sheet_slot]
 
-	if(!(t_state in icon_states(icon_path)))
+	if(!("[t_state][icon_state_appendix]" in icon_states(icon_path)))
 		if(t_state in icon_states(def_icon_path))
 			icon_path = def_icon_path
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -119,8 +119,7 @@ Please contact me on #coderbus IRC. ~Carn x
 		icon_path = S.sprite_sheets[sprite_sheet_slot]
 
 	if(!("[t_state][icon_state_appendix]" in icon_states(icon_path)))
-		if(t_state in icon_states(def_icon_path))
-			icon_path = def_icon_path
+		icon_path = def_icon_path
 
 	var/fem = ""
 	if(H.gender == FEMALE && S.gender_limb_icons)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -119,7 +119,8 @@ Please contact me on #coderbus IRC. ~Carn x
 		icon_path = S.sprite_sheets[sprite_sheet_slot]
 
 	if(!(t_state in icon_states(icon_path)))
-		icon_path = def_icon_path
+		if(t_state in icon_states(def_icon_path))
+			icon_path = def_icon_path
 
 	var/fem = ""
 	if(H.gender == FEMALE && S.gender_limb_icons)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
https://github.com/TauCetiStation/TauCetiClassic/pull/12465 добавил оверрайд оверрайднутых айкон стейтов, добавляю вторую проверочку поверх для отмены этого если там пусто
## Почему и что этот ПР улучшит
closes #12930
![ffff](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/318733e8-d60e-4470-a890-79a3a88e945f)

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- fix: В руках космонавтика заметны транспаранты
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
