### PR TITLE
facehuggers vomit fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
@@ -356,7 +356,7 @@
 	playsound(src, 'sound/voice/xenomorph/facehugger_dies.ogg', VOL_EFFECTS_MASTER)
 	visible_message("<span class='warning'>[src] curls up into a ball and exudes a strange substance!</span>")
 	for(var/mob/living/carbon/human/H in view(1, src))
-		if(!mouth_is_protected())
+		if(!mouth_is_protected(H.wear_mask))
 			H.invoke_vomit_async()
 
 /obj/item/clothing/mask/facehugger/verb/hide_fh()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Оказывается, [на протяжении двух лет](https://github.com/TauCetiStation/TauCetiClassic/pull/10489) в игре существовал крайне неприятный баг, а точнее: маски не защищали от рвоты после смерти фейсхаггера!
## Почему и что этот ПР улучшит
меньше багов
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka

- fix: Смерть лицехвата вызывала рвоту, даже если на персонаже была защитная маска.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
