### PR TITLE
Возвращение термита к играбельному состоянию

### DIFF
--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -12,7 +12,7 @@
 
 	sheet_type = /obj/item/stack/sheet/plasteel
 
-	seconds_to_melt = 60
+	seconds_to_melt = 10
 
 	var/d_state = INTACT
 

--- a/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
@@ -125,7 +125,7 @@
 
 /datum/reagent/thermite/reaction_turf(turf/T, volume)
 	. = ..()
-	if(volume >= 30)
+	if(volume >= 15)
 		if(iswallturf(T))
 			var/turf/simulated/wall/W = T
 			W.thermite = 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

С учётом нынешней реализации скиллов термит в том состоянии, в который его завели стал абсолютно бесполезным, теперь он снова прожигает стены 10 секунд, требует 15 юнитов для использования. У нас его нерфили из-за малфа, но малфа больше нет, а термит всё так же неюзабелен

## Почему и что этот ПР улучшит

Термит снова играбельный

## Авторство

@L4rever 

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- balance: Термит прожигает все стены теперь за 10 секунд и требует 15 юнитов для этого
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
