### PR TITLE
Larva_evolve runtime fix?

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/powers.dm
@@ -420,7 +420,7 @@
 							"Трутень" = /mob/living/carbon/xenomorph/humanoid/drone)
 
 /obj/effect/proc_holder/spell/no_target/larva_evolve/cast_check(skipcharge = FALSE, mob/user = usr, try_start = TRUE)
-	if(!user in global.alien_list[ALIEN_LARVA])
+	if(!(user in global.alien_list[ALIEN_LARVA]))
 		return FALSE
 
 	if(!isturf(user.loc))

--- a/code/modules/mob/living/carbon/xenomorph/powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/powers.dm
@@ -420,10 +420,14 @@
 							"Трутень" = /mob/living/carbon/xenomorph/humanoid/drone)
 
 /obj/effect/proc_holder/spell/no_target/larva_evolve/cast_check(skipcharge = FALSE, mob/user = usr, try_start = TRUE)
+	if(!user in global.alien_list[ALIEN_LARVA])
+		return FALSE
+
 	if(!isturf(user.loc))
 		if(try_start)
 			to_chat(user, "<span class='warning'>Вы не можете эволюционировать, когда находитесь внутри чего-то.</span>")
 		return FALSE
+
 	var/mob/living/carbon/xenomorph/larva/larva = user
 	if(larva.amount_grown < larva.max_grown)
 		if(try_start)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
После эволва майнд лярвы переносится в нового ксеноморфика. И как я понял где-то в этот момент успевает проскочить каст чек. майнд уже не в лярве, а в другом чупике, прокает каст чек, и подливится, не найдя у новоиспеченного чупика переменной роста.

мейби есть способ как-то иначе это пофиксить, разобравшись как там че с каст чеком этим, в корне так скажем. но я хз и не шарю, поэтому просто сунул в каст чек ифку-затычку-проверку является ли юзер лярвой.

```
Runtime in code/modules/mob/living/carbon/xenomorph/powers.dm:434 : undefined variable /mob/living/carbon/xenomorph/humanoid/drone/var/amount_grown
  proc name: cast check (/obj/effect/proc_holder/spell/no_target/larva_evolve/cast_check)
  usr: The alien drone (586) (tap0r) 
```

по сути как я понял такая ситуация проверяется в предке, но он вызывается где-то там внизу и подлива на несуществующей переменной происходит раньше

```
if(((!user.mind) || !(src in user.mind.spell_list)) && !(src in user.spell_list))
		if(try_start)
			to_chat(user, "<span class='red'> You shouldn't have this spell! Something's wrong.</span>")
		return FALSE
```

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
