### PR TITLE
Fix_Bump

### DIFF
--- a/code/game/gamemodes/modes_gameplays/blob/blobs/shield.dm
+++ b/code/game/gamemodes/modes_gameplays/blob/blobs/shield.dm
@@ -36,9 +36,7 @@
 			var/new_x = P.starting.x + pick(0, 0, 0, 0, -1, 1, -2, 2, -3, 3)
 			var/new_y = P.starting.y + pick(0, 0, 0, 0, -1, 1, -2, 2, -3, 3)
 			var/turf/curloc = get_turf(src)
-			if(OV) //If we have an overmind to blame this shot on
-				P.redirect(new_x, new_y, curloc, OV) //Stolen from armor' deflection
-				return PROJECTILE_FORCE_MISS
-			P.redirect(new_x, new_y, curloc) //Stolen from armor' deflection
+
+			P.redirect(new_x, new_y, curloc, src) //Stolen from armor' deflection
 			return PROJECTILE_FORCE_MISS
 	return ..()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -137,7 +137,7 @@
 	return target == output //Send it back to the gun!
 
 //Used to change the direction of the projectile in flight.
-/obj/item/projectile/proc/redirect(new_x, new_y, atom/starting_loc, mob/new_firer=null)
+/obj/item/projectile/proc/redirect(new_x, new_y, atom/starting_loc, atom/new_firer=null)
 	original = locate(new_x, new_y, src.z)
 	starting = starting_loc
 	current = starting_loc

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -177,7 +177,7 @@
 	return FALSE
 
 /obj/item/projectile/Bump(atom/A, forced=0)
-	if((bumped && !forced))
+	if((bumped && !forced) || (A == src))
 		return 0
 
 	var/turf/A_loc = isturf(A) ?  A : A.loc


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Пофиксил баг #13216
## Почему и что этот ПР улучшит
Лазеры теперь снова могут рикошетить обратно в стреляющего. 
## Авторство
Risraivyn
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
Лазеры снова могут отражаться.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:  Risraivyn
- bugfix: Пофикшен баг с отражением лазеров.