### PR TITLE
flare light_color fix

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -23,7 +23,6 @@
 /obj/item/device/flashlight/atom_init()
 	. = ..()
 	update_brightness()
-	update_item_actions()
 
 /obj/item/device/flashlight/proc/update_brightness(mob/user = null)
 	if(on)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -11,6 +11,7 @@
 	g_amt = 20
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_flashlight)
 	light_color = "#ffffff"
+	light_power = 0.6
 	var/on = 0
 	var/button_sound = 'sound/items/flashlight.ogg' // Sound when using light
 	var/brightness_on = 5 //luminosity when on
@@ -27,7 +28,7 @@
 /obj/item/device/flashlight/proc/update_brightness(mob/user = null)
 	if(on)
 		icon_state = "[initial(icon_state)]-on"
-		set_light(brightness_on, 0.6, light_color)
+		set_light(brightness_on)
 	else
 		icon_state = initial(icon_state)
 		set_light(0)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -11,7 +11,7 @@
 	g_amt = 20
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_flashlight)
 	light_color = "#ffffff"
-	light_power = 0.6
+	light_power = 1
 	var/on = 0
 	var/button_sound = 'sound/items/flashlight.ogg' // Sound when using light
 	var/brightness_on = 5 //luminosity when on
@@ -169,6 +169,7 @@
 	desc = "Маленькая лампа."
 	icon_state = "lampsmall"
 	brightness_on = 3
+	light_power = 0.6
 	light_color = "#ffb46b"
 
 	glow_icon_state = "lampsmall"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -10,10 +10,10 @@
 	m_amt = 50
 	g_amt = 20
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_flashlight)
+	light_color = "#ffffff"
 	var/on = 0
 	var/button_sound = 'sound/items/flashlight.ogg' // Sound when using light
 	var/brightness_on = 5 //luminosity when on
-	var/lightcolor = "#ffffff"
 	var/last_button_sound = 0 // Prevents spamming for Object lights
 
 /datum/action/item_action/hands_free/toggle_flashlight
@@ -27,7 +27,7 @@
 /obj/item/device/flashlight/proc/update_brightness(mob/user = null)
 	if(on)
 		icon_state = "[initial(icon_state)]-on"
-		set_light(brightness_on, 0.6, lightcolor)
+		set_light(brightness_on, 0.6, light_color)
 	else
 		icon_state = initial(icon_state)
 		set_light(0)
@@ -168,7 +168,7 @@
 	desc = "Маленькая лампа."
 	icon_state = "lampsmall"
 	brightness_on = 3
-	lightcolor = "#ffb46b"
+	light_color = "#ffb46b"
 
 	glow_icon_state = "lampsmall"
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
поменял у фонариков переменную lightcolor на light_color
(Гусев зачем-то добавил отдельную переменную lightcolor, она используется только у одного светильника, в то время как у всех остальных фонариков/флаеров/etc прописан только light_color)
## Почему и что этот ПР улучшит
fixes #12312
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Фальшфейер светился белым светом, а не красным.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
