### PR TITLE
Update civilian.dm

### DIFF
--- a/code/modules/skills/skillsets/civilian.dm
+++ b/code/modules/skills/skillsets/civilian.dm
@@ -90,7 +90,8 @@
 /datum/skillset/assistant
 	name = "Assistant"
 	initial_skills = list(
-		/datum/skill/command = SKILL_LEVEL_TRAINED
+		/datum/skill/construction = SKILL_LEVEL_NOVICE,
+		/datum/skill/engineering = SKILL_LEVEL_NOVICE
 	)
 
 /datum/skillset/assistant/lawyer
@@ -142,12 +143,5 @@
 /datum/skillset/assistant/test_subject
 	name = "Test Subject"
 	initial_skills = list(
-		/datum/skill/research = SKILL_LEVEL_TRAINED
-	)
-
-/datum/skillset/assistant
-	name = "Assistant"
-	initial_skills = list(
-		/datum/skill/construction = SKILL_LEVEL_NOVICE,
-		/datum/skill/engineering = SKILL_LEVEL_NOVICE
+		/datum/skill/research = SKILL_LEVEL_TRAINED,
 	)

--- a/code/modules/skills/skillsets/civilian.dm
+++ b/code/modules/skills/skillsets/civilian.dm
@@ -142,5 +142,12 @@
 /datum/skillset/assistant/test_subject
 	name = "Test Subject"
 	initial_skills = list(
-		/datum/skill/research = SKILL_LEVEL_TRAINED,
+		/datum/skill/research = SKILL_LEVEL_TRAINED
+	)
+
+/datum/skillset/assistant
+	name = "Assistant"
+	initial_skills = list(
+		/datum/skill/construction = SKILL_LEVEL_NOVICE,
+		/datum/skill/engineering = SKILL_LEVEL_NOVICE
 	)


### PR DESCRIPTION
Теперь ассистенты получают по 1 уровню engineering и construction. До этого у них было 2 command.

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
У ассистентов до этого было 2 command. Теперь у них 1 engineering и 1 construction.
## Почему и что этот ПР улучшит
Если для тестовика обосновано наличие навыка в науке (он ведь работает вместе с учеными, испытывает всякие опасные штуки на себе, по задумке по крайней мере), то для ассистента будет логично наличие навыков строительства и инженерии, иначе зачем им целая ассистентская, наполненная различными инструментами? К тому же, разные подпрофессии ассистента имеют различные навыки (медицина и химия у официанта, командование у адвоката, стрельба у частного сыщика), но ни у одной из них нет навыков в области инженерии. Так пусть будет у простого ассистента! 
## Авторство
IamSpy
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
У ассистентов теперь навыки 1 engineering и 1 construction.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
