### PR TITLE
Убирает отстегивание от стула при наручах

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -942,7 +942,7 @@
 	//breaking out of handcuffs and putting off fires
 	if(iscarbon(L))
 		var/mob/living/carbon/CM = L
-		if(CM.on_fire && CM.canmove)
+		if(CM.on_fire && CM.canmove && !CM.buckled)
 			CM.fire_stacks -= 5
 			CM.Stun(5)
 			CM.Weaken(5)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -942,7 +942,7 @@
 	//breaking out of handcuffs and putting off fires
 	if(iscarbon(L))
 		var/mob/living/carbon/CM = L
-		if(CM.on_fire && CM.canmove && !CM.buckled)
+		if(CM.on_fire && CM.canmove && !(CM.lying || CM.crawling))
 			CM.fire_stacks -= 5
 			CM.Stun(5)
 			CM.Weaken(5)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -920,7 +920,7 @@
 			if (istype(C.buckled,/obj/structure/stool/bed/nest))
 				C.buckled.user_unbuckle_mob(C)
 				return
-			if(C.handcuffed || istype(C.buckled, /obj/machinery/optable/torture_table))
+			if(istype(C.buckled, /obj/machinery/optable/torture_table))
 				C.next_move = world.time + 100
 				C.last_special = world.time + 100
 				C.visible_message("<span class='danger'>[usr] attempts to unbuckle themself!</span>", self_message = "<span class='rose'>You attempt to unbuckle yourself. (This will take around 2 minutes and you need to stand still)</span>")
@@ -940,10 +940,9 @@
 			C.container_resist(L)
 
 	//breaking out of handcuffs and putting off fires
-	else if(iscarbon(L))
+	if(iscarbon(L))
 		var/mob/living/carbon/CM = L
-		if(CM.on_fire)
-			if(!CM.canmove && !CM.crawling)	return
+		if(CM.on_fire && CM.canmove)
 			CM.fire_stacks -= 5
 			CM.Stun(5)
 			CM.Weaken(5)
@@ -976,7 +975,7 @@
 				CM.visible_message("<span class='danger'>[usr] attempts to remove \the [HC]!</span>", self_message = "<span class='notice'>You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)</span>")
 				spawn(0)
 					if(do_after(CM, breakouttime, target = usr))
-						if(!CM.handcuffed || CM.buckled)
+						if(!CM.handcuffed)
 							return // time leniency for lag which also might make this whole thing pointless but the server lags so hard that 40s isn't lenient enough - Quarxink
 						if(istype(HC, /obj/item/weapon/handcuffs/alien))
 							CM.visible_message("<span class='danger'>[CM] break in a discharge of energy!</span>", \


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убирает 2-х минутное отстегивание от стула, кроватей и т.п. если ты закован в наручники. Вместо этого сразу идёт прогресс бар рассковки наручей. На столе пыток по прежнему нужно сначала отстегнуться от стола, а потом снимать наручники.

Немного переделал логику тушения резистом чтоб всё работало под эти изменения. Убрал лишнюю как по мне проверку на crawling.
## Почему и что этот ПР улучшит
Немного легче сделает жизнь тех кто в наручах. Вместо четырех минут (если никто не мешает) нужно две минуты на освобождение. Две минуты вполне нормально как по мне.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - tweak: При освобождение из наручников не нужно 2 минуты отстегиваться от стула, кроватей и т.п.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
