### PR TITLE
Фикс невозможности сделать укрепленные плитки из форонного стекла

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -30,7 +30,7 @@ var/global/list/datum/stack_recipe/glass_reinforced_recipes = list (
 
 var/global/list/datum/stack_recipe/glass_reinforced_phoron_recipes = list (
 	new/datum/stack_recipe("thin windows", /obj/structure/window/thin/reinforced/phoron, 1, time = 5, max_per_turf = 4, build_outline = TRUE),
-	new/datum/stack_recipe("glass tile", /obj/item/stack/tile/glass/reinforced, 1, 4, 20, required_skills = list(/datum/skill/construction = SKILL_LEVEL_NOVICE)),
+	new/datum/stack_recipe("glass tile", /obj/item/stack/tile/glass/reinforced/phoron, 1, 4, 20, required_skills = list(/datum/skill/construction = SKILL_LEVEL_NOVICE)),
 )
 
 /*


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
багфикс
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- bugfix: Из укреплённого форонного стекла получались плитки укреплённого обычного пола.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
