### PR TITLE
убирает возможность возвращать вещи в вендомат

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -242,11 +242,6 @@
 		ewallet = W
 		to_chat(user, "<span class='notice'>You insert the [W] into the [src]</span>")
 
-	else if(src.panel_open)
-		for(var/datum/data/vending_product/R in product_records)
-			if(istype(W, R.product_path))
-				stock(R, user)
-				qdel(W)
 	else
 		..()
 
@@ -484,13 +479,6 @@
 		src.vend_ready = 1
 		src.currently_vending = null
 		updateUsrDialog()
-
-/obj/machinery/vending/proc/stock(datum/data/vending_product/R, mob/user)
-	if(src.panel_open)
-		to_chat(user, "<span class='notice'>You stock the [src] with \a [R.product_name]</span>")
-		R.amount++
-
-	updateUsrDialog()
 
 /obj/machinery/vending/proc/say_slogan()
 	if(stat & (BROKEN|NOPOWER))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
убирает возможность возвращать вещи в вендомат
## Почему и что этот ПР улучшит
resolves #9139
fixes #12797
fixes #13031
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
🆑 Simbaka
- fix: Исправлены все баги и абузы связанные с возможностью вставлять вещи обратно в вендомат.
- del: В вендомат более нельзя возвращать вещи напрямую, но всё ещё можно с помощью restocking unit'а из карго.