### PR TITLE
Добавлен доступ к консоли карго в компутер редактирования доступов

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -250,7 +250,7 @@
 		if(6) //station general
 			return list(access_kitchen,access_bar, access_hydroponics, access_barber, access_janitor, access_chapel_office, access_crematorium, access_library, access_lawyer, access_theatre)
 		if(7) //supply
-			return list(access_mailsorting, access_mining, access_mining_station, access_cargo, access_recycler, access_qm)
+			return list(access_mailsorting, access_cargoshop, access_mining, access_mining_station, access_cargo, access_recycler, access_qm)
 
 /proc/get_region_accesses_name(code)
 	switch(code)
@@ -281,7 +281,7 @@
 		if(access_detective)
 			return "Detective"
 		if(access_cargoshop)
-			return "Cargo Delivery"
+			return "Cargo Delivery/Supply Console"
 		if(access_security)
 			return "Security"
 		if(access_blueshield)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -218,6 +218,9 @@
 	origin_tech = "programming=3"
 	var/contraband_enabled = FALSE
 	var/hacked = FALSE
+/obj/item/weapon/circuitboard/computer/cargo/qm
+	name = "Circuit board (QM Supply shuttle console)"
+	build_path = /obj/machinery/computer/cargo/qm
 /*/obj/item/weapon/circuitboard/research_shuttle
 	name = "Circuit board (Research Shuttle)"
 	build_path = /obj/machinery/computer/research_shuttle

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -27,11 +27,6 @@
 			circuit = new circuit(null)
 		else
 			resistance_flags |= FULL_INDESTRUCTIBLE // no circuit = INDESTRUCTIBLE cuz we cant build it
-	if(circuit && istype(circuit))
-		if(req_access != initial(req_access))
-			circuit.req_access = req_access
-		if(req_one_access != initial(req_one_access))
-			circuit.req_one_access = req_one_access // Sync edited access to board
 	power_change()
 
 /obj/machinery/computer/Topic(href, href_list)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -27,6 +27,11 @@
 			circuit = new circuit(null)
 		else
 			resistance_flags |= FULL_INDESTRUCTIBLE // no circuit = INDESTRUCTIBLE cuz we cant build it
+	if(circuit && istype(circuit))
+		if(req_access != initial(req_access))
+			circuit.req_access = req_access
+		if(req_one_access != initial(req_one_access))
+			circuit.req_one_access = req_one_access // Sync edited access to board
 	power_change()
 
 /obj/machinery/computer/Topic(href, href_list)

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -20,6 +20,11 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/computer/cargo, cargo_consoles)
 	var/safety_warning = "For safety reasons the automated supply shuttle \
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
+/obj/machinery/computer/cargo/qm
+	name = "QM Supply console"
+	desc = "Used to order supplies, approve requests, and control the shuttle. Access requirements removed."
+	req_access = list()
+	circuit = /obj/item/weapon/circuitboard/computer/cargo/qm
 
 /obj/machinery/computer/cargo/request
 	name = "Supply request console"

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -13473,9 +13473,8 @@
 /turf/simulated/wall,
 /area/station/security/range)
 "axc" = (
-/obj/machinery/computer/cargo{
-	dir = 1;
-	req_access = list()
+/obj/machinery/computer/cargo/qm{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 9;

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -46122,9 +46122,8 @@
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
 "hBk" = (
-/obj/machinery/computer/cargo{
-	dir = 8;
-	req_access = list()
+/obj/machinery/computer/cargo/qm{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -34313,9 +34313,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "xFt" = (
-/obj/machinery/computer/cargo{
-	req_access = list()
-	},
+/obj/machinery/computer/cargo/qm,
 /obj/machinery/light/smart{
 	dir = 1
 	},

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -48506,6 +48506,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "iUy" = (
+/obj/machinery/atm{
+	pixel_y = -32
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -116835,9 +116838,8 @@
 	},
 /area/station/hallway/secondary/entry)
 "wHq" = (
-/obj/machinery/computer/cargo{
-	dir = 4;
-	req_access = list()
+/obj/machinery/computer/cargo/qm{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -74578,6 +74578,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	icon_state = "darkbrown"
 	},
@@ -85515,7 +85516,7 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "uwO" = (
-/obj/machinery/computer/cargo,
+/obj/machinery/computer/cargo/qm,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -88732,7 +88733,6 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/engineering)
 "vlq" = (
-/obj/item/weapon/flora/random,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -88741,6 +88741,9 @@
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
 	dir = 6
+	},
+/obj/machinery/atm{
+	pixel_y = 32
 	},
 /turf/simulated/floor{
 	dir = 1;


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавлен доступ к консоли карго в компутер редактирования доступов. 
Консоль КМа вынесена в отдельный объект с отдельной платой чтоб можно было ломать плату не сбрасывая доступ.
На прометее и гамме в кабинет КМа добавлен АТМ, там их не было, хотя на других картах(кроме фалькона но там нету отдельного кабинета) есть АТМ
## Почему и что этот ПР улучшит
ГП сможет давать доступ к консоли карго всяким там типочкам типам там левым тоже можно, когда допустим на станции нету там ну этих карготехов там кмов хопчик может выдать доступ шахтеру чтоб тот продал ресурсы бабло получил там заказал пиццу и чтоб все ок было короче даааааа
А с платой ну там можно ее ломать мультитулом ради пчел и не сосать от сброса доступа если там КМа нет и ты вломился чтоб чето заказать.
А АТМ удобно чтобы там деньги воровать с карго счета или там как премию отправлять карго акциями все дела.
## Авторство
AirBlack - красивый пенис
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: AirBlack
- bugfix: В консоль смены доступа добавлен доступ к карго консоли.
- tweak: Консоль КМа без доступа вынесена в отдельный объект
- map: На прометее и гамме в кабинет КМа добавлен АТМ

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl: 
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
