### PR TITLE
/obj/item/atom_init now properly sets can_block_air

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -74,6 +74,9 @@
 
 	var/resistance_flags = FULL_INDESTRUCTIBLE // INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ON_FIRE | UNACIDABLE | ACID_PROOF
 
+	var/can_block_air = FALSE // shared flag between /turf/s and /movable/s, you should use it only for movables
+	                          // if you want to set it true for object then remember to create CanPass or c_airblock methods or it will do nothing (pls refactor it)
+
 /atom/New(loc, ...)
 	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		_preloader.load(src)
@@ -105,7 +108,9 @@
 // /mob/dead/atom_init
 // /obj/item
 
-//Do also note that this proc always runs in New for /mob/dead
+// Read commentary above if you want to create:
+// /atom/movable/atom_init
+
 /atom/proc/atom_init(mapload, ...)
 	SHOULD_NOT_SLEEP(TRUE)
 	SHOULD_CALL_PARENT(TRUE)
@@ -116,9 +121,14 @@
 	if(light_power && light_range)
 		update_light()
 
-	if(opacity && isturf(src.loc))
-		var/turf/T = src.loc
+	if(opacity && isturf(loc))
+		var/turf/T = loc
 		T.has_opaque_atom = TRUE // No need to recalculate it in this case, it's guaranteed to be on afterwards anyways.
+
+	if(can_block_air && isturf(loc))
+		var/turf/T = loc
+		if(!T.can_block_air)
+			T.can_block_air = TRUE
 
 	if(uses_integrity)
 		if (!armor)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -32,14 +32,6 @@
 	// A (nested) list of contents that need to be sent signals to when moving between areas. Can include src.
 	var/list/area_sensitive_contents
 
-/atom/movable/atom_init(mapload, ...)
-	. = ..()
-
-	if (can_block_air && isturf(loc))
-		var/turf/T = loc
-		if(!T.can_block_air)
-			T.can_block_air = TRUE
-
 /atom/movable/Destroy()
 
 	var/turf/T = loc

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -97,6 +97,9 @@
 	var/list/flash_protection_slots = list()
 	var/can_get_wet = TRUE
 
+/**
+  * Doesn't call parent, see [/atom/proc/atom_init]
+  */
 /obj/item/atom_init()
 	SHOULD_CALL_PARENT(FALSE)
 	if(initialized)
@@ -106,9 +109,14 @@
 	if(light_power && light_range)
 		update_light()
 
-	if(opacity && isturf(src.loc))
-		var/turf/T = src.loc
+	if(opacity && isturf(loc))
+		var/turf/T = loc
 		T.has_opaque_atom = TRUE // No need to recalculate it in this case, it's guaranteed to be on afterwards anyways.
+
+	if(can_block_air && isturf(loc))
+		var/turf/T = loc
+		if(!T.can_block_air)
+			T.can_block_air = TRUE
 
 	if(uses_integrity)
 		if (!armor)

--- a/code/modules/atmospheric/ZAS/Atom.dm
+++ b/code/modules/atmospheric/ZAS/Atom.dm
@@ -48,8 +48,6 @@
 
 	return TRUE
 
-/atom/var/can_block_air = FALSE // if true - object need also CanPass or c_airblock
-
 //Basically another way of calling CanPass(null, other, 0, 0).
 //Returns:
 // 0 - Not blocked


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Людук заметил, что ``/obj/item/atom_init`` не вызывал родителя, и сам по себе не сетапил ``can_block_air``. Поправил, так что что-то могло починиться.

Убирать ``/atom/movable/atom_init`` было мало смысла (хотя лишний атом_инит с ..() на верхнем уровне может сильно замедлять инициализацию, это не тот случай), но я подумал, что так будет проще, когда всё в одном месте.

Немного поправил комментарии, чтоб это всё меньше сбивало с толку.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
