### PR TITLE
Эктоплазму теперь можно дробить на научные очки

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -149,6 +149,7 @@ var/global/list/uncommon_loot = list(
 		/obj/item/weapon/grenade/cancasing = 1,
 		/obj/item/weapon/melee/cattleprod = 1,
 		/obj/item/weapon/throwing_star = 1,
+		/obj/item/weapon/reagent_containers/food/snacks/ectoplasm = 1,
 		) = 8,
 
 	list(
@@ -210,6 +211,7 @@ var/global/list/oddity_loot = list(
 		/obj/item/clothing/suit/armor/vest/reactive = 1,
 		/obj/item/weapon/storage/pouch/medium_generic = 1,
 		/obj/item/weapon/storage/pouch/small_generic = 1,
+		/obj/item/weapon/reagent_containers/food/snacks/ectoplasm = 1,
 	)
 
 //Maintenance loot spawner pools

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3445,6 +3445,7 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "ectoplasm"
 	list_reagents = list("ectoplasm" = 5)
+	origin_tech = "biotech=5"
 	food_type = JUNK_FOOD
 	food_moodlet = /datum/mood_event/junk_food
 

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -76565,6 +76565,7 @@
 "kjb" = (
 /obj/structure/stool,
 /obj/effect/decal/remains/human,
+/obj/item/weapon/inflatable_duck,
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -76565,7 +76565,6 @@
 "kjb" = (
 /obj/structure/stool,
 /obj/effect/decal/remains/human,
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -100490,7 +100490,6 @@
 	},
 /area/station/hallway/primary/starboard)
 "uQb" = (
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -1622,7 +1622,6 @@
 "acS" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
@@ -18594,7 +18593,6 @@
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "cXz" = (
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
@@ -40536,7 +40534,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "hrc" = (
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
@@ -40592,7 +40589,6 @@
 "hrT" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -66560,7 +66556,6 @@
 	pixel_x = -4;
 	pixel_y = 7
 	},
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /turf/simulated/floor/garden{
 	icon_state = "asteroid3"
 	},
@@ -83058,7 +83053,6 @@
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "pWm" = (
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "pWn" = (
@@ -88633,7 +88627,6 @@
 /area/station/tcommsat/chamber)
 "rbk" = (
 /obj/structure/stool/bed/chair/e_chair,
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "rbl" = (
@@ -115319,7 +115312,6 @@
 "wqc" = (
 /obj/item/clothing/shoes/laceup,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "wqj" = (
@@ -120416,7 +120408,6 @@
 	pixel_x = -3;
 	pixel_y = 10
 	},
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -451,7 +451,6 @@
 /area/station/medical/genetics)
 "aaF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/item/weapon/pen,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
@@ -34991,7 +34990,6 @@
 	},
 /area/station/security/armoury)
 "hNj" = (
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -76781,7 +76779,6 @@
 /obj/item/weapon/storage/box/drinkingglasses,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
-/obj/item/weapon/reagent_containers/food/snacks/ectoplasm,
 /turf/simulated/floor/wood,
 /area/station/maintenance/brig)
 "snZ" = (


### PR DESCRIPTION

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Эктоплазму теперь можно дробить на научные очки в сумм 1500 очков
## Почему и что этот ПР улучшит
Разнобразие добычи очков
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->:cl: Riverz
 - tweak: Эктоплазму теперь можно дробить на научные очки
