### PR TITLE
Возврат многозарядного гранатомета на станции.

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -3243,13 +3243,18 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
-/obj/item/weapon/gun/projectile/grenade_launcher/m79,
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	name = "Weapons locker"
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/item/weapon/gun/projectile/grenade_launcher/m79{
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/grenadelauncher{
+	pixel_y = -3
 	},
 /turf/simulated/floor,
 /area/station/security/armoury)
@@ -81899,11 +81904,6 @@
 	icon_state = "barber"
 	},
 /area/station/civilian/locker)
-"qoQ" = (
-/obj/machinery/light/small,
-/obj/machinery/light/small,
-/turf/simulated/floor/engine,
-/area/station/rnd/xenobiology)
 "qoS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -133235,7 +133235,7 @@ kZn
 cjv
 cjr
 ckC
-qoQ
+kZn
 cjv
 cuL
 cey

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -6894,11 +6894,16 @@
 /area/station/security/armoury)
 "alr" = (
 /obj/structure/rack,
-/obj/item/weapon/gun/projectile/grenade_launcher/m79,
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "delivery"
 	},
 /obj/machinery/door/window/brigdoor/northleft,
+/obj/item/weapon/gun/grenadelauncher{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/projectile/grenade_launcher/m79{
+	pixel_y = 6
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -70543,9 +70543,14 @@
 /area/station/maintenance/chapel)
 "qIs" = (
 /obj/structure/rack,
-/obj/item/weapon/gun/projectile/grenade_launcher/m79,
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
+	},
+/obj/item/weapon/gun/projectile/grenade_launcher/m79{
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/grenadelauncher{
+	pixel_y = -3
 	},
 /turf/simulated/floor{
 	icon_state = "dark"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил многозарядный гранатомет в оружейную Бокса, Прометея, Дельты.
Удалил дубликат лампы в ксенобиологии Бокса.
## Почему и что этот ПР улучшит
Возврат потерянного оружия в каком-то из ремапов, который потянулся дальше на другие карты. 
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - map: Многозарядный гранатомет вернули в оружейные на всех станциях.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
