### PR TITLE
убирает возможность спайдерботу переносить nuclear authentication disk

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -266,6 +266,8 @@
 
 	var/list/items = list()
 	for(var/obj/item/I in view(1,src))
+		if(istype(I, /obj/item/weapon/disk/nuclear))
+			continue
 		if(I.loc != src && I.w_class <= SIZE_TINY)
 			items.Add(I)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
см. название
## Почему и что этот ПР улучшит
Баланс, наверное
Мелкий робот может взять диск от ядерки и на протяжении всего раунда убегать по трубам от нюкеров
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Simbaka
- balance: Робот-паук не может переносить диск ядерной аутентификации.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
