### PR TITLE
доукрепляем отсеки на боксе

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -23017,9 +23017,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/brainstorm_center)
-"aPa" = (
-/turf/simulated/wall,
-/area/station/rnd/hor)
 "aPb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -119840,7 +119837,7 @@ aaa
 cAd
 cAd
 cAd
-aaV
+rnU
 aaV
 aaV
 aaV
@@ -120097,7 +120094,7 @@ aaa
 cAd
 aaa
 aaa
-aaV
+rnU
 aaA
 aaP
 aaV
@@ -120354,7 +120351,7 @@ aaa
 cAd
 aaa
 qDo
-aaV
+rnU
 aaz
 aaO
 abb
@@ -120611,7 +120608,7 @@ aaa
 cAd
 aaa
 aah
-aaV
+rnU
 aaC
 aaQ
 aaV
@@ -120868,7 +120865,7 @@ aaa
 cAd
 aaa
 aah
-aaV
+rnU
 bQb
 bQb
 aaV
@@ -121125,7 +121122,7 @@ aaa
 cAd
 aaa
 aah
-aaV
+rnU
 fJb
 fKb
 aaV
@@ -121382,10 +121379,10 @@ aaa
 cAd
 aah
 mUK
-aaV
-aaV
-aaV
-aaV
+rnU
+rnU
+rnU
+rnU
 aEy
 acl
 aSb
@@ -121899,15 +121896,15 @@ aah
 aah
 cAd
 aaa
+rnU
+rnU
+rnU
+rnU
 aaV
-aaV
-aaV
-aaV
-aaV
-aaV
-aaV
-aaV
-aaV
+rnU
+rnU
+rnU
+rnU
 adj
 agg
 aem
@@ -126057,7 +126054,7 @@ aJh
 aKX
 aMs
 aHV
-aPa
+bAU
 aQo
 aRo
 aSS
@@ -126314,7 +126311,7 @@ aHW
 aLd
 aMt
 aFI
-aPa
+bAU
 aQp
 aRq
 bEo
@@ -126571,7 +126568,7 @@ aHX
 aLe
 aMu
 aNL
-aPa
+bAU
 aQt
 bFC
 bFE
@@ -126828,7 +126825,7 @@ aHY
 aLf
 aMv
 aNM
-aPa
+bAU
 aQu
 aRr
 aST
@@ -127085,7 +127082,7 @@ aJi
 aLh
 aMx
 aNN
-aPa
+bAU
 aQv
 aRu
 aSU

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -121900,7 +121900,7 @@ rnU
 rnU
 rnU
 rnU
-aaV
+rnU
 rnU
 rnU
 rnU


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
добавлены укрепстенки для кабинета рд со стороны склада токсинной
![image](https://github.com/user-attachments/assets/855e082f-654c-40ea-a5dc-fa5b0ebe381d)
добавлены укрепстенки для брига со стороны космоса
![image](https://github.com/user-attachments/assets/61877089-972f-44dc-9585-940080dcda2d)
## Почему и что этот ПР улучшит
мне кажется логичным поставить укрепстенки в этих местах, это ВОЗМОЖНО усложнит раш нюкеров через бриг и теперь кабинет рд не будет страдать от взрывов бомбы в складе токсинной (сомневаюсь что это так надо)
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: maleyvich
- map: Бриг и кабинет РД "Исходе" стали более укрепленными.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
