### PR TITLE
Переосмысление "Помощи Императрицы"

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -205,7 +205,7 @@
 //Roundstart help for xeno
 /datum/status_effect/young_queen_buff
 	id = "queen_help"
-	duration = 7 MINUTES
+	duration = 5 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/young_queen_buff
 	examine_text = "Looks quite young"
 
@@ -214,22 +214,21 @@
 	if(!isxeno(owner))
 		return
 	var/mob/living/carbon/xenomorph/Q = owner
-	Q.maxHealth = Q.maxHealth * 2
-	Q.health = Q.health * 2
 	Q.heal_rate = Q.heal_rate * 2.5
-	Q.plasma_rate = Q.plasma_rate * 1.5
+	Q.plasma_rate = Q.plasma_rate * 2
+	Q.storedPlasma = Q.storedPlasma * 2
+	Q.max_plasma = Q.max_plasma * 1.5
 	to_chat(Q, "<span class='alien large'>Пока ваш улей слаб, вам будет помогать Императрица. Некоторое время...</span>")
 
 /datum/status_effect/young_queen_buff/on_remove()
 	if(!isxeno(owner))
 		return
 	var/mob/living/carbon/xenomorph/Q = owner
-	Q.bruteloss = Q.bruteloss / 2
 	Q.fireloss = Q.fireloss / 2
-	Q.maxHealth = Q.maxHealth / 2
-	Q.update_health_hud()
 	Q.heal_rate = Q.heal_rate / 2.5
-	Q.plasma_rate = Q.plasma_rate / 1.5
+	Q.plasma_rate = Q.plasma_rate / 2
+	Q.storedPlasma = Q.storedPlasma / 2
+	Q.max_plasma = Q.max_plasma / 1.5
 	to_chat(Q, "<span class='alien large'>Императрица перестала активно поддерживать улей. Улей теперь должен заботиться о себе сам.</span>")
 
 /atom/movable/screen/alert/status_effect/young_queen_buff

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -214,7 +214,7 @@
 	if(!isxeno(owner))
 		return
 	var/mob/living/carbon/xenomorph/Q = owner
-	Q.heal_rate = Q.heal_rate * 2.5
+	Q.heal_rate = Q.heal_rate * 1.5
 	Q.plasma_rate = Q.plasma_rate * 2
 	Q.storedPlasma = Q.storedPlasma * 2
 	Q.max_plasma = Q.max_plasma * 1.5

--- a/code/modules/mob/living/carbon/xenomorph/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/special/alien_embryo.dm
@@ -87,6 +87,9 @@ This is emryo growth procs
 		else
 			baby.clear_alert("alien_embryo")
 
+	if(baby.has_status_effect(/datum/status_effect/young_queen_buff))
+		growth_rate = growth_rate * 2
+
 	var/diff = FULL_EMBRYO_GROWTH - growth_counter
 	if(diff < growth_rate)
 		growth_counter += diff	//so as not to go beyond the growth counter


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь начальный бафф "Помощь Императрицы" для ксеноморфов накладывает другие усиления, в т.ч ускорение роста лярв внутри хостов. Были убраны усиления к ХП, за исключением ускорения отхила здоровья, значения которого были понижены. Длительность баффа снижена с 7 до 5 минут.
## Почему и что этот ПР улучшит
Непонятно, зачем ксеноморфам бафф к ХП в начальной стадии, когда им нужно больше размножаться. Суть ПР-а заключается в её ускорении, ибо по недавним раундам, если лицехваты спавнились  лейтспавн ивентом - то они не успевали эскалировать конфликт. 
## Авторство
:cl: maleyvich
- tweak[link]: Начальный бафф "Помощь Императрицы" теперь накладывает другие эффекты.
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
