### PR TITLE
Фикс нестов

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -62,6 +62,6 @@
 		if(BURN)
 			playsound(loc, 'sound/items/welder.ogg', VOL_EFFECTS_MASTER, 100, TRUE)
 
-/obj/structure/bed/nest/post_buckle_mob(mob/living/buckling_mob)
+/obj/structure/stool/bed/nest/post_buckle_mob(mob/living/buckling_mob)
 	. = ..()
 	buckling_mob.reagents.add_reagent("xenojelly_n", 30)


### PR DESCRIPTION

## Описание изменений

Несты не лечили, а были должны.

## Почему и что этот ПР улучшит

Несты теперь лечат хостов.

## Авторство

Nasend_, Maleyvich

## Чеинжлог

:cl:

- bugfix: Гнёзда ксеноморфов не лечили  людей на них

