### PR TITLE
Исправление бага с плевком мага

### DIFF
--- a/code/datums/spells/in_hand.dm
+++ b/code/datums/spells/in_hand.dm
@@ -189,8 +189,8 @@
 /obj/item/projectile/neurotoxin/magic
 	name = "toxin"
 	damage = 40
-	weaken = 1
-	stun = 4
+	weaken = 4
+	stun = 1
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "neurotoxin"
 	flag = "magic"

--- a/code/datums/spells/in_hand.dm
+++ b/code/datums/spells/in_hand.dm
@@ -190,6 +190,7 @@
 	name = "toxin"
 	damage = 40
 	weaken = 1
+	stun = 4
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "neurotoxin"
 	flag = "magic"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
плевок мага станил на 10 секунд из-за наследования переменной stun у /obj/item/projectile/neurotoxin. вряд-ли это так задумывалось, учитывая что щас там и так стоит односекундный weaken. теперь плевок мага станит на 1 секунду, а weaken длится 4.
## Почему и что этот ПР улучшит
исправляем баги (или нет?) таукотии
## Авторство
maleyvich
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: maleyvich
- bugfix: Способность мага "Кислотный Чих" оглушала цель на более большее время, чем планировалось.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
