### PR TITLE
glasses lighting alpha changes

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -48,7 +48,7 @@
 	toggleable = TRUE
 	sightglassesmod = "meson"
 	vision_flags = SEE_TURFS
-	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_goggles)
 
 /datum/action/item_action/hands_free/toggle_goggles
@@ -276,7 +276,7 @@
 	activation_sound = 'sound/effects/glasses_switch.ogg'
 	sightglassesmod  = "hos"
 	darkness_view = 7
-	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	flash_protection = FLASHES_AMPLIFIER
 	flash_protection_slots = list(SLOT_GLASSES)
 	item_action_types = list(/datum/action/item_action/switch_shades_mode)

--- a/code/modules/mining/scanners.dm
+++ b/code/modules/mining/scanners.dm
@@ -59,7 +59,7 @@
 	sightglassesmod = "sepia"
 	hud_types = list(DATA_HUD_MINER)
 	vision_flags = SEE_TURFS
-	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_goggles)
 
 /datum/action/item_action/hands_free/toggle_goggles

--- a/code/modules/mining/scanners.dm
+++ b/code/modules/mining/scanners.dm
@@ -67,6 +67,7 @@
 /obj/item/clothing/glasses/hud/mining/ancient
 	name = "Ancient Mining Hud MK II"
 	desc = "This hud for mine work in hostile territory, with builded bioscanner inside."
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	icon = 'icons/obj/xenoarchaeology/finds.dmi'
 	icon_custom = 'icons/mob/eyes.dmi'
 	icon_state = "HUDmining"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Пофиксил то что шахтёрские термалы не показывали мобов сквозь стены
Поменял лайтинг альфу у мезонок и ПНВ ХОСа

![test0](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/546f26b8-bd86-4406-86dc-a6835534b367)
(без очков, лампы были убраны специально)

<details>
  <summary>Мезонки</summary>
Новое:

![test1](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/076f3300-c501-4554-beb9-5e52779e911e)

Старое:

![test12](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/6961565a-67c8-4922-b60e-2da37d2bd290)

</details>

<details>
  <summary>ПНВ хоса</summary>
Новое:

![test2](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/32989c2e-ce14-4a53-9963-8a16e6daf48b)

Старое:

![test22](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/705d6617-7e2a-45c0-9003-b12388ed7bc6)


</details>

## Почему и что этот ПР улучшит
Фикс бага
И ещё с включенными мезонками/ПНВ ХОСа игра не будет выглядеть так вырвиглазно.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Продвинутые шахтёрские очки не показывали мобов сквозь стены.
- tweak: Во включённых мезонках и очках ХоСа видно тьму.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
