### PR TITLE
добавляет капитану бронеплиту-аксессуар

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -20,6 +20,7 @@
 	else
 		new /obj/item/weapon/gun/energy/gun/head(src)
 
+	new /obj/item/clothing/accessory/armor(src)
 	new /obj/item/clothing/suit/captunic(src)
 	new /obj/item/clothing/suit/captunic/capjacket(src)
 	new /obj/item/clothing/head/helmet/cap(src)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -15,19 +15,18 @@
 //Captain
 /obj/item/clothing/suit/captunic
 	name = "captain's parade tunic"
-	desc = "Worn by a Captain to show their class."
+	desc = "Worn by a Captain to show their class. Also has some space for armor plate."
 	icon_state = "captunic"
 	item_state = "bio_suit"
+	valid_accessory_slots = list("armband", "decor", "armor_plate")
+	restricted_accessory_slots = list("armband", "armor_plate")
 	body_parts_covered = UPPER_TORSO|ARMS
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/captunic/capjacket
 	name = "captain's uniform jacket"
-	desc = "A less formal jacket for everyday captain use."
+	desc = "A less formal jacket for everyday captain use. Also has some space for armor plate."
 	icon_state = "capjacket"
-	item_state = "bio_suit"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	flags_inv = HIDEJUMPSUIT
 
 //Chaplain
 /obj/item/clothing/suit/chaplain_hoodie

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -18,8 +18,8 @@
 	desc = "Worn by a Captain to show their class. Also has some space for armor plate."
 	icon_state = "captunic"
 	item_state = "bio_suit"
-	valid_accessory_slots = list("armband", "decor", "armor_plate")
-	restricted_accessory_slots = list("armband", "armor_plate")
+	valid_accessory_slots = list("armband", "decor", "armor")
+	restricted_accessory_slots = list("armband", "armor")
 	body_parts_covered = UPPER_TORSO|ARMS
 	flags_inv = HIDEJUMPSUIT
 

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -2,7 +2,7 @@
 	name = "armor plate"
 	desc = "Time for some serious protection."
 	icon_state = "armor"
-	slot = "armor"
+	slot = "armor_plate"
 	armor = list(melee = 50, bullet = 45, laser = 40, energy = 25, bomb = 35, bio = 0, rad = 0)
 	pierce_protection = UPPER_TORSO|LOWER_TORSO
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -2,7 +2,7 @@
 	name = "armor plate"
 	desc = "Time for some serious protection."
 	icon_state = "armor"
-	slot = "armor_plate"
+	slot = "armor"
 	armor = list(melee = 50, bullet = 45, laser = 40, energy = 25, bomb = 35, bio = 0, rad = 0)
 	pierce_protection = UPPER_TORSO|LOWER_TORSO
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO

--- a/code/modules/holidays/new_year/clothing.dm
+++ b/code/modules/holidays/new_year/clothing.dm
@@ -52,7 +52,8 @@
 	name = "captain's winter coat"
 	icon_state = "coatcaptain"
 	hoodtype = /obj/item/clothing/head/wintercoat/captain
-	armor = list(melee = 35, bullet = 25, laser = 20, energy = 10, bomb = 15, bio = 0, rad = 0)
+	valid_accessory_slots = list("armband", "decor", "armor_plate")
+	restricted_accessory_slots = list("armband", "armor_plate")
 	allowed = list(/obj/item/weapon/gun/energy,/obj/item/weapon/gun/plasma,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/telebaton)
 
 /obj/item/clothing/head/wintercoat/captain

--- a/code/modules/holidays/new_year/clothing.dm
+++ b/code/modules/holidays/new_year/clothing.dm
@@ -52,8 +52,8 @@
 	name = "captain's winter coat"
 	icon_state = "coatcaptain"
 	hoodtype = /obj/item/clothing/head/wintercoat/captain
-	valid_accessory_slots = list("armband", "decor", "armor_plate")
-	restricted_accessory_slots = list("armband", "armor_plate")
+	valid_accessory_slots = list("armband", "decor", "armor")
+	restricted_accessory_slots = list("armband", "armor")
 	allowed = list(/obj/item/weapon/gun/energy,/obj/item/weapon/gun/plasma,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/telebaton)
 
 /obj/item/clothing/head/wintercoat/captain


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавляет в шкафчик капитана броню-аксессуар (бронеплиту), даёт такую же защиту что и обычный бронежилет, плиту можно повесить на куртку и парадный костюм капитана.
ещё убрал пару бессмысленных переменных у одежды капитана, они и без этого наследуются.
## Почему и что этот ПР улучшит
Стиль!!!!
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- add: В шкафчик капитана добавлена бронеплита, которую можно спрятать под курткой или парадным костюмом.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
