### PR TITLE
Clickplace: Fixes shoving and slamming.

### DIFF
--- a/code/datums/components/clickplace.dm
+++ b/code/datums/components/clickplace.dm
@@ -197,7 +197,7 @@
 		victim.Weaken(5)
 	victim.apply_damage(8, def_zone = BP_HEAD)
 	victim.visible_message("<span class='danger'>[assailant] slams [victim]'s face against \the [A]!</span>")
-	playsound(src, 'sound/weapons/tablehit1.ogg', VOL_EFFECTS_MASTER)
+	playsound(parent, 'sound/weapons/tablehit1.ogg', VOL_EFFECTS_MASTER)
 
 	victim.log_combat(assailant, "face-slammed against \the [parent]")
 	return FALSE
@@ -217,7 +217,7 @@
 		victim.visible_message("<span class='danger'>[assailant] shoves [victim] into [A]!</span>")
 
 		step_towards(victim, A)
-		qdel(src)
+		qdel(G)
 		return
 
 	assailant.SetNextMove(CLICK_CD_MELEE)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Удаляет граб а не компоненту при сламе.

Проигрывает звук лицастола при применении лица к столу.

## Почему и что этот ПР улучшит

1. Исправит багу с тем что после засовывания кого-то перетаскиванием в шкаф на шкаф нельзя класть вещи.
2. Звукоатмосфера удара об стол.

Никто не заметил проблему поэтому никакого ченжлога. Всё всегда работало как надо.
