### PR TITLE
ipc operations skill fix

### DIFF
--- a/code/modules/skills/skillbooks/skillbooks.dm
+++ b/code/modules/skills/skillbooks/skillbooks.dm
@@ -144,7 +144,7 @@
 		/datum/skill/medical = SKILL_LEVEL_NOVICE,
 		/datum/skill/surgery = SKILL_LEVEL_NOVICE,
 		/datum/skill/construction = SKILL_LEVEL_NOVICE,
-		/datum/skill/engineering = SKILL_LEVEL_NOVICE,
+		/datum/skill/engineering = SKILL_LEVEL_TRAINED,
 		/datum/skill/chemistry = SKILL_LEVEL_NOVICE,
 	)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -140,11 +140,13 @@
 	if(ishuman(M))
 		covered = get_human_covering(M)
 
-	var/skillcheck = /datum/skill/surgery
-	if(M.species.flags[IS_SYNTHETIC])
-		skillcheck = /datum/skill/engineering
+	var/skillcheck = list(/datum/skill/surgery = SKILL_LEVEL_TRAINED)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species.flags[IS_SYNTHETIC])
+			skillcheck = list(/datum/skill/engineering = SKILL_LEVEL_TRAINED)
 
-	if(!handle_fumbling(user, M, SKILL_TASK_AVERAGE, list(skillcheck = SKILL_LEVEL_TRAINED), "<span class='notice'>You fumble around figuring out how to operate [M].</span>"))
+	if(!handle_fumbling(user, M, SKILL_TASK_AVERAGE, skillcheck, "<span class='notice'>You fumble around figuring out how to operate [M].</span>"))
 		return
 
 	for(var/datum/surgery_step/S in surgery_steps)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -144,7 +144,7 @@
 	if(M.species.flags[IS_SYNTHETIC])
 		skillcheck = /datum/skill/engineering
 
-	if(!handle_fumbling(user, M, SKILL_TASK_CHALLENGING, list(skillcheck = SKILL_LEVEL_TRAINED), "<span class='notice'>You fumble around figuring out how to operate [M].</span>"))
+	if(!handle_fumbling(user, M, SKILL_TASK_AVERAGE, list(skillcheck = SKILL_LEVEL_TRAINED), "<span class='notice'>You fumble around figuring out how to operate [M].</span>"))
 		return
 
 	for(var/datum/surgery_step/S in surgery_steps)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -140,7 +140,11 @@
 	if(ishuman(M))
 		covered = get_human_covering(M)
 
-	if(!handle_fumbling(user, M, SKILL_TASK_CHALLENGING, list(/datum/skill/surgery = SKILL_LEVEL_TRAINED), "<span class='notice'>You fumble around figuring out how to operate [M].</span>"))
+	var/skillcheck = /datum/skill/surgery
+	if(M.species.flags[IS_SYNTHETIC])
+		skillcheck = /datum/skill/engineering
+
+	if(!handle_fumbling(user, M, SKILL_TASK_CHALLENGING, list(skillcheck = SKILL_LEVEL_TRAINED), "<span class='notice'>You fumble around figuring out how to operate [M].</span>"))
 		return
 
 	for(var/datum/surgery_step/S in surgery_steps)
@@ -208,5 +212,5 @@
 /datum/surgery_step/ipc
 	can_infect = FALSE
 	allowed_species = list(IPC)
-	required_skills = list(/datum/skill/engineering = SKILL_LEVEL_TRAINED, /datum/skill/surgery = SKILL_LEVEL_TRAINED)
+	required_skills = list(/datum/skill/engineering = SKILL_LEVEL_TRAINED, /datum/skill/surgery = SKILL_LEVEL_NOVICE)
 	skills_speed_bonus = -0.2


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

СПУ оказались в уязвимом положении, потому что единственным, у кого было достаточно скиллов для их оперирования, был оригинальный (не сабпрофа) роботист. У всех остальных ученых не хватало хирургического скилла для работы с СПУ, а у медиков не хватало инженерных.

Теперь все подпрофы роботиста смогут оперировать СПУ без проблем, и книги ученых будет достаточно, чтоб остальные тоже могли.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->

:cl:
 - bugfix: Подпрофы роботиста имели проблемы с оперированием СПУ.
 - tweak: Книга "Skills 101: Science" достаточна для оперирования СПУ.
 - tweak: На оперировании совсем без скиллов стоял слишком большой предварительный скиллчек, он был уменьшен в 2 раза. Любой последующий шаг операции в любом случае тоже проверяет скиллы.