### PR TITLE
Удалены изоляционные перчатки и солнцезащитные очки со одинаковых спаунов, а также добавлены в рандомные предметы разбросаные по тех тонелям на карте Box

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -162,6 +162,8 @@ var/global/list/uncommon_loot = list(
 		/obj/item/clothing/mask/muzzle = 1,
 		/obj/item/clothing/ears/earmuffs = 1,
 		/obj/item/clothing/gloves/black = 1,
+		/obj/item/clothing/gloves/insulated = 1,
+		/obj/item/clothing/glasses/sunglasses = 1,
 		) = 8,
 
 	list(

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -21799,7 +21799,6 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "aMG" = (
-/obj/item/clothing/gloves/insulated,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet,
 /turf/simulated/floor/plating,
@@ -68315,7 +68314,6 @@
 "cIQ" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/coloured,
-/obj/item/clothing/glasses/sunglasses,
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -76091,7 +76089,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jMb" = (
-/obj/item/clothing/gloves/insulated,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,


### PR DESCRIPTION

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Удалил с однаковых спаунов очки и изолционные перчатки, но добавил в рандомный спаун по тех тонелям
## Почему и что этот ПР улучшит
Меньше манча
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->:cl: Riverz
 - tweak: Удалены изоляционные перчатки и солнцезащитные очки со одинаковых спаунов, а также добавлены в рандомные предметы разбросаные по тех тонелям на карте Box
