### PR TITLE
Несты теперь не сковывают насовсем

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -26,11 +26,14 @@
 			"<span class='warning'>You struggle to break free from the gelatinous resin...</span>",
 			"<span class='notice'>You hear squelching...</span>")
 
-		if(!(do_after(L, 5 MINUTES, target = L) && buckled_mob == L))
+		if(!(do_after(L, 3 MINUTES, target = L) && buckled_mob == L))
 			return
 
 	L.pixel_y = L.default_pixel_y
 	unbuckle_mob()
+	to_chat(L, "<span class='notice'>You successfly break free from the nest!</span>")
+	L.visible_message(
+			"<span class='warning'>[L.name] break free from the nest...</span>",)
 
 /obj/structure/stool/bed/nest/can_user_buckle(mob/living/M, mob/user)
 	if(isxeno(M) || !isxenoadult(user))

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -26,7 +26,7 @@
 			"<span class='warning'>You struggle to break free from the gelatinous resin...</span>",
 			"<span class='notice'>You hear squelching...</span>")
 
-		if(!(do_after(L, 3 MINUTES, needhand = FALSE, target = L) && buckled_mob == L))
+		if(!(do_after(L, 3 MINUTES, target = L) && buckled_mob == L))
 			return
 
 	L.pixel_y = L.default_pixel_y

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -26,7 +26,7 @@
 			"<span class='warning'>You struggle to break free from the gelatinous resin...</span>",
 			"<span class='notice'>You hear squelching...</span>")
 
-		if(!(do_after(L, 3 MINUTES, target = L) && buckled_mob == L))
+		if(!(do_after(L, 3 MINUTES, needhand = FALSE, target = L) && buckled_mob == L))
 			return
 
 	L.pixel_y = L.default_pixel_y

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -389,8 +389,6 @@
 		return TRUE
 	if (istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
 		return TRUE
-	if (istype(buckled, /obj/structure/stool/bed/nest))
-		return TRUE
 	return 0
 
 /mob/living/carbon/human/resist()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
несты теперь не скручивают руки и ноги, снижение кулдауна на анбакл с неста с 5 минут до трёх
минусы: можно брать предметы с пола пока лежишь в несте (контрится возможностью ксеносов плавить предметы, не считаю это слишком опасным) 
## Почему и что этот ПР улучшит
фикс бага и вроде бы нерф ксеноморфов, resolves https://github.com/TauCetiStation/TauCetiClassic/issues/10288
## Авторство
:cl: maleyvich
- bugfix: Теперь с гнёзд ксеноморфов можно слезть самим.
- balance: Кулдаун на слезание с гнезда снижен с пяти минут до трёх
- tweak: Находясь в гнезде, можно брать предметы поблизости.
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
