### PR TITLE
Фикс синдишлема

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -784,11 +784,13 @@
 			armor = combat_armor
 			canremove = FALSE
 			flags |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
+			flags_pressure &= ~STOPS_PRESSUREDMAGE
 			usr.visible_message("<span class='notice'>[usr] moves faceplate of their helmet into combat position, covering their visor and extending cameras.</span>")
 		else
 			armor = space_armor
 			canremove = TRUE
 			flags &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+			flags_pressure |= STOPS_PRESSUREDMAGE
 			usr.visible_message("<span class='notice'>[usr] pulls up faceplate from helmet's visor, retracting cameras</span>")
 		checklight()
 		update_icon(usr)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фиксит баг из-за которого синдишлем в боевом режиме защищал от разгермы
## Почему и что этот ПР улучшит
fixes #11629 
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
 - bugfix: Шлемы ригов Синдиката в боевом режиме больше не защищают от разгермы.
