### PR TITLE
револьвер пробивает броню

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -74,8 +74,8 @@
 	damage = 25
 
 /obj/item/projectile/bullet/revbullet //.357
-	damage = 60
-	armor_multiplier = 1.5
+	damage = 35
+	armor_multiplier = 0.6
 
 /obj/item/projectile/bullet/rifle1
 	damage = 40


### PR DESCRIPTION
Теперь пули револьвера наносит меньше урона, но пробивают броню

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Урон пулей револьвера уменьшен с 60 до 35, модификатор брони изменен с 1.5 на 0.6.
## Почему и что этот ПР улучшит
Из-за модификатора брони 1.5 получалось так, что даже стечкин наносит больше урона по бронированным целям, чем револьвер, а по буллетпруфу патронами .357 урона не наносилось вовсе. Револьвер стоит дороже стечкина и трейтору нужно потратиться на барабан чтобы иметь возможность быстро его перезаряжать, в то время как магазины для стечкина доступны в взломанном автолате, и даже у лидера ядерных оперативников имеется револьвер, а у остальных нюкеров простой стечкин, так что по идее револьвер должен быть лучше в бою. Гибать головы ничего не ожидающим людям, несомненно, весело и убийце и жертве, но повоевать тоже иногда хочется.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
