### PR TITLE
syndicate bomb Взрывается в два раза сильнее

### DIFF
--- a/code/game/machinery/syndie_big_bomb.dm
+++ b/code/game/machinery/syndie_big_bomb.dm
@@ -36,7 +36,7 @@
 /obj/machinery/syndicatebomb/proc/try_detonate(ignore_active = FALSE)
 	. = !degutted && (active || ignore_active)
 	if(.)
-		explosion(loc, 2, 5, 11)
+		explosion(loc, 4, 10, 22)
 		degutted = TRUE // prevent double caboom
 		qdel(src)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Тепреь syndicate bomb взрвыается в два раза сильнее чем раньше
## Почему и что этот ПР улучшит
Появлется чуть больше логики игры и эту бомбу буду использовать чаще.
Это бомба проигрывает лимитки во всем, начиная от таймера в 60 секунд, заканчивая слабым взрывом и тем что её нужно закрепить и после активации она будет громоко пикать, дак ещё её можно разминировать.
Да и взять в расчет цель то это добавит чуть больше хаоса, а то сейчас это выглядит как пук, а не взрыв
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->:cl: Riverz
 - balance: syndicate bomb Взрывается в два раза сильнее
