### PR TITLE
Уменьшение кулдауна посоху анимации и посохоу огненных шаров

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -13,6 +13,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/animate
 	icon_state = "staffofanimation"
 	item_state = "staffofanimation"
+	recharge_rate = 5
 
 /obj/item/weapon/gun/magic/healing
 	name = "staff of healing"
@@ -36,3 +37,4 @@
 	item_state = "lavastaff"
 	desc = "An artefact that spits a fireball."
 	ammo_type = /obj/item/ammo_casing/magic/fireball
+	recharge_rate = 5


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Уменьшил куладаун посоху анимации и посоху огненных шаров
## Почему и что этот ПР улучшит
На данный момент посохи просто не играбельны если ты не мирно маг, а учитывая какие у нас посохи есть часть из них становится бесполезной а все из-за пары факторов: посох огромный и его можно носить только за спиной, у посохов большой куладаун, посохи дорогие. Чтобы сделать посохи более превлекательными я добавил им меньший кулдан.
Проще говоря ПР делает посохи более играбельными в реалиях тау
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->:cl: Riverz
- balance: Уменьшение кулдауна посоху анимации и посохоу огненных шаров