### PR TITLE
Phoron contagion fix 2

### DIFF
--- a/code/modules/atmospheric/ZAS/Phoron.dm
+++ b/code/modules/atmospheric/ZAS/Phoron.dm
@@ -65,16 +65,23 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 /mob/living/carbon/human/contaminate()
 	//See if anything can be contaminated.
 
-	if(!pl_suit_protected())
-		suit_contamination()
+	if(!pl_cloth_protected(UPPER_TORSO) && wear_suit)
+		wear_suit.contaminate()
 
-	if(!pl_head_protected())
-		if(prob(1))
-			suit_contamination() //Phoron can sometimes get through such an open suit.
+	if(!pl_cloth_protected(UPPER_TORSO) && w_uniform)
+		w_uniform.contaminate()
 
-//Cannot wash backpacks currently.
-//	if(istype(back,/obj/item/weapon/storage/backpack))
-//		back.contaminate()
+	if(!pl_cloth_protected(LEGS) && shoes)
+		shoes.contaminate()
+
+	if(!pl_cloth_protected(ARMS) && gloves)
+		gloves.contaminate()
+
+	if(!pl_cloth_protected(HEAD) && head)
+		head.contaminate()
+
+	if(!pl_cloth_protected(FACE) && wear_mask)
+		wear_mask.contaminate()
 
 /mob/proc/pl_effects()
 
@@ -91,7 +98,7 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 
 	//Burn skin if exposed.
 	if(vsc.plc.SKIN_BURNS)
-		if(!pl_head_protected() || !pl_suit_protected())
+		if(!pl_cloth_protected(HEAD) || !pl_cloth_protected(UPPER_TORSO) || !pl_cloth_protected(ARMS) || !pl_cloth_protected(LEGS))
 			burn_skin(0.75)
 			if(prob(20))
 				to_chat(src, "<span class='danger'>Your skin burns!</span>")
@@ -99,9 +106,8 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 
 	//Burn eyes if exposed.
 	if(vsc.plc.EYE_BURNS)
-		if(!(head && (head.body_parts_covered & EYES)))
-			if(!(wear_mask && (wear_mask.body_parts_covered & EYES)))
-				burn_eyes()
+		if(!pl_cloth_protected(FACE))
+			burn_eyes()
 
 	//Genetic Corruption
 	if(vsc.plc.GENETIC_CORRUPTION)
@@ -124,37 +130,12 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 			to_chat(src, "<span class='danger'>You are blinded!</span>")
 			eye_blind += 20
 
-/mob/living/carbon/human/proc/pl_head_protected()
-	//Checks if the head is adequately sealed.
-	if(head)
-		if(vsc.plc.PHORONGUARD_ONLY)
-			if(head.flags & PHORONGUARD)
-				return TRUE
-		else if(head.body_parts_covered & EYES)
+/mob/living/carbon/human/proc/pl_cloth_protected(body_part)
+	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
+	for(var/obj/item/clothing/C in protective_gear)
+		if((C.body_parts_covered & body_part) && (C.flags & PHORONGUARD))
 			return TRUE
 	return FALSE
-
-/mob/living/carbon/human/proc/pl_suit_protected()
-	//Checks if the suit is adequately sealed.
-	var/coverage = 0
-	for(var/obj/item/protection in list(wear_suit, gloves, shoes))
-		if(!protection)
-			continue
-		if(vsc.plc.PHORONGUARD_ONLY && !(protection.flags & PHORONGUARD))
-			return FALSE
-		coverage |= protection.body_parts_covered
-
-	if(vsc.plc.PHORONGUARD_ONLY)
-		return TRUE
-
-	return BIT_TEST_ALL(coverage, UPPER_TORSO|LOWER_TORSO|LEGS|ARMS)
-
-/mob/living/carbon/human/proc/suit_contamination()
-	//Runs over the things that can be contaminated and does so.
-	if(w_uniform) w_uniform.contaminate()
-	if(shoes) shoes.contaminate()
-	if(gloves) gloves.contaminate()
-
 
 /turf/Entered(obj/item/I)
 	. = ..()

--- a/code/modules/atmospheric/ZAS/Phoron.dm
+++ b/code/modules/atmospheric/ZAS/Phoron.dm
@@ -106,7 +106,7 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 
 	//Burn eyes if exposed.
 	if(vsc.plc.EYE_BURNS)
-		if(!pl_cloth_protected(FACE))
+		if(!pl_cloth_protected(EYES))
 			burn_eyes()
 
 	//Genetic Corruption


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь космические костюмы и биосьюты защищают от воздействия форона, как и должны.
## Почему и что этот ПР улучшит
fixes #9937
fixes #7058
fixes #3940
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Форон заражал вещи сквозь риги и биосьюты.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
