### PR TITLE
фикс модуля РЦД

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -89,7 +89,7 @@ RCD
 	if(RCD_MODE_PNEUMATIC in available_modes)
 		options[RCD_MODE_PNEUMATIC] = radial_pipe
 
-	var/choice = show_radial_menu(user, src, options, tooltips = TRUE)
+	var/choice = show_radial_menu(user, user, options, tooltips = TRUE)
 
 	if(!choice) //closed radial menu
 		return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Исправлена недоработка
(при смене режима модуля РЦД (который в риге) не вызывалось радиал меню)
## Почему и что этот ПР улучшит
фикс бага
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Исправлено переключение режима работы у модуля РЦД.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
