### PR TITLE
Продолжение отлова Error-турфов

### DIFF
--- a/maps/RandomZLevels/wildwest.dmm
+++ b/maps/RandomZLevels/wildwest.dmm
@@ -637,28 +637,16 @@
 /area/awaymission/wildwest/mansion)
 "cp" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
-/area/awaymission/wildwest/mansion)
-"cq" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "cr" = (
 /obj/structure/table/woodentable,
 /obj/machinery/kitchen_machine/microwave,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "cs" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "ct" = (
 /obj/structure/lattice,
@@ -687,11 +675,6 @@
 "cy" = (
 /obj/structure/stool/bed/chair/wood/wings,
 /turf/simulated/floor/wood,
-/area/awaymission/wildwest/mansion)
-"cz" = (
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
 /area/awaymission/wildwest/mansion)
 "cA" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -723,19 +706,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
-"cG" = (
-/mob/living/simple_animal/hostile/creature,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
-/area/awaymission/wildwest/mansion)
 "cH" = (
 /obj/effect/landmark/corpse/chef{
 	mobname = "Chef"
 	},
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "cI" = (
 /obj/structure/bookcase{
@@ -805,23 +780,17 @@
 "cV" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/monkeysdelight,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "cW" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/kitchenknife/butch,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "cX" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/soup/stew,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "cY" = (
 /obj/structure/stool/bed/chair/comfy/black{
@@ -853,23 +822,17 @@
 "dd" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/bread/cheese,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "de" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/kitchen/rollingpin,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "df" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/cake/lemon,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion{
 	dir = 1;
 	icon_state = "fwindow"
@@ -919,9 +882,7 @@
 "dq" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/wine,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "dr" = (
 /obj/structure/table/woodentable,
@@ -929,16 +890,12 @@
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "ds" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/patron,
-/turf/simulated/floor{
-	icon_state = "stage_bleft"
-	},
+/turf/simulated/floor/wood,
 /area/awaymission/wildwest/mansion)
 "dt" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -12279,13 +12236,13 @@ bR
 bY
 bP
 cp
-cz
-cz
-cz
-cz
-cz
-cG
-cz
+cn
+cn
+cn
+cn
+cn
+cN
+cn
 dq
 bP
 bY
@@ -12535,14 +12492,14 @@ bw
 bR
 bY
 bP
-cq
-cz
-cz
-cz
-cz
+cF
+cn
+cn
+cn
+cn
 cV
 dd
-cz
+cn
 dq
 bP
 bY
@@ -12793,13 +12750,13 @@ bR
 bY
 bP
 cr
-cz
-cG
-cz
-cz
+cn
+cN
+cn
+cn
 cW
 de
-cz
+cn
 dr
 bP
 bY
@@ -13049,14 +13006,14 @@ bv
 bR
 bY
 bP
-cq
-cz
+cF
+cn
 cH
-cz
-cz
+cn
+cn
 cX
 df
-cz
+cn
 ds
 bP
 bY
@@ -13307,13 +13264,13 @@ bR
 bY
 bP
 cs
-cz
-cz
-cz
-cz
-cz
-cz
-cz
+cn
+cn
+cn
+cn
+cn
+cn
+cn
 ds
 bP
 bY

--- a/maps/templates/space_structures/derelict_station.dmm
+++ b/maps/templates/space_structures/derelict_station.dmm
@@ -1067,11 +1067,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating/airless,
 /area/space)
-"du" = (
-/turf/simulated/floor/airless{
-	icon_state = "circuit"
-	},
-/area/space_structures/derelict/singularity_engine)
 "dv" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -1132,12 +1127,6 @@
 	},
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/airless,
-/area/space_structures/derelict/singularity_engine)
-"dF" = (
-/obj/item/stack/rods,
-/turf/simulated/floor/airless{
-	icon_state = "circuit"
-	},
 /area/space_structures/derelict/singularity_engine)
 "dH" = (
 /turf/simulated/floor/plating/airless,
@@ -6814,11 +6803,11 @@ cP
 dc
 bW
 bW
-dF
-du
-du
-du
-du
+cQ
+bW
+bW
+bW
+bW
 bS
 bS
 bS
@@ -6916,13 +6905,13 @@ bS
 cQ
 bW
 bW
-du
+bW
 aa
 aa
 aa
 aa
 aa
-du
+bW
 bW
 eD
 dl
@@ -7019,13 +7008,13 @@ bS
 bW
 bW
 bW
-du
+bW
 aa
 aa
 aa
 aa
 aa
-du
+bW
 bW
 bS
 bS
@@ -7122,13 +7111,13 @@ bW
 cR
 bW
 bW
-du
+bW
 aa
 aa
 aa
 aa
 aa
-du
+bW
 bW
 bS
 bS
@@ -7225,13 +7214,13 @@ bW
 bW
 bW
 bW
-du
+bW
 aa
 aa
 aa
 aa
 aa
-du
+bW
 bS
 bS
 bS
@@ -7328,13 +7317,13 @@ bS
 bW
 bW
 bW
-du
+bW
 aa
 aa
 aa
 aa
 aa
-du
+bW
 bS
 ce
 cq
@@ -7432,11 +7421,11 @@ cS
 dd
 bW
 bW
-du
-du
-du
-du
-du
+bW
+bW
+bW
+bW
+bW
 bW
 bW
 ce


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Замена Error турфов на нормальные. Изменения в мапдифе.
## Почему и что этот ПР улучшит
Продолжение улучшения иммерсивности для игроков, закрытие задачи по отлову Error-турфов 
fixed #11880
## Авторство
Ястарк
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
Не требуется
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
