### PR TITLE
Фикс the mecha equipment у рипли/файрфайтеров из аспекта

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -42,7 +42,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/extinguisher(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/cable_layer(src)
 	ME.attach(src)
 
 /obj/mecha/working/ripley/mine/atom_init() //for aspect
@@ -75,7 +75,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/extinguisher(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/cable_layer(src)
 	ME.attach(src)
 
 /obj/mecha/working/ripley/firefighter/ert


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Рабочие мехи из аспекта спавнились с new /obj/item/mecha_parts/mecha_equipment(src)

Заменил на cable layer
## Почему и что этот ПР улучшит
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/5171605/82dbea69-06c3-49ee-bf7c-3fd1f0ef14bc)

## Авторство
Simbaka - недописал тип
AirBlack - крутой мужик с яйцами заметил и починил
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: AirBlack
 - bugfix: В рипли по аспекту теперь спавнится cable layer за место нерабочего модуля.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
