### PR TITLE
Prefs cleanup (cid history), admin stuff

### DIFF
--- a/code/__DEFINES/varedit.dm
+++ b/code/__DEFINES/varedit.dm
@@ -51,7 +51,7 @@
 
 /* hidden variables */
 #define VE_HIDDEN_LOG \
-	list("address", "computer_id", "guard", "related_accounts_ip", "related_accounts_cid", "lastKnownIP", "telemetry_connections")
+	list("address", "computer_id", "guard", "related_accounts_ip", "related_accounts_cid", "admin_cid_request_cache", "admin_ip_request_cache", "lastKnownIP", "telemetry_connections")
 
 var/global/list/duplicate_forbidden_vars = list(
 	"tag", "area", "type", "loc", "locs", "vars", "verbs", "contents",

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -33,6 +33,14 @@
 
 		return "[output][and_text][input[index]]"
 
+/proc/list2text(list/input, separator = ", ")
+	. = ""
+
+	for(var/line in input)
+		if(length(.))
+			. += separator
+		. += line
+
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/list,index)
 	if(istype(list) && list.len)

--- a/code/game/area/shuttle_areas.dm
+++ b/code/game/area/shuttle_areas.dm
@@ -71,7 +71,7 @@
 /area/shuttle/arrival/velocity/Entered(mob/M)
 	..()
 	if(istype(M) && M.client)
-		M.client.guard.time_velocity_shuttle = world.timeofday
+		M.client.prefs.guard.time_velocity_shuttle = world.timeofday
 
 /area/shuttle/arrival/transit
 	name = "Space"

--- a/code/game/machinery/computer/arrival_shuttle.dm
+++ b/code/game/machinery/computer/arrival_shuttle.dm
@@ -174,7 +174,7 @@ var/global/lastMove = 0
 		else
 			to_chat(usr, "<span class='notice'>Шаттл уже движется или состыкован со станцией.</span>")
 
-		usr.client.guard.velocity_console = TRUE
+		usr.client.prefs.guard.velocity_console = TRUE
 
 /obj/machinery/computer/arrival_shuttle/dock
 	name = "Arrival Shuttle Communication Console"
@@ -204,7 +204,7 @@ var/global/lastMove = 0
 		else
 			to_chat(usr, "<span class='notice'>Шаттл уже движется или состыкован со станцией.</span>")
 
-		usr.client.guard.velocity_console_dock = TRUE
+		usr.client.prefs.guard.velocity_console_dock = TRUE
 
 /obj/machinery/computer/arrival_shuttle/proc/radio_message_via_ai(msg)
 	if (!msg)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -71,9 +71,9 @@ var/global/BSACooldown = 0
 		<a href='?src=\ref[src];adminplayerobservefollow=\ref[M]'>FLW</a>
 		<br>
 		<b>Mob type</b> = [M.type]<br><br>
-		<b>Guard:</b> <A href='?src=\ref[src];guard=\ref[M]'>Show</A> |
-		<b>List of CIDs:</b> <A href='?src=\ref[src];cid_list=\ref[M]'>Get</A><br>
-		<b>Related accounts by IP and cid</b>: <A href='?src=\ref[src];related_accounts=\ref[M]'>Get</A><br>
+		<b>Guard:</b> <A href='?src=\ref[src];guard=\ref[M]'>Show</A><br>
+		<b>Related accounts by current IP and CID</b>: <A href='?src=\ref[src];related_accounts=\ref[M]'>Get</A><br>
+		<b>Slow queries:</b> <A href='?src=\ref[src];cid_history=\ref[M]'>CID history</A> | <A href='?src=\ref[src];ip_history=\ref[M]'>IP history</A><br>
 		<b>CentCom (other server bans)</b>: <A target='_blank' href='https://centcom.melonmesa.com/viewer/view/[M.ckey]'>CentCom (ENG)</A><br>
 		<b>BYOND profile</b>: <A target='_blank' href='http://byond.com/members/[M.ckey]'>[M.ckey]</A><br><br>
 		<A href='?src=\ref[src];boot2=\ref[M]'>Kick</A> |

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -72,7 +72,7 @@ var/global/BSACooldown = 0
 		<br>
 		<b>Mob type</b> = [M.type]<br><br>
 		<b>Guard:</b> <A href='?src=\ref[src];guard=\ref[M]'>Show</A> |
-		<b>List of CIDs:</b> <A href='?src=\ref[src];cid_list=\ref[M]'>Get</A>|<A href='?src=\ref[src];cid_ignore=\ref[M]'>Ignore Warning</A><br>
+		<b>List of CIDs:</b> <A href='?src=\ref[src];cid_list=\ref[M]'>Get</A><br>
 		<b>Related accounts by IP and cid</b>: <A href='?src=\ref[src];related_accounts=\ref[M]'>Get</A><br>
 		<b>CentCom (other server bans)</b>: <A target='_blank' href='https://centcom.melonmesa.com/viewer/view/[M.ckey]'>CentCom (ENG)</A><br>
 		<b>BYOND profile</b>: <A target='_blank' href='http://byond.com/members/[M.ckey]'>[M.ckey]</A><br><br>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -968,26 +968,13 @@
 					return
 				var/client/C = M.client
 				var/dat = ""
-				dat += "<center><b>Ckey:</b> [C.ckey] | <b>Ignore warning:</b> [C.prefs.ignore_cid_warning ? "yes" : "no"]</center>"
+				dat += "<center><b>Ckey:</b> [C.ckey]</center>"
 				for(var/x in C.prefs.cid_list)
 					dat += "<b>computer_id:</b> [x] - <b>first seen:</b> [C.prefs.cid_list[x]["first_seen"]] - <b>last seen:</b> [C.prefs.cid_list[x]["last_seen"]]<br>"
 
 				var/datum/browser/popup = new(usr, "[C.ckey]_cid_list", "[C.ckey] cid list")
 				popup.set_content(dat)
 				popup.open()
-
-	else if(href_list["cid_ignore"])
-		if(!check_rights(R_LOG))
-			return
-		else
-			var/mob/M = locate(href_list["cid_ignore"])
-			if (ismob(M))
-				if(!M.client)
-					return
-				var/client/C = M.client
-				C.prefs.ignore_cid_warning = !(C.prefs.ignore_cid_warning)
-				log_admin("[key_name(usr)] has [C.prefs.ignore_cid_warning ? "disabled" : "enabled"] multiple cid notice for [C.ckey].")
-				message_admins("[key_name_admin(usr)] has [C.prefs.ignore_cid_warning ? "disabled" : "enabled"] multiple cid notice for [C.ckey].")
 
 	else if(href_list["related_accounts"])
 		if(!check_rights(R_LOG))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -983,7 +983,7 @@
 			dat += "</table>"
 		else
 			dat += "<b>No history or we can't access database</b>"
-		dat += "<i>By default, we check only for the last 2 years</i>"
+		dat += "<i>By default, we check only for the last 2 years and last 30 cid</i>"
 
 		var/datum/browser/popup = new(usr, "[C.ckey]_cid_history", "Computer ID history for [C.ckey]", 700, 300)
 		popup.set_content(dat)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -958,23 +958,67 @@
 				return
 			M.client.prefs.guard.print_report()
 
-	else if(href_list["cid_list"])
+	else if(href_list["cid_history"])
 		if(!check_rights(R_LOG))
 			return
-		else
-			var/mob/M = locate(href_list["cid_list"])
-			if (ismob(M))
-				if(!M.client)
-					return
-				var/client/C = M.client
-				var/dat = ""
-				dat += "<center><b>Ckey:</b> [C.ckey]</center>"
-				for(var/x in C.prefs.cid_list)
-					dat += "<b>computer_id:</b> [x] - <b>first seen:</b> [C.prefs.cid_list[x]["first_seen"]] - <b>last seen:</b> [C.prefs.cid_list[x]["last_seen"]]<br>"
 
-				var/datum/browser/popup = new(usr, "[C.ckey]_cid_list", "[C.ckey] cid list")
-				popup.set_content(dat)
-				popup.open()
+		var/mob/M = locate(href_list["cid_history"])
+		if (!ismob(M) || !M.client)
+			return
+
+		var/client/C = M.client
+		if(!C.prefs.admin_cid_request_cache)
+			C.prefs.admin_cid_request_cache = C.generate_cid_history()
+
+		var/dat = ""
+		if(length(C.prefs.admin_cid_request_cache))
+			dat += "<table><tr><th>CID</th><th>First seen</th><th>Last seen</th><th>Related accounts</th></tr>"
+			for(var/cid in C.prefs.admin_cid_request_cache)
+				dat += "<tr>"
+				dat += "<td>[cid]</td>"
+				dat += "<td>[C.prefs.admin_cid_request_cache[cid]["first_seen"]]</td>"
+				dat += "<td>[C.prefs.admin_cid_request_cache[cid]["last_seen"]]</td>"
+				dat += "<td>[list2text(C.prefs.admin_cid_request_cache[cid]["match"], separator = "; ")]</td>"
+				dat += "</tr>"
+			dat += "</table>"
+		else
+			dat += "<b>No history or we can't access database</b>"
+		dat += "<i>By default, we check only for the last 2 years</i>"
+
+		var/datum/browser/popup = new(usr, "[C.ckey]_cid_history", "Computer ID history for [C.ckey]", 700, 300)
+		popup.set_content(dat)
+		popup.open()
+
+	else if(href_list["ip_history"])
+		if(!check_rights(R_LOG))
+			return
+
+		var/mob/M = locate(href_list["ip_history"])
+		if (!ismob(M) || !M.client)
+			return
+
+		var/client/C = M.client
+		if(!C.prefs.admin_ip_request_cache)
+			C.prefs.admin_ip_request_cache = C.generate_ip_history()
+
+		var/dat = ""
+		if(length(C.prefs.admin_ip_request_cache))
+			dat += "<table><tr><th>CID</th><th>First seen</th><th>Last seen</th><th>Related accounts</th></tr>"
+			for(var/ip in C.prefs.admin_ip_request_cache)
+				dat += "<tr>"
+				dat += "<td>[ip]</td>"
+				dat += "<td>[C.prefs.admin_ip_request_cache[ip]["first_seen"]]</td>"
+				dat += "<td>[C.prefs.admin_ip_request_cache[ip]["last_seen"]]</td>"
+				dat += "<td>[list2text(C.prefs.admin_ip_request_cache[ip]["match"], separator = "; ")]</td>"
+				dat += "</tr>"
+			dat += "</table>"
+		else
+			dat += "<b>No history or we can't access database</b>"
+		dat += "<i>By default, we check only for the last 2 years and last 30 ip</i>"
+
+		var/datum/browser/popup = new(usr, "[C.ckey]_ip_history", "IP history for [C.ckey]", 700, 300)
+		popup.set_content(dat)
+		popup.open()
 
 	else if(href_list["related_accounts"])
 		if(!check_rights(R_LOG))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -956,7 +956,7 @@
 		if (ismob(M))
 			if(!M.client)
 				return
-			M.client.guard.print_report()
+			M.client.prefs.guard.print_report()
 
 	else if(href_list["cid_list"])
 		if(!check_rights(R_LOG))

--- a/code/modules/bridge/commands/player_panel.dm
+++ b/code/modules/bridge/commands/player_panel.dm
@@ -76,10 +76,10 @@
 
 	// guard
 	if(online_client)
-		if(!length(online_client.guard.short_report))
-			online_client.guard.prepare()
+		if(!length(online_client.prefs.guard.short_report))
+			online_client.prefs.guard.prepare()
 
-		message += "**Guard report**: [online_client.guard.short_report]"
+		message += "**Guard report**: [online_client.prefs.guard.short_report]"
 
 	else
 		message += "**Guard report**: not available for offline player"

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -59,8 +59,6 @@
 	// Set on login.
 	var/datum/media_manager/media = null
 
-	var/datum/guard/guard = null
-
 	var/datum/tooltip/tooltips
 
 	var/list/datum/browser/browsers

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -552,7 +552,7 @@ var/global/list/blacklisted_builds = list(
 		if(query_accesslog.NextRow())
 			prefs.cid_count = text2num(query_accesslog.item[1])
 
-/client/proc/generate_cid_history(years = 2)
+/client/proc/generate_cid_history(years = 2, hardcap = 30)
 	if(!establish_db_connection("erro_connection_log"))
 		return FALSE
 
@@ -560,10 +560,12 @@ var/global/list/blacklisted_builds = list(
 	var/years_cap_sql
 	if(years && isnum(years))
 		years_cap_sql = "AND datetime > (Now() - interval [years] year)"
+	if(hardcap && isnum(hardcap))
+		hard_cap_sql = "LIMIT [hardcap]"
 
 	var/list/cid_list = list()
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT computerid, MIN(datetime) as first, MAX(datetime) as last from erro_connection_log WHERE ckey='[sql_ckey]' [years_cap_sql] GROUP BY computerid ORDER BY last DESC;")
+	var/DBQuery/query = dbcon.NewQuery("SELECT computerid, MIN(datetime) as first, MAX(datetime) as last from erro_connection_log WHERE ckey='[sql_ckey]' [years_cap_sql] GROUP BY computerid ORDER BY last DESC [hard_cap_sql];")
 	query.Execute()
 	while(query.NextRow())
 		cid_list[query.item[1]] = list("first_seen" = query.item[2], "last_seen" = query.item[3])

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -558,6 +558,7 @@ var/global/list/blacklisted_builds = list(
 
 	var/sql_ckey = ckey(ckey)
 	var/years_cap_sql
+	var/hard_cap_sql
 	if(years && isnum(years))
 		years_cap_sql = "AND datetime > (Now() - interval [years] year)"
 	if(hardcap && isnum(hardcap))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -247,9 +247,6 @@ var/global/list/blacklisted_builds = list(
 	if(connection != "seeker")					//Invalid connection type.
 		return null
 
-	if(!guard)
-		guard = new(src)
-
 	// Change the way they should download resources.
 	if(config.resource_urls)
 		src.preload_rsc = pick(config.resource_urls)
@@ -289,12 +286,13 @@ var/global/list/blacklisted_builds = list(
 	update_supporter_status()
 
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)
-	prefs = preferences_datums[ckey]
-	if(prefs)
-		prefs.parent = src
+	if(preferences_datums[ckey])
+		prefs = preferences_datums[ckey]
+		prefs.reattach_to_client(src)
 	else
 		prefs = new /datum/preferences(src)
 		preferences_datums[ckey] = prefs
+
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
 	fps = (prefs.clientfps < 0) ? RECOMMENDED_FPS : prefs.clientfps
@@ -545,7 +543,7 @@ var/global/list/blacklisted_builds = list(
 		query_update.Execute()
 	else if(!config.bunker_ban_mode)
 		//New player!! Need to insert all the stuff
-		guard.first_entry = TRUE
+		prefs.guard.first_entry = TRUE
 		var/DBQuery/query_insert = dbcon.NewQuery("INSERT INTO erro_player (id, ckey, firstseen, lastseen, ip, computerid, lastadminrank, ingameage) VALUES (null, '[sql_ckey]', Now(), Now(), '[sql_ip]', '[sql_computerid]', '[sql_admin_rank]', '[sql_player_ingame_age]')")
 		query_insert.Execute()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -297,16 +297,6 @@ var/global/list/blacklisted_builds = list(
 	prefs.last_id = computer_id			//these are gonna be used for banning
 	fps = (prefs.clientfps < 0) ? RECOMMENDED_FPS : prefs.clientfps
 
-	var/cur_date = time2text(world.realtime, "YYYY/MM/DD hh:mm:ss")
-	if("[computer_id]" in prefs.cid_list)
-		prefs.cid_list["[computer_id]"]["last_seen"] = cur_date
-	else
-		prefs.cid_list["[computer_id]"] = list("first_seen"=cur_date, "last_seen"=cur_date)
-
-	if(prefs.cid_list.len > 2)
-		log_admin("[ckey] has [prefs.cid_list.len] different computer_id.")
-		message_admins("[ckey] has <span class='red'>[prefs.cid_list.len]</span> different computer_id.")
-
 	prefs.save_preferences()
 
 	prefs_ready = TRUE // if moved below parent call, Login feature with lobby music will be broken and maybe anything else.
@@ -555,6 +545,73 @@ var/global/list/blacklisted_builds = list(
 		var/serverip = sanitize_sql("[world.internet_address]:[world.port]")
 		var/DBQuery/query_accesslog = dbcon.NewQuery("INSERT INTO `erro_connection_log`(`id`,`datetime`,`serverip`,`ckey`,`ip`,`computerid`) VALUES(null,Now(),'[serverip]','[sql_ckey]','[sql_ip]','[sql_computerid]');")
 		query_accesslog.Execute()
+
+		query_accesslog = dbcon.NewQuery("SELECT count(DISTINCT computerid) from erro_connection_log where ckey='[sql_ckey]';")
+		query_accesslog.Execute()
+
+		if(query_accesslog.NextRow())
+			prefs.cid_count = text2num(query_accesslog.item[1])
+
+/client/proc/generate_cid_history(years = 2)
+	if(!establish_db_connection("erro_connection_log"))
+		return FALSE
+
+	var/sql_ckey = ckey(ckey)
+	var/years_cap_sql
+	if(years && isnum(years))
+		years_cap_sql = "AND datetime > (Now() - interval [years] year)"
+
+	var/list/cid_list = list()
+
+	var/DBQuery/query = dbcon.NewQuery("SELECT computerid, MIN(datetime) as first, MAX(datetime) as last from erro_connection_log WHERE ckey='[sql_ckey]' [years_cap_sql] GROUP BY computerid ORDER BY last DESC;")
+	query.Execute()
+	while(query.NextRow())
+		cid_list[query.item[1]] = list("first_seen" = query.item[2], "last_seen" = query.item[3])
+
+	for(var/query_cid in cid_list)
+		var/list/match_ckeys = list()
+
+		query = dbcon.NewQuery("SELECT DISTINCT ckey from erro_connection_log WHERE computerid = '[query_cid]' AND ckey!='[sql_ckey]';")
+		query.Execute()
+		while(query.NextRow())
+			match_ckeys += query.item[1]
+
+		if(length(match_ckeys))
+			cid_list[query_cid]["match"] = match_ckeys
+
+	return cid_list
+
+/client/proc/generate_ip_history(years = 2, hardcap = 30)
+	if(!establish_db_connection("erro_connection_log"))
+		return FALSE
+
+	var/sql_ckey = ckey(ckey)
+	var/years_cap_sql
+	if(years && isnum(years))
+		years_cap_sql = "AND datetime > (Now() - interval [years] year)"
+	var/hard_cap_sql
+	if(hardcap && isnum(hardcap))
+		hard_cap_sql = "LIMIT [hardcap]"
+
+	var/list/ip_list = list()
+
+	var/DBQuery/query = dbcon.NewQuery("SELECT ip, MIN(datetime) as first, MAX(datetime) as last from erro_connection_log WHERE ckey='[sql_ckey]' [years_cap_sql] GROUP BY ip ORDER BY last DESC [hard_cap_sql];")
+	query.Execute()
+	while(query.NextRow())
+		ip_list[query.item[1]] = list("first_seen" = query.item[2], "last_seen" = query.item[3])
+
+	for(var/query_ip in ip_list)
+		var/list/match_ckeys = list()
+
+		query = dbcon.NewQuery("SELECT DISTINCT ckey from erro_connection_log WHERE ip = '[query_ip]' AND ckey!='[sql_ckey]';")
+		query.Execute()
+		while(query.NextRow())
+			match_ckeys += query.item[1]
+
+		if(length(match_ckeys))
+			ip_list[query_ip]["match"] = match_ckeys
+
+	return ip_list
 
 /client/proc/check_randomizer(topic)
 	. = FALSE

--- a/code/modules/client/guard.dm
+++ b/code/modules/client/guard.dm
@@ -2,6 +2,7 @@ var/global/list/guard_blacklist = list("IP" = list(), "ISP" = list())
 
 /datum/guard
 	var/client/holder
+
 	var/total_alert_weight = 0
 	var/bridge_reported = FALSE
 
@@ -31,6 +32,7 @@ var/global/list/guard_blacklist = list("IP" = list(), "ISP" = list())
 	addtimer(CALLBACK(src, PROC_REF(trigger_init)), 20 SECONDS) // time for other systems to collect data
 
 /datum/guard/proc/trigger_init()
+	// if client was lost somehow, mob/login should restart test again
 	if(holder && isnum(holder.player_ingame_age) && holder.player_ingame_age < GUARD_CHECK_AGE)
 		load_geoip() // this may takes a few minutes in bad case
 

--- a/code/modules/client/guard.dm
+++ b/code/modules/client/guard.dm
@@ -173,19 +173,19 @@ var/global/list/guard_blacklist = list("IP" = list(), "ISP" = list())
 
 		total_alert_weight += related_db_weight
 
-	if(holder.prefs.cid_list.len > 1)
+	if(holder.prefs.cid_count > 1)
 		var/multicid_weight = 0
 		var/allowed_amount = 1
 
 		if(isnum(holder.player_age) && holder.player_age > 60)
 			allowed_amount++
 
-		multicid_weight += min(((holder.prefs.cid_list.len - allowed_amount) * 0.35), 2) // new account, should not be many. 4 cids in the first hour -> +1 weight
+		multicid_weight += min(((holder.prefs.cid_count - allowed_amount) * 0.35), 2) // new account, should not be many. 4 cids in the first hour -> +1 weight
 
 		new_report += {"<div class='Section'><h3>Differents CID's ([multicid_weight]):</h3>
-		Has [holder.prefs.cid_list.len] different computer_id.</div>"}
+		Has [holder.prefs.cid_count] different computer_id.</div>"}
 
-		new_short_report += "Has [holder.prefs.cid_list.len] CID's (tw: [multicid_weight]); "
+		new_short_report += "Has [holder.prefs.cid_count] CID's (tw: [multicid_weight]); "
 
 		total_alert_weight += multicid_weight
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1,4 +1,4 @@
-var/global/list/preferences_datums = list()
+var/global/list/datum/preferences/preferences_datums = list()
 
 #define MAX_SAVE_SLOTS 10
 #define MAX_SAVE_SLOTS_SUPPORTER MAX_SAVE_SLOTS+10
@@ -6,6 +6,10 @@ var/global/list/preferences_datums = list()
 
 #define MAX_GEAR_COST 5
 #define MAX_GEAR_COST_SUPPORTER MAX_GEAR_COST+3
+
+// this datum keeps preferences and some random client things we need to keep persistent
+// because byond client object is too fickle https://www.byond.com/forum/post/2927086
+// todo: after moving preferences to new datumized system we should rename this to something like client_data
 /datum/preferences
 	var/client/parent
 	//doohickeys for savefiles
@@ -180,8 +184,13 @@ var/global/list/preferences_datums = list()
 	var/chosen_ringtone = "Flip-Flap"
 	var/custom_melody = "E7,E7,E7"
 
+	var/datum/guard/guard = null
+
 /datum/preferences/New(client/C)
 	parent = C
+
+	guard = new(parent)
+
 	UI_style = global.available_ui_styles[1]
 	custom_emote_panel = global.emotes_for_emote_panel
 	if(istype(C))
@@ -194,6 +203,10 @@ var/global/list/preferences_datums = list()
 	real_name = random_name(gender)
 	key_bindings = deepCopyList(global.hotkey_keybinding_list_by_key) // give them default keybinds too
 	C?.set_macros()
+
+// reattach existing datum to client if client was disconnected and connects again
+/datum/preferences/proc/reattach_to_client(client/client)
+	parent = client
 
 /datum/preferences/proc/ShowChoices(mob/user)
 	if(!user || !user.client)	return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -27,7 +27,9 @@ var/global/list/datum/preferences/preferences_datums = list()
 	var/list/ignore_question = list()		//For roles which getting player_saves with question system
 
 	//account data
-	var/list/cid_list = list()
+	var/cid_count = 0
+	var/admin_cid_request_cache
+	var/admin_ip_request_cache
 
 	//game-preferences
 	var/UI_style = null

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -24,7 +24,6 @@ var/global/list/preferences_datums = list()
 
 	//account data
 	var/list/cid_list = list()
-	var/ignore_cid_warning = 0
 
 	//game-preferences
 	var/UI_style = null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -347,10 +347,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(needs_update == SAVEFILE_TOO_OLD) // fatal, can't load any data
 		return 0
 
-	//Account data
-	S["cid_list"]			>> cid_list
-	S["ignore_cid_warning"]	>> ignore_cid_warning
-
 	//General preferences
 	S["ooccolor"]          >> ooccolor
 	S["aooccolor"]         >> aooccolor
@@ -439,9 +435,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	outline_color 	= normalize_color(sanitize_hexcolor(outline_color, initial(outline_color)))
 	eorg_enabled 	= sanitize_integer(eorg_enabled, 0, 1, initial(eorg_enabled))
 	show_runechat	= sanitize_integer(show_runechat, 0, 1, initial(show_runechat))
-	if(!cid_list)
-		cid_list = list()
-	ignore_cid_warning	= sanitize_integer(ignore_cid_warning, 0, 1, initial(ignore_cid_warning))
 	custom_emote_panel  = sanitize_emote_panel(custom_emote_panel)
 
 	snd_music_vol	= sanitize_integer(snd_music_vol, 0, 100, initial(snd_music_vol))
@@ -479,10 +472,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S.cd = "/"
 
 	S["version"] << SAVEFILE_VERSION_MAX
-
-	//Account data
-	S["cid_list"]           << cid_list
-	S["ignore_cid_warning"] << ignore_cid_warning
 
 	//general preferences
 	S["ooccolor"]          << ooccolor

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -293,7 +293,7 @@
 	joined_player_list += character.ckey
 
 	if(character.client)
-		character.client.guard.time_velocity_spawn = world.timeofday
+		character.client.prefs.guard.time_velocity_spawn = world.timeofday
 
 	qdel(src)
 

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -12,7 +12,7 @@
 	noob_notify(src)
 
 	if(config.guard_enabled)
-		client.guard.trigger_init()
+		client.prefs.guard.trigger_init()
 
 	//Jukebox
 	client.media?.open()

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -55,16 +55,16 @@
 	
 	var/payload_charset = payload["charset"]
 	if(istext(payload_charset))
-		client.guard.chat_data["charset"] = ckey(payload_charset)
+		client.prefs.guard.chat_data["charset"] = ckey(payload_charset)
 
 	var/payload_localtime = payload["localTime"]
 	if(isnum(payload_localtime))
-		client.guard.chat_data["local_time"] = payload_localtime
+		client.prefs.guard.chat_data["local_time"] = payload_localtime
 
 	telemetry_connections = payload["connections"]
 	var/len = length(telemetry_connections)
 	if(len == 0)
-		client.guard.chat_processed = TRUE
+		client.prefs.guard.chat_processed = TRUE
 		return
 	if(len > TGUI_TELEMETRY_MAX_CONNECTIONS)
 		message_admins("[key_name(client)] was kicked for sending a huge telemetry payload", R_LOG)
@@ -97,9 +97,9 @@
 
 	// This fucker has a history of playing on a banned account.
 	if(found)
-		client.guard.chat_data["cookie_match"] = found
+		client.prefs.guard.chat_data["cookie_match"] = found
 		var/msg = "[key_name(client)] has a banned account in connection history! (Matched: [found["ckey"]], [found["address"]], [found["computer_id"]])"
 		message_admins(msg, R_LOG)
 		log_admin_private(msg)
 
-	client.guard.chat_processed = TRUE
+	client.prefs.guard.chat_processed = TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Вынес часть из #13141, чтоб его не перегружать.

Сейвфайлы игроков больше не используются для хранения cid-ов, у нас уже давно есть база данных для этого. ``ignore_cid_warning`` вообще никогда не использовался.

Пока всё равно был тут, оформил админам две новые панельки для истории игроков. И сделал guard датум более постоянным, а то я устал наступать на грабли с бьендовским клиентом, которому ничего нельзя доверить.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
