### PR TITLE
Голод больше не увеличивается настолько сильно после качалки

### DIFF
--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -40,7 +40,7 @@
 	if(BP.pumped <= 0 && old_pumped > 0)
 		BP.owner.metabolism_factor.RemoveModifier("Pumped_[BP.name]")
 	else
-		BP.owner.metabolism_factor.AddModifier("Pumped_[BP.name]", base_additive = 0.0005 * BP.pumped)
+		BP.owner.metabolism_factor.AddModifier("Pumped_[BP.name]", base_additive = 0.00015 * BP.pumped)
 
 	return BP.pumped - old_pumped
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Голод усиливается теперь лишь немного. 
fixes: #13122 

## Почему и что этот ПР улучшит

Качалка не будет заставлять людей так страдать, особенно в лоупоп

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- tweak: Голод после качалки становится не таким сильным как раньше
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
