### PR TITLE
Фикс телепортера

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -411,15 +411,33 @@
 	return ..()
 
 /obj/machinery/teleport/station/attackby(obj/item/weapon/W, mob/user)
-	if(ispulsing(W) && !panel_open)
-		var/obj/item/device/multitool/M = W
-		if(M.buffer && istype(M.buffer, /obj/machinery/teleport/station) && M.buffer != src)
-			if(linked_stations.len < efficiency)
-				linked_stations.Add(M.buffer)
-				M.buffer = null
-				to_chat(user, "<span class='notice'>You upload the data from the [W.name]'s buffer.</span>")
-			else
-				to_chat(user, "<span class='alert'>This station cant hold more information, try to use better parts.</span>")
+	if(ispulsing(W) && panel_open)
+		var/actions = list("Download data in buffer", "Load data from buffer", "Connect to nearby machinery")
+		var/choice = tgui_input_list(user, "Choose your action", "Action", actions)
+		switch(choice)
+			if("Download data in buffer")
+				var/obj/item/device/multitool/M = W
+				M.buffer = src
+				to_chat(user, "<span class='notice'>You download the data to the [W.name]'s buffer.</span>")
+				return
+			if("Load data from buffer")
+				var/obj/item/device/multitool/M = W
+				if(M.buffer && istype(M.buffer, /obj/machinery/teleport/station) && M.buffer != src)
+					if(linked_stations.len < efficiency)
+						linked_stations.Add(M.buffer)
+						M.buffer = null
+						to_chat(user, "<span class='notice'>You upload the data from the [W.name]'s buffer.</span>")
+					else
+						to_chat(user, "<span class='alert'>This station can't hold more information, try to use better parts.</span>")
+				else if(M.buffer == src)
+					to_chat(user, "<span class='alert'>You can't load information about the same station.</span>")
+				else
+					to_chat(user, "<span class='alert'>Something went wrong!</span>")
+			if("Connect to nearby machinery")
+				link_console_and_hub()
+				to_chat(user, "<span class='notice'>You reconnect the station to nearby machinery.</span>")
+				return
+
 	if(default_deconstruction_screwdriver(user, "controller-o", "controller", W))
 		update_icon()
 		return
@@ -428,17 +446,6 @@
 		return
 
 	default_deconstruction_crowbar(W)
-
-	if(panel_open)
-		if(ispulsing(W))
-			var/obj/item/device/multitool/M = W
-			M.buffer = src
-			to_chat(user, "<span class='notice'>You download the data to the [W.name]'s buffer.</span>")
-			return
-		if(iscutter(W))
-			link_console_and_hub()
-			to_chat(user, "<span class='notice'>You reconnect the station to nearby machinery.</span>")
-			return
 
 /obj/machinery/teleport/station/attack_hand(mob/user)
 	. = ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Теперь все действия по подключению/скачиванию информации о станции с телепортера выполняются мультитулом. Так же для удобства все действия были перенесены в tgui_input_list с вариантами действий

fixes: #13148, #7043 

## Почему и что этот ПР улучшит

Улучшит удобство взаимодействия со стационарным телепортером

## Авторство
@L4rever 
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- bugfix: теперь телепортер подключается к машинерии мультитулом
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
