### PR TITLE
Лицехваты более не вызывают рвоту, когда умирают

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
@@ -355,9 +355,6 @@
 
 	playsound(src, 'sound/voice/xenomorph/facehugger_dies.ogg', VOL_EFFECTS_MASTER)
 	visible_message("<span class='warning'>[src] curls up into a ball and exudes a strange substance!</span>")
-	for(var/mob/living/carbon/human/H in view(1, src))
-		if(!mouth_is_protected())
-			H.invoke_vomit_async()
 
 /obj/item/clothing/mask/facehugger/verb/hide_fh()
 	set name = "Спрятать"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
у ксеносов и так достаточно станов чтоб ловить людей, это уже слишком.
## Авторство
maleyvich, идею дал симбака
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: maleyvich
- tweak: Лицехваты более не вызывают рвоту у окружающих, когда умирают.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
