### PR TITLE
Хэви риг доступен только для войны и лонопа

### DIFF
--- a/code/game/machinery/vending/other.dm
+++ b/code/game/machinery/vending/other.dm
@@ -320,6 +320,12 @@
 		"Assault Armor" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "assaultarmor"),
 	)
 
+/obj/machinery/vending/syndi/proc/armourpopulate_selection_noheavy()
+	selections_armor = list(
+		"Hybrid suit" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "rig-syndie-combat"),
+		"Assault Armor" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "assaultarmor"),
+	)
+
 /obj/machinery/vending/syndi/proc/givekit(obj/voucher, mob/user)
 	var/selection = show_radial_menu(user, src, selections_kits, require_near = TRUE, tooltips = TRUE)
 	if(voucher.in_use)
@@ -352,11 +358,14 @@
 		S.uplink_purchases += stat
 
 /obj/machinery/vending/syndi/proc/givearmor(obj/voucher, mob/user)
+	if(isrole(LONE_OP, user))
+		armourpopulate_selection()
+	else if(!war_device_activated)
+		armourpopulate_selection_noheavy()
+	else armourpopulate_selection()
 	var/selection = show_radial_menu(user, src, selections_armor, require_near = TRUE, tooltips = TRUE)
 	if(voucher.in_use)
 		return
-	if(!selections_armor)
-		armourpopulate_selection()
 	if(!selection || !Adjacent(user))
 		return
 	voucher.in_use = TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Хэви риг может купить только лоноп или если объявить войну
## Почему и что этот ПР улучшит
Баланс наверное. Хэви риг имеет защиты почти как у дедсквадовцев. Я думаю это слишком жирно, если нет войны. Обычный риг синдикатовцев практически на уровне ОБРовских и его вполне достаточно без войны. Лоноп один и его обычно гасят толпой, поэтому ему норм иметь хэви риг.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:

- balance: Тяжёлые риги Синдиката доступны только во время войны и для Одиночного оперативника Синдиката.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
