### PR TITLE
Increase virus speed in plant

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -282,7 +282,7 @@
 
 /datum/disease2/disease/proc/activate_symptom(atom/A)
 	//Moving to the next stage
-	if(clicks > stage * 100 && prob(10) && stage < effects.len)
+	if(clicks > stage * 100 && prob(stageprob) && stage < effects.len)
 		stage++
 
 	//Do nasty effects

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -119,6 +119,13 @@
 	if(!can_be_infected(source))
 		return
 	var/datum/disease2/disease/D = source.getcopy()
+	//boost growing in hydroponic tray
+	D.stageprob *= 10
+	D.speed *= 10
+	D.cooldown_mul *= 10
+	for(var/datum/disease2/effectholder/holder in D.effects)
+		holder.chance *= 10
+
 	virus2["[D.uniqueID]"] = D
 	D.register_host(src)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
переменная stageprob в вирусах задействована и теперь влияет на шанс развития вируса до следующей стадии.

У растений увеличены в 10 раз:
1. Шанс на развитие вируса до следующей стадии.
2. Шансы активации у каждого из эффектов вируса.
3. Скорость развития вируса.
4. Скорость развития эффектов вируса

## Почему и что этот ПР улучшит
### tl;dr Щас долго всё делать, надо минимум на 30% быстрее
Ради почти что флаффа развитие вируса занимает просто непомерно огромное время. Я то на локалке все параметры увеличивал чтобы посмотреть результат, а не выжидал каждый раз как будет в обычном раунде.

Математика:
Выведение вируса занимает значительное колличество времени (среднее значение 30 минут). При вносе его к растению, он стартует с 1-й стадии. Первые две стадии искуственного вируса зачастую не являются влияющими и не могут быть убраны по механу действия слиптоксина на вирусы (меньше двух симптомов - эффекта нет, при уничтожении симптома выбор что убрать абсолютно случайный). Развивается вирус с 100+ очков прогресса. Очки прогресса копятся в лайфе по 1-му в лайфтик. Лайфтик не происходит если нет растения или оно умерло. Лайфтик у растений происходит раз в 10 секунд. После срабатывания эффекта вируса с шансом на мутацию, ботанику нужно растение мутировать. Мутация растений происходит с результами: сработало (~20%), ничего не произошло (~40%), растение сдохло (~40%). Мутаген ботаникам достать тоже нужно какое-то время (допустим минут 5). 
Итого: 30 минут (вывод вируса) + 16 (минут на 1 стадию) * 3 (стадий до эффекта) + 5 (минут на активацию симптома) + 5 (минут на возню с мутагеном) = **88 минут**
88 минут это 1:28 смены. Средняя длительность смены 1:30.
При этом не активно задрачивая всё, можно время до результата и не вписать даже в отбытие шаттла. Непомерно долго. Надо менять, пробую убрать влияние всяких шансов и лайфтиков на систему вирусов на растения (там зачастую 10% у шансов на какой-то прогресс).
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Deahaka
- balance: Вирусы у растений активируются быстрее.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
