### PR TITLE
REPEATED_MAPS_FACTOR_DECREASE update

### DIFF
--- a/code/controllers/subsystem/voting/poll_types.dm
+++ b/code/controllers/subsystem/voting/poll_types.dm
@@ -233,7 +233,7 @@
 		return "Отсутствует конфиг карт"
 
 #define FORMAT_MAP_NAME(name) splittext(name, " ")[1]
-#define REPEATED_MAPS_FACTOR_DECREASE 0.1
+#define REPEATED_MAPS_FACTOR_DECREASE 0.15
 
 /datum/poll/nextmap/init_choices()
 	var/list/voteweights = get_voteweights()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

resolves #13187

0.2 было много, 0.1 оказалось мало. При 0.15 штраф за воут за туже карту будет 15%-30%-45% (в зависимости от повторов) .

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
