### PR TITLE
Ротация отделов на боксе

### DIFF
--- a/code/game/area/station_areas.dm
+++ b/code/game/area/station_areas.dm
@@ -672,6 +672,11 @@ ADD_TO_GLOBAL_LIST(/area/station, the_station_areas)
 	icon_state = "sec_prison"
 	ambience = list('sound/ambience/prison_1.ogg')
 
+/area/station/security/visiting_room
+	name = "Visiting Room"
+	cases = list("комната для свиданий", "комнаты для свиданий", "комнате для свиданий", "комната для свиданий", "комнатой для свиданий", "комнатой для свиданий")
+	icon_state = "sec_prison"
+
 /area/station/security/prison/toilet
 	name = "Prison Toilet"
 	cases = list("тюремный туалет", "тюремного туалета", "тюремному туалету", "тюремный туалет", "тюремным туалетом", "тюремном туалете")

--- a/code/game/area/station_areas.dm
+++ b/code/game/area/station_areas.dm
@@ -676,11 +676,6 @@ ADD_TO_GLOBAL_LIST(/area/station, the_station_areas)
 	icon_state = "sec_prison"
 	ambience = list('sound/ambience/prison_1.ogg')
 
-/area/station/security/visiting_room
-	name = "Visiting Room"
-	cases = list("комната для свиданий", "комнаты для свиданий", "комнате для свиданий", "комната для свиданий", "комнатой для свиданий", "комнатой для свиданий")
-	icon_state = "sec_prison"
-
 /area/station/security/prison/toilet
 	name = "Prison Toilet"
 	cases = list("тюремный туалет", "тюремного туалета", "тюремному туалету", "тюремный туалет", "тюремным туалетом", "тюремном туалете")

--- a/code/game/area/station_areas.dm
+++ b/code/game/area/station_areas.dm
@@ -453,7 +453,7 @@ ADD_TO_GLOBAL_LIST(/area/station, the_station_areas)
 
 /area/station/civilian/hydroponics/old
 	name = "Old Hydroponics"
-	cases = list("старая гидропоника", "старой гидропоники", "старой гидропоникой", "старая гидропоника", "старой гидропониками", "старой гидропонике")
+	cases = list("старая гидропоника", "старой гидропоники", "старой гидропонике", "старую гидропонику", "старой гидропоникой", "старой гидропонике")
 
 //Holodeck
 /area/station/civilian/holodeck

--- a/code/game/area/station_areas.dm
+++ b/code/game/area/station_areas.dm
@@ -453,7 +453,7 @@ ADD_TO_GLOBAL_LIST(/area/station, the_station_areas)
 
 /area/station/civilian/hydroponics/old
 	name = "Old Hydroponics"
-	cases = list("старые гидропоники", "старых гидропоник", "старым гидропоникам", "старые гидропоники", "старыми гидропониками", "старых гидропониках")
+	cases = list("старая гидропоника", "старой гидропоники", "старой гидропоникой", "старая гидропоника", "старой гидропониками", "старой гидропонике")
 
 //Holodeck
 /area/station/civilian/holodeck

--- a/code/game/area/station_areas.dm
+++ b/code/game/area/station_areas.dm
@@ -451,6 +451,10 @@ ADD_TO_GLOBAL_LIST(/area/station, the_station_areas)
 	cases = list("гидропоники", "гидропоник", "гидропоникам", "гидропоник", "гидропониками","гидропониках")
 	icon_state = "hydro"
 
+/area/station/civilian/hydroponics/old
+	name = "Old Hydroponics"
+	cases = list("старые гидропоники", "старых гидропоник", "старым гидропоникам", "старые гидропоники", "старыми гидропониками", "старых гидропониках")
+
 //Holodeck
 /area/station/civilian/holodeck
 	name = "Holodeck"

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -44358,14 +44358,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bBx" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/random/vending/snack,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/hallway/primary/central)
 "bBy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74033,10 +74031,13 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "icr" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
 "idb" = (
@@ -77689,10 +77690,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lHr" = (
-/obj/random/vending/snack,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
 "lIb" = (
@@ -78286,11 +78287,11 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "mlb" = (
-/obj/item/weapon/flora/random,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
+/obj/machinery/color_mixer,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -81204,8 +81205,7 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "pGk" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -113078,10 +113078,10 @@ atB
 biL
 atG
 axN
-bQl
-bQl
-bQl
-bQl
+bIZ
+bIZ
+bIZ
+bIZ
 cKa
 bBB
 bzS
@@ -113335,12 +113335,12 @@ awt
 bJM
 axN
 axN
-aMR
-aMR
-aMR
-bIZ
-bIZ
 bBx
+lHr
+icr
+bIZ
+bPF
+bBD
 bCE
 ckS
 bQl
@@ -113592,8 +113592,8 @@ aws
 aIR
 aIR
 aIR
-lHr
-icr
+bht
+bht
 pGk
 bIZ
 jMb

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9564,20 +9564,6 @@
 	icon_state = "red"
 	},
 /area/station/security/lobby)
-"apV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "apW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -11444,11 +11430,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -14187,6 +14168,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "ayr" = (
@@ -16064,9 +16050,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/cable,
 /turf/simulated/wall/r_wall,
 /area/station/security/visiting_room)
 "aBP" = (
@@ -18884,13 +18868,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/genetics_cloning)
-"aHq" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -43616,6 +43593,16 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
+"bzI" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -47110,20 +47097,6 @@
 	icon_state = "dark"
 	},
 /area/station/storage/tech)
-"bFW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
@@ -47300,14 +47273,6 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
-"bGn" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable,
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "bGo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69226,8 +69191,14 @@
 	},
 /area/station/hallway/primary/central)
 "cMR" = (
-/turf/environment/space,
-/area/station/bridge/hop_office)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "cMW" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/red,
@@ -74224,6 +74195,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"icK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -76479,15 +76464,12 @@
 	},
 /area/station/medical/reception)
 "kmt" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/prison)
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -85608,14 +85590,20 @@
 	},
 /area/station/civilian/toilet)
 "uHF" = (
-/obj/structure/table/reinforced,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "uIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -86965,6 +86953,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/photocopier,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -87349,6 +87338,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ygy" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -115482,9 +115480,9 @@ cIb
 aqz
 are
 ash
-kmt
+atr
 aNr
-bGn
+aBO
 bnA
 nYP
 wjo
@@ -115996,9 +115994,9 @@ apc
 cIb
 axL
 atN
-atr
+uHF
 avR
-aBO
+bzI
 bAf
 nYP
 bso
@@ -116298,7 +116296,7 @@ bcO
 bra
 bra
 bra
-cMR
+bra
 bra
 bra
 bzN
@@ -116512,10 +116510,10 @@ arn
 auc
 atq
 avS
-bGn
+aBO
 ark
 nYP
-ayq
+cMR
 bHu
 bIT
 adW
@@ -116772,8 +116770,8 @@ avV
 adW
 adW
 adW
-apV
-uHF
+ayq
+ygy
 bGs
 adW
 alZ
@@ -117026,10 +117024,10 @@ asU
 aso
 auR
 avW
-aBO
+bzI
 ayn
 nYP
-bFW
+icK
 bHu
 oLn
 adW
@@ -117288,7 +117286,7 @@ adW
 adW
 bzQ
 adW
-aHq
+kmt
 adW
 agO
 bNs

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36386,9 +36386,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bmS" = (
-/obj/machinery/hydroponics/constructable,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
+/area/station/security/iaa_office)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -47069,6 +47076,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
+"bFU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "bFV" = (
 /obj/machinery/requests_console/tech_storage{
 	pixel_y = -32
@@ -53945,6 +53957,10 @@
 	icon_state = "green"
 	},
 /area/station/hallway/primary/starboard)
+"bSY" = (
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "bSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -57270,17 +57286,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
-"cer" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
-/obj/structure/cable,
-/turf/simulated/floor{
-	icon_state = "darkblue"
-	},
-/area/station/security/iaa_office)
 "ces" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -69451,6 +69456,10 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/chiefs_office)
+"cXG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "cXS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -84710,10 +84719,6 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
-"tfv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
 "tfA" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -112806,7 +112811,7 @@ azD
 bjH
 bHl
 eKS
-cer
+bmS
 axN
 aMj
 cfq
@@ -132616,10 +132621,10 @@ csA
 cAL
 cBh
 cuo
-bmS
-bmS
-bmS
-bmS
+bSY
+bSY
+bSY
+bSY
 cbz
 aah
 aaa
@@ -133130,9 +133135,9 @@ cbz
 cEy
 cfB
 cil
-tfv
+cXG
 ddK
-tfv
+cXG
 itg
 eJE
 aah
@@ -133390,7 +133395,7 @@ bkt
 peN
 bkt
 peN
-bkt
+bFU
 qFY
 aah
 aah
@@ -133901,10 +133906,10 @@ ccR
 cew
 cfD
 cya
-bmS
-bmS
-bmS
-bmS
+bSY
+bSY
+bSY
+bSY
 cbz
 aah
 aaa

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11434,6 +11434,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -14171,6 +14176,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "ayr" = (
@@ -16048,6 +16058,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/structure/cable,
 /turf/simulated/wall/r_wall,
 /area/station/security/visiting_room)
 "aBP" = (
@@ -18865,6 +18876,16 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/genetics_cloning)
+"aHq" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -42110,12 +42131,6 @@
 	icon_state = "browncorner"
 	},
 /area/station/cargo/storage)
-"bxc" = (
-/obj/machinery/power/apc{
-	pixel_y = 2
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/iaa_office)
 "bxd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -42714,11 +42729,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bye" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barberы";
-	sortType = "Internal Affairs"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -43601,16 +43611,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
-"bzI" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -44994,12 +44994,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8;
-	name = "Internal Affairs";
-	sortType = "Internal Affairs"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Visiting Room";
+	sortType = "Barbershop"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "bCp" = (
@@ -47281,21 +47281,6 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
-"bGn" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/prison)
 "bGo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47350,6 +47335,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -47865,6 +47856,11 @@
 /area/station/maintenance/atmos)
 "bHu" = (
 /obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "bHv" = (
@@ -50026,6 +50022,11 @@
 /area/station/security/prison)
 "bLy" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -53083,6 +53084,12 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -69311,6 +69318,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "cPb" = (
@@ -74190,19 +74203,15 @@
 	},
 /area/station/hallway/primary/central)
 "icK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -76457,6 +76466,15 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"kmt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79594,12 +79612,8 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "nFG" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable,
-/turf/simulated/wall/r_wall,
+/obj/structure/table/reinforced,
+/turf/simulated/floor,
 /area/station/security/visiting_room)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
@@ -80714,7 +80728,7 @@
 	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
-	name = "Barbershop";
+	name = "Visiting Room";
 	sortType = "Barbershop"
 	},
 /obj/structure/cable{
@@ -81889,6 +81903,13 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"qvb" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "qvh" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NE"
@@ -85584,20 +85605,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
-"uHF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "uIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -85896,6 +85903,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"vDk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "vDF" = (
 /obj/item/clothing/under/rainbow,
 /turf/simulated/floor/wood,
@@ -87331,15 +87352,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ygy" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -112439,7 +112451,7 @@ biL
 bBM
 nSy
 bLy
-bxc
+axN
 bfn
 bIZ
 bIZ
@@ -115473,9 +115485,9 @@ cIb
 aqz
 are
 ash
-atr
+icK
 aNr
-nFG
+aBO
 bnA
 nYP
 wjo
@@ -115987,9 +115999,9 @@ apc
 cIb
 axL
 atN
-bGn
+atr
 avR
-bzI
+aHq
 bAf
 nYP
 bso
@@ -116503,11 +116515,11 @@ arn
 auc
 atq
 avS
-nFG
+aBO
 ark
 nYP
-ayq
-bHu
+kmt
+nFG
 bIT
 adW
 alZ
@@ -116763,8 +116775,8 @@ avV
 adW
 adW
 adW
-uHF
-ygy
+ayq
+bHu
 bGs
 adW
 alZ
@@ -117017,11 +117029,11 @@ asU
 aso
 auR
 avW
-bzI
+aHq
 ayn
 nYP
-icK
-bHu
+vDk
+nFG
 oLn
 adW
 alZ
@@ -117279,7 +117291,7 @@ adW
 adW
 bzQ
 adW
-aBO
+qvb
 adW
 agO
 bNs

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10967,23 +10967,15 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "lawyer_blast";
-	name = "Internal Affairs";
-	opacity = 0
-	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "asx" = (
 /turf/simulated/floor{
@@ -13112,24 +13104,13 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/command/glass{
-	dir = 4;
-	name = "IAA Office";
-	req_one_access = list(19, 38);
-	req_access = list(19, 38)
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkblue"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/station/security/iaa_office)
 "awt" = (
@@ -13144,6 +13125,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "IAA Office";
+	req_one_access = list(19, 38);
+	req_access = list(19, 38)
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "awv" = (
@@ -13153,6 +13140,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -28
 	},
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -13684,6 +13672,19 @@
 /obj/item/mars_globe{
 	pixel_x = 8;
 	pixel_y = 14
+	},
+/obj/item/device/camera,
+/obj/item/device/taperecorder{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/device/camera_film{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/device/camera_film{
+	pixel_x = -5;
+	pixel_y = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -14847,10 +14848,15 @@
 	},
 /area/station/civilian/gym)
 "azJ" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/wiki/sop{
+	pixel_x = -7;
+	pixel_y = 6
 	},
-/obj/item/weapon/flora/pottedplant/palm,
+/obj/item/weapon/book/manual/wiki/security_space_law{
+	pixel_x = 4;
+	pixel_y = 3
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31868,6 +31874,14 @@
 /area/station/bridge/meeting_room)
 "beM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Internal Affairs Desk";
+	req_access = list(38)
+	},
+/obj/item/weapon/paper_bin{
+	pixel_y = 4
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "beN" = (
@@ -33664,20 +33678,7 @@
 /obj/machinery/requests_console/internal_affairs{
 	pixel_x = -32
 	},
-/obj/structure/table/woodentable,
-/obj/item/device/camera_film{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/device/camera_film{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/device/taperecorder{
-	pixel_x = 7;
-	pixel_y = -1
-	},
-/obj/item/device/camera,
+/obj/structure/filingcabinet/chestdrawer/black,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -36339,14 +36340,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bmS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
+/obj/machinery/power/apc{
+	pixel_y = 2
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -43799,12 +43797,13 @@
 	},
 /area/station/hallway/primary/central)
 "bAd" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "apc top";
-	pixel_y = 28
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/security/iaa_office)
 "bAe" = (
 /obj/effect/decal/turf_decal{
@@ -47274,20 +47273,10 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "lawyer_blast";
-	name = "Internal Affairs";
-	opacity = 0
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/obj/structure/cable,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
 /area/station/security/iaa_office)
 "bGr" = (
 /turf/simulated/wall/r_wall,
@@ -47812,16 +47801,9 @@
 	},
 /area/station/civilian/barbershop)
 "bHq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/westleft{
-	name = "Internal Affairs Desk";
-	req_access = list(38)
-	},
-/obj/item/weapon/paper_bin{
-	pixel_y = 4
-	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/station/security/iaa_office)
 "bHr" = (
@@ -49145,6 +49127,18 @@
 /area/station/civilian/dormitories/dormthree)
 "bJM" = (
 /obj/structure/cable,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lawyer_blast";
+	name = "Internal Affairs";
+	opacity = 0
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bJN" = (
@@ -50051,9 +50045,6 @@
 	},
 /area/station/security/prison)
 "bLy" = (
-/obj/structure/filingcabinet/chestdrawer/black{
-	dir = 1
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -80738,9 +80729,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "oZb" = (
@@ -85177,20 +85165,20 @@
 	},
 /area/station/medical/genetics)
 "udd" = (
-/obj/machinery/door_control{
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
 	id = "lawyer_blast";
-	name = "Privacy Shutters";
-	pixel_y = 28;
-	req_access = list(38)
+	name = "Internal Affairs";
+	opacity = 0
 	},
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual/wiki/sop{
-	pixel_x = -7;
-	pixel_y = 6
+/obj/structure/cable{
+	dir = 8
 	},
-/obj/item/weapon/book/manual/wiki/security_space_law{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -86802,6 +86790,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"xdE" = (
+/obj/machinery/door_control{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	pixel_y = 32;
+	req_access = list(38)
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "xeC" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -111926,7 +111923,7 @@ bhX
 bzC
 aGx
 axN
-axN
+xdE
 bfn
 bHa
 cbf
@@ -112440,7 +112437,7 @@ biL
 bBM
 nSy
 bLy
-axN
+bmS
 bfn
 bIZ
 bIZ
@@ -113210,7 +113207,7 @@ udd
 beM
 awt
 bJM
-bAd
+axN
 aMR
 aMR
 aMR
@@ -113462,12 +113459,12 @@ sVa
 aIR
 kYG
 bWY
-axN
+bAd
 asw
 bHq
 aws
 bGq
-axN
+bHq
 bAc
 lHr
 icr
@@ -113724,7 +113721,7 @@ bxe
 bVa
 bVa
 pOb
-bmS
+cro
 cro
 cro
 bxT

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9564,20 +9564,6 @@
 	icon_state = "red"
 	},
 /area/station/security/lobby)
-"apV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "apW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -18840,19 +18826,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/genetics_cloning)
-"aHq" = (
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/weapon/reagent_containers/spray/plantbgone,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -21969,12 +21942,14 @@
 	},
 /area/station/security/prison)
 "aNe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille{
-	destroyed = 1
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/space)
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "aNf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43586,17 +43561,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
-"bzI" = (
-/obj/item/weapon/hatchet,
-/obj/item/weapon/minihoe,
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/wheatseed,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -47085,16 +47049,6 @@
 	icon_state = "dark"
 	},
 /area/station/storage/tech)
-"bFW" = (
-/obj/item/seeds/glowshroom,
-/obj/item/seeds/cornseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
@@ -47271,22 +47225,6 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
-"bGn" = (
-/obj/structure/rack,
-/obj/item/seeds/ambrosiavulgarisseed,
-/obj/item/seeds/cornseed,
-/obj/item/seeds/cabbageseed,
-/obj/item/seeds/grassseed,
-/obj/item/seeds/chiliseed,
-/obj/item/weapon/minihoe,
-/obj/item/weapon/shovel/spade,
-/obj/item/device/plant_analyzer,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "bGo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47424,10 +47362,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"bGC" = (
-/obj/item/seeds/tomatoseed,
-/turf/simulated/floor/plating,
-/area/space)
 "bGD" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -47919,9 +47853,6 @@
 /obj/item/weapon/tank/oxygen,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
-"bHA" = (
-/turf/simulated/floor/plating,
-/area/space)
 "bHB" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Equpment";
@@ -47941,10 +47872,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
-"bHD" = (
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/space)
 "bHE" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -70560,15 +70487,6 @@
 /obj/random/vending/cola,
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
-"ekS" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "elb" = (
 /obj/machinery/vending/coffee,
 /obj/item/portrait/captain{
@@ -72915,14 +72833,19 @@
 	},
 /area/station/civilian/hydroponics)
 "gNl" = (
-/obj/item/seeds/watermelonseed,
-/obj/machinery/seed_extractor,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "gOl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -74203,10 +74126,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"icK" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/space)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -76014,9 +75933,19 @@
 	},
 /area/station/civilian/kitchen)
 "jQM" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/turf/simulated/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76465,11 +76394,6 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
-"kmt" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor/plating,
-/area/space)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79606,15 +79530,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"nFG" = (
-/obj/item/seeds/berryseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -80219,10 +80134,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"onV" = (
-/obj/item/seeds/potatoseed,
-/turf/simulated/floor/plating,
-/area/space)
 "oob" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -81553,20 +81464,6 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
-"qeY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "qgb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/chief_engineer,
@@ -81916,15 +81813,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
-"qvb" = (
-/obj/item/seeds/ambrosiavulgarisseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "qvh" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NE"
@@ -83631,15 +83519,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"sfp" = (
-/obj/item/weapon/storage/bag/plants,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "sfM" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "2,0"
@@ -85629,10 +85508,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
-"uHF" = (
-/obj/item/seeds/grapeseed,
-/turf/simulated/floor/plating,
-/area/space)
 "uIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -85931,16 +85806,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
-"vDk" = (
-/obj/item/seeds/ambrosiavulgarisseed,
-/obj/item/seeds/carrotseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "vDF" = (
 /obj/item/clothing/under/rainbow,
 /turf/simulated/floor/wood,
@@ -86449,14 +86314,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
-"woE" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "woS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -87302,14 +87159,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
-"xXl" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/effect/decal/turf_decal/set_damaged,
-/turf/simulated/floor/plating,
-/area/space)
 "xYb" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -87392,15 +87241,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ygy" = (
-/obj/item/seeds/watermelonseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -108321,15 +108161,15 @@ aaa
 aaa
 aaa
 aaa
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aah
@@ -108578,15 +108418,15 @@ aaa
 aaa
 aaa
 aaa
-bkb
-aHq
-bzI
-vDk
-bkb
-ygy
-nFG
-qvb
-bkb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aah
@@ -108835,15 +108675,15 @@ aaa
 aaa
 aaa
 aaa
-bkb
-onV
-bHA
-bHA
-xXl
-icK
-bHA
-kmt
-bkb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aah
@@ -109092,15 +108932,15 @@ aah
 aaa
 aaa
 aaa
-bkb
-jQM
-uHF
-bHA
-bHA
-bGC
-aNe
-bHA
-bkb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aah
@@ -109349,15 +109189,15 @@ aah
 aah
 aaa
 aaa
-bkb
-woE
-gNl
-bGn
-bkb
-bFW
-bHD
-sfp
-bkb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aah
@@ -116824,8 +116664,8 @@ avV
 adW
 adW
 adW
-qeY
-ekS
+jQM
+aNe
 bGs
 adW
 alZ
@@ -117081,7 +116921,7 @@ avW
 aBO
 ayn
 nYP
-apV
+gNl
 bHu
 oLn
 adW

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11530,6 +11530,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "atC" = (
@@ -13087,9 +13090,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -13115,6 +13115,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/black,
@@ -42633,9 +42636,7 @@
 	sortType = "Barbershop"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -44503,6 +44504,9 @@
 /obj/effect/landmark/start{
 	name = "Internal Affairs Agent"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bBD" = (
@@ -44633,6 +44637,9 @@
 /obj/item/weapon/book/manual/wiki/sop{
 	pixel_x = -7;
 	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -47659,6 +47666,9 @@
 	},
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -62929,6 +62939,7 @@
 /obj/effect/landmark/start{
 	name = "Internal Affairs Agent"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "ctn" = (
@@ -71333,6 +71344,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"fnp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "fob" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -73648,15 +73668,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"hHE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/dormitory)
 "hIb" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -73930,6 +73941,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry)
+"hVd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "hVJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -75971,6 +75991,12 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage_secure)
+"jUv" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "jVb" = (
 /obj/machinery/door/airlock{
 	dir = 4;
@@ -77083,12 +77109,6 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
-"kYM" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "kZn" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
@@ -80634,15 +80654,6 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
-"oQk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "oQM" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
@@ -81779,12 +81790,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"qnb" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "qnN" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,5"
@@ -83084,6 +83089,9 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "rzr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "darkblue"
 	},
@@ -84949,6 +84957,12 @@
 	icon_state = "blue"
 	},
 /area/station/medical/genetics)
+"tyC" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "tzb" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 4
@@ -86403,23 +86417,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/teleporter)
-"wja" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "wjr" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,3"
@@ -86671,7 +86668,6 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "wCF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -86684,6 +86680,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -87164,6 +87163,25 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"xGf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "xGD" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -118737,12 +118755,12 @@ aua
 bbb
 aef
 ayu
-hHE
+fnp
 bAH
-hHE
-hHE
-hHE
-hHE
+fnp
+fnp
+fnp
+fnp
 bNP
 aeJ
 aeJ
@@ -119503,7 +119521,7 @@ aoz
 arJ
 byE
 sNO
-kYM
+jUv
 rEq
 jtE
 byE
@@ -121044,7 +121062,7 @@ ajo
 apb
 aql
 byE
-qnb
+tyC
 arT
 whD
 avj
@@ -122121,12 +122139,12 @@ cro
 qBb
 xTO
 cro
-bye
-oQk
-oQk
+xGf
+hVd
+hVd
 bGq
-oQk
-wja
+hVd
+bye
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11434,11 +11434,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -14176,11 +14171,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "ayr" = (
@@ -16058,7 +16048,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/wall/r_wall,
 /area/station/security/visiting_room)
 "aBP" = (
@@ -18876,16 +18868,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/genetics_cloning)
-"aHq" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -43611,6 +43593,14 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
+"bzI" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable,
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -47856,11 +47846,6 @@
 /area/station/maintenance/atmos)
 "bHu" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "bHv" = (
@@ -47944,6 +47929,20 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
+"bHD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "bHE" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -74203,15 +74202,12 @@
 	},
 /area/station/hallway/primary/central)
 "icK" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/prison)
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -76467,11 +76463,11 @@
 	},
 /area/station/medical/reception)
 "kmt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -79611,10 +79607,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"nFG" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -81903,13 +81895,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
-"qvb" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "qvh" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NE"
@@ -85605,6 +85590,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"uHF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "uIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -85903,20 +85902,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
-"vDk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "vDF" = (
 /obj/item/clothing/under/rainbow,
 /turf/simulated/floor/wood,
@@ -87352,6 +87337,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ygy" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -112187,7 +112187,7 @@ bIp
 bHU
 aGn
 tgJ
-bEW
+bdE
 axN
 axw
 bAD
@@ -115485,9 +115485,9 @@ cIb
 aqz
 are
 ash
-icK
+atr
 aNr
-aBO
+bzI
 bnA
 nYP
 wjo
@@ -115999,9 +115999,9 @@ apc
 cIb
 axL
 atN
-atr
+ygy
 avR
-aHq
+aBO
 bAf
 nYP
 bso
@@ -116515,11 +116515,11 @@ arn
 auc
 atq
 avS
-aBO
+bzI
 ark
 nYP
-kmt
-nFG
+ayq
+bHu
 bIT
 adW
 alZ
@@ -116775,8 +116775,8 @@ avV
 adW
 adW
 adW
-ayq
-bHu
+bHD
+kmt
 bGs
 adW
 alZ
@@ -117029,11 +117029,11 @@ asU
 aso
 auR
 avW
-aHq
+aBO
 ayn
 nYP
-vDk
-nFG
+uHF
+bHu
 oLn
 adW
 alZ
@@ -117291,7 +117291,7 @@ adW
 adW
 bzQ
 adW
-qvb
+icK
 adW
 agO
 bNs

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11891,11 +11891,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -12689,6 +12684,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
@@ -23846,6 +23846,11 @@
 /obj/item/weapon/storage/box/cdeathalarm_kit{
 	pixel_y = -8
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -34317,6 +34322,11 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/blueshield_officer,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -37757,7 +37767,9 @@
 /area/station/security/blueshield)
 "bpJ" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39197,6 +39209,11 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -39223,6 +39240,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -42607,6 +42629,11 @@
 	dir = 1;
 	name = "Barbershop";
 	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -47153,6 +47180,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -73957,6 +73987,23 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"hYL" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "hZb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -80514,6 +80561,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -80893,6 +80946,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"pnF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "pqb" = (
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
@@ -81670,6 +81732,12 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
+"qls" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "qlZ" = (
 /turf/simulated/wall,
 /area/station/cargo/qm)
@@ -82437,6 +82505,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"qWI" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "qXb" = (
 /obj/machinery/door/morgue{
 	dir = 4;
@@ -83316,12 +83390,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"rOU" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "rPb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84871,12 +84939,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/singularity)
-"twk" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "tyb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 1
@@ -119423,7 +119485,7 @@ aoz
 arJ
 byE
 sNO
-twk
+qWI
 rEq
 jtE
 byE
@@ -120964,7 +121026,7 @@ ajo
 apb
 aql
 byE
-rOU
+qls
 arT
 whD
 avj
@@ -122042,11 +122104,11 @@ qBb
 xTO
 cro
 bye
-cro
-cro
+pnF
+pnF
 bGq
-cro
-bye
+pnF
+hYL
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10268,19 +10268,20 @@
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "ark" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1484;
+	name = "Chamber Three";
+	pixel_x = -26
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "black"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/eva)
 "arl" = (
 /obj/item/weapon/cigbutt{
 	pixel_x = 5;
@@ -10863,19 +10864,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 31
 	},
-/obj/structure/stool/bed/chair/pedalgen{
-	anchored = 1;
-	dir = 8
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10976,7 +10964,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/security/iaa_office)
+/area/station/hallway/primary/central)
 "asx" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -11419,6 +11407,11 @@
 /area/station/security/prison)
 "atq" = (
 /obj/item/weapon/beach_ball/holoball,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -12249,13 +12242,8 @@
 	},
 /area/station/security/prison)
 "auR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/smart{
-	dir = 4
+/obj/structure/holohoop{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -12819,9 +12807,7 @@
 /obj/structure/sign/poster/official/obey{
 	pixel_y = -32
 	},
-/turf/simulated/floor{
-	icon_state = "black"
-	},
+/turf/simulated/wall/r_wall,
 /area/station/security/prison)
 "avR" = (
 /obj/machinery/camera{
@@ -12829,12 +12815,25 @@
 	dir = 1;
 	network = list("SS13","Prison")
 	},
-/obj/structure/dumbbells_rack,
+/obj/structure/stool/bed/chair/metal/red,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Chamber One";
+	pixel_x = -26
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
 /area/station/security/prison)
 "avS" = (
+/obj/structure/stool/bed/chair/metal/red,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Chamber One";
+	pixel_x = -26
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "red"
@@ -12862,17 +12861,17 @@
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/library)
 "avV" = (
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "red"
-	},
+/obj/machinery/light/smart,
+/turf/simulated/wall/r_wall,
 /area/station/security/prison)
 "avW" = (
-/obj/structure/stool/bed/chair/pedalgen{
-	anchored = 1;
-	dir = 8
+/obj/structure/stool/bed/chair/metal/red,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Chamber One";
+	pixel_x = -26
 	},
-/obj/structure/cable,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -13112,7 +13111,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/security/iaa_office)
+/area/station/hallway/primary/central)
 "awt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14093,21 +14092,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "ayn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1486;
+	name = "Chamber Four";
+	pixel_x = -26
 	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "whitepurple"
+	dir = 1;
+	icon_state = "black"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/eva)
 "ayo" = (
 /obj/item/weapon/flora/pottedplant{
 	icon_state = "plant-22"
@@ -14125,18 +14123,14 @@
 	},
 /area/station/hallway/primary/fore)
 "ayq" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "ayr" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prison)
@@ -16008,11 +16002,12 @@
 	},
 /area/station/civilian/kitchen)
 "aBO" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurple"
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/area/station/civilian/barbershop)
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/eva)
 "aBP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -16309,8 +16304,8 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aCt" = (
-/obj/item/weapon/flora/random,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/weightlifter,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "black"
@@ -16502,10 +16497,13 @@
 /turf/simulated/floor,
 /area/station/security/range)
 "aCO" = (
+/obj/structure/stool/bed/chair/pedalgen{
+	anchored = 1;
+	dir = 8
+	},
 /obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -17210,14 +17208,17 @@
 	},
 /area/station/security/main)
 "aEq" = (
-/obj/item/seeds/glowshroom,
-/obj/item/seeds/cornseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
+/obj/item/weapon/haircomb,
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/device/cardpay{
+	dir = 8;
+	pixel_x = -3;
+	pixel_y = 15
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "aEr" = (
 /obj/structure/table/reinforced,
@@ -17544,9 +17545,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aEV" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18262,10 +18262,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aGm" = (
-/obj/structure/holohoop{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stool/bed/chair/pedalgen{
+	anchored = 1;
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -18752,8 +18757,11 @@
 	},
 /area/station/ai_monitored/eva)
 "aHk" = (
-/obj/item/seeds/grapeseed,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "aHl" = (
 /turf/simulated/wall,
@@ -18823,7 +18831,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/atmos)
+/area/space)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -19378,15 +19386,10 @@
 	},
 /area/station/medical/hallway)
 "aIu" = (
-/obj/item/weapon/hatchet,
-/obj/item/weapon/minihoe,
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/wheatseed,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
+/obj/structure/table/glass,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "aIv" = (
 /turf/simulated/floor,
@@ -19436,13 +19439,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aIA" = (
-/obj/item/weapon/storage/bag/plants,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
+/obj/machinery/vending/barbervend,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "aIB" = (
 /obj/structure/table,
@@ -20226,13 +20226,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aJV" = (
-/obj/item/seeds/watermelonseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "aJW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -20289,13 +20288,8 @@
 	},
 /area/station/hallway/secondary/arrival)
 "aKa" = (
-/obj/item/seeds/berryseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/mirror,
+/turf/simulated/wall,
 /area/station/maintenance/atmos)
 "aKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21954,14 +21948,12 @@
 	},
 /area/station/security/prison)
 "aNe" = (
-/obj/item/seeds/ambrosiavulgarisseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	destroyed = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/atmos)
+/area/space)
 "aNf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22046,9 +22038,18 @@
 	},
 /area/station/civilian/bar)
 "aNo" = (
-/turf/simulated/floor{
-	icon_state = "black"
+/obj/machinery/flasher{
+	id = "permflash"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "aNp" = (
 /obj/structure/closet{
@@ -22071,9 +22072,15 @@
 /turf/simulated/floor,
 /area/station/civilian/garden)
 "aNr" = (
-/obj/structure/weightlifter,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/structure/stool/bed/chair/metal/red,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Chamber One";
+	pixel_x = -26
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -36645,20 +36652,20 @@
 	},
 /area/station/bridge)
 "bnA" = (
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
 	},
-/obj/structure/dryer{
-	pixel_y = 14
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Chamber One";
+	pixel_x = -26
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "black"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/eva)
 "bnB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36744,16 +36751,13 @@
 	},
 /area/station/cargo/storage)
 "bnJ" = (
-/obj/structure/sign/barber{
-	buildable_sign = 0;
-	pixel_x = -13
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/atmos)
 "bnL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -39247,19 +39251,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bso" = (
-/obj/structure/stool/bed/chair/barber{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/effect/landmark/start/barber,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "bsp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -42682,15 +42678,16 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bye" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=HOP";
-	location = "CHE"
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barberы";
+	sortType = "Internal Affairs"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -43569,23 +43566,16 @@
 	},
 /area/station/bridge)
 "bzI" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 4
+/obj/item/weapon/hatchet,
+/obj/item/weapon/minihoe,
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/wheatseed,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor/plating,
+/area/space)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -43673,25 +43663,18 @@
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "bzQ" = (
+/obj/machinery/door/airlock/security{
+	name = "Visiting Room";
+	req_access = list(1)
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "bzR" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -43831,23 +43814,20 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "bAf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "apc top";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1482;
+	name = "Chamber Two";
+	pixel_x = -26
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "black"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/eva)
 "bAg" = (
 /obj/structure/closet/fireaxecabinet{
 	pixel_y = -32
@@ -44868,20 +44848,16 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "bCi" = (
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
+/obj/machinery/door/airlock/glass{
+	name = "Barbershop"
 	},
-/obj/machinery/door/firedoor{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "whitepurple"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/barbershop)
+/area/station/maintenance/atmos)
 "bCj" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -44973,7 +44949,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
+	dir = 8;
 	name = "Internal Affairs";
 	sortType = "Internal Affairs"
 	},
@@ -47084,8 +47060,15 @@
 	},
 /area/station/storage/tech)
 "bFW" = (
-/turf/simulated/wall,
-/area/station/civilian/barbershop)
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/cornseed,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
@@ -47263,14 +47246,21 @@
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
 "bGn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/rack,
+/obj/item/seeds/ambrosiavulgarisseed,
+/obj/item/seeds/cornseed,
+/obj/item/seeds/cabbageseed,
+/obj/item/seeds/grassseed,
+/obj/item/seeds/chiliseed,
+/obj/item/weapon/minihoe,
+/obj/item/weapon/shovel/spade,
+/obj/item/device/plant_analyzer,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor/plating,
+/area/space)
 "bGo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47288,43 +47278,31 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "bGq" = (
-/obj/machinery/door/firedoor{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/area/station/security/iaa_office)
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "bGr" = (
-/turf/simulated/wall/r_wall,
-/area/station/civilian/barbershop)
-"bGs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass{
-	dir = 4;
-	name = "Barbershop"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/atmos)
+"bGs" = (
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
+/turf/simulated/floor{
+	icon_state = "black"
+	},
+/area/station/maintenance/eva)
 "bGt" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -47353,14 +47331,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bGw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/effect/landmark/start/barber,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/atmos)
 "bGx" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder{
@@ -47381,21 +47360,19 @@
 	},
 /area/station/security/iaa_office)
 "bGy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/atmos)
 "bGz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/item/trash/candy,
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
@@ -47421,16 +47398,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "bGC" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/obj/item/seeds/tomatoseed,
+/turf/simulated/floor/plating,
+/area/space)
 "bGD" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -47738,14 +47708,13 @@
 	},
 /area/station/medical/hallway)
 "bHi" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 4
-	},
+/obj/item/weapon/razor,
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/dropper/precision,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/atmos)
 "bHj" = (
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -47814,16 +47783,22 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "bHp" = (
-/turf/simulated/floor{
-	icon_state = "purplechecker"
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
 	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor{
+	icon_state = "black"
+	},
+/area/station/maintenance/eva)
 "bHq" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/area/station/security/iaa_office)
+/turf/simulated/floor{
+	icon_state = "whitepurple"
+	},
+/area/station/maintenance/atmos)
 "bHr" = (
 /obj/effect/decal/turf_decal/alpha/black{
 	dir = 1;
@@ -47844,23 +47819,17 @@
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bHt" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/atmos)
 "bHu" = (
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
-	},
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/barbershop)
+/obj/structure/table/reinforced,
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "bHv" = (
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
@@ -47924,26 +47893,8 @@
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bHA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/machinery/camera{
-	c_tag = "Barbershop"
-	},
-/obj/machinery/color_mixer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor/plating,
+/area/space)
 "bHB" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Equpment";
@@ -47964,16 +47915,9 @@
 	},
 /area/station/civilian/cold_room)
 "bHD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/space)
 "bHE" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -48050,17 +47994,15 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "bHK" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -6
 	},
-/obj/item/weapon/razor,
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/dropper/precision,
-/turf/simulated/floor{
-	icon_state = "purplechecker"
+/obj/item/weapon/pen{
+	pixel_x = 6
 	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "bHL" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor{
@@ -48138,7 +48080,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/security/iaa_office)
+/area/station/hallway/primary/central)
 "bHT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48169,13 +48111,8 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "bHV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "bHW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48354,13 +48291,11 @@
 	},
 /area/station/medical/patient_a)
 "bIl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "bIm" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -48684,25 +48619,27 @@
 	},
 /area/station/civilian/dormitories)
 "bIO" = (
-/obj/machinery/vending/barbervend,
+/obj/structure/table,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "black"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/eva)
 "bIP" = (
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "black"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/eva)
 "bIQ" = (
-/obj/structure/closet/secure_closet/barber,
-/turf/simulated/floor{
-	icon_state = "purplechecker"
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Brig Desk";
+	req_access = list(63);
+	dir = 4
 	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor{
+	icon_state = "black"
+	},
+/area/station/maintenance/eva)
 "bIR" = (
 /obj/item/weapon/folder/white,
 /obj/item/device/radio/headset/headset_medsci,
@@ -48730,15 +48667,10 @@
 /turf/simulated/wall,
 /area/station/medical/storage)
 "bIT" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "black"
 	},
-/area/station/civilian/barbershop)
+/area/station/maintenance/eva)
 "bIU" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -48823,12 +48755,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bJd" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/structure/stool/bed/chair/barber{
+	dir = 8
 	},
-/obj/effect/decal/turf_decal/set_damaged,
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "bJe" = (
 /turf/simulated/wall,
@@ -49726,16 +49658,14 @@
 	},
 /area/station/medical/cryo)
 "bKR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "bKS" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -50679,15 +50609,12 @@
 /turf/simulated/floor,
 /area/station/medical/hallway)
 "bME" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/structure/sign/barber{
+	pixel_x = 15
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -64389,11 +64316,16 @@
 	},
 /area/station/civilian/garden)
 "cxv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/station/hallway/primary/central)
 "cxx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -69221,12 +69153,12 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "cMQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway South-East";
 	dir = 8
+	},
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -72946,6 +72878,15 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"gNl" = (
+/obj/item/seeds/watermelonseed,
+/obj/machinery/seed_extractor,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "gOl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -74226,6 +74167,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"icK" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/space)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -75366,15 +75311,14 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
 "jhA" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/atmos)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -76033,6 +75977,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"jQM" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/turf/simulated/floor/plating,
+/area/space)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76481,6 +76429,11 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"kmt" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/simulated/floor/plating,
+/area/space)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -77424,6 +77377,10 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
+"lqv" = (
+/obj/structure/mirror,
+/turf/simulated/wall,
+/area/station/medical/storage)
 "lqO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78375,20 +78332,10 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "mlb" = (
-/obj/structure/rack,
-/obj/item/seeds/ambrosiavulgarisseed,
-/obj/item/seeds/cornseed,
-/obj/item/seeds/cabbageseed,
-/obj/item/seeds/grassseed,
-/obj/item/seeds/chiliseed,
-/obj/item/weapon/minihoe,
-/obj/item/weapon/shovel/spade,
-/obj/item/device/plant_analyzer,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "mlh" = (
 /obj/structure/grille,
@@ -79030,12 +78977,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "mXb" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "mXO" = (
 /obj/machinery/door/airlock/glass{
@@ -79622,6 +79570,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"nFG" = (
+/obj/item/seeds/berryseed,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -79901,17 +79858,12 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nYP" = (
-/obj/structure/sign/poster/official/soft_cap_pop_art{
-	pixel_x = -32
+/obj/machinery/door/morgue{
+	dir = 8;
+	name = "Confession Booth"
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/environment/space,
+/area/station/maintenance/eva)
 "nZb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -80231,6 +80183,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"onV" = (
+/obj/item/seeds/potatoseed,
+/turf/simulated/floor/plating,
+/area/space)
 "oob" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -80565,19 +80521,23 @@
 	},
 /area/station/civilian/garden)
 "oLb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille{
-	destroyed = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/atmos)
-"oLn" = (
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/primary/central)
+"oLn" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor{
+	icon_state = "black"
+	},
+/area/station/maintenance/eva)
 "oMb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -80857,8 +80817,12 @@
 	},
 /area/station/hallway/secondary/entry)
 "pib" = (
-/obj/item/seeds/tomatoseed,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "piY" = (
 /obj/structure/disposalpipe/segment,
@@ -80867,13 +80831,10 @@
 	},
 /area/station/rnd/xenobiology)
 "pjb" = (
-/obj/item/seeds/watermelonseed,
-/obj/machinery/seed_extractor,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "pjk" = (
 /obj/structure/disposalpipe/segment{
@@ -81773,8 +81734,9 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "qob" = (
-/obj/item/seeds/potatoseed,
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "qoN" = (
 /obj/machinery/light/smart,
@@ -81905,10 +81867,14 @@
 	},
 /area/station/medical/hallway)
 "qvb" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/seeds/ambrosiavulgarisseed,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/atmos)
+/area/space)
 "qvh" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NE"
@@ -82876,6 +82842,13 @@
 	icon_state = "2,2"
 	},
 /area/shuttle/supply/station)
+"rsD" = (
+/obj/structure/dumbbells_rack,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/security/prison)
 "rsM" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/device/radio/intercom{
@@ -83607,6 +83580,15 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"sfp" = (
+/obj/item/weapon/storage/bag/plants,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "sfM" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "2,0"
@@ -83964,14 +83946,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "sxb" = (
-/obj/item/seeds/ambrosiavulgarisseed,
-/obj/item/seeds/carrotseed,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/maintenance/atmos)
 "sxr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -85594,6 +85578,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"uHF" = (
+/obj/item/seeds/grapeseed,
+/turf/simulated/floor/plating,
+/area/space)
 "uIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -85892,6 +85880,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"vDk" = (
+/obj/item/seeds/ambrosiavulgarisseed,
+/obj/item/seeds/carrotseed,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "vDF" = (
 /obj/item/clothing/under/rainbow,
 /turf/simulated/floor/wood,
@@ -86287,21 +86285,9 @@
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "wjo" = (
-/obj/item/weapon/haircomb,
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/cardpay{
-	dir = 8;
-	pixel_x = -3;
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "wjr" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,3"
@@ -86412,6 +86398,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"woE" = (
+/obj/machinery/biogenerator,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "woS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -87257,6 +87251,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
+"xXl" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/turf_decal/set_damaged,
+/turf/simulated/floor/plating,
+/area/space)
 "xYb" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -87339,6 +87341,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ygy" = (
+/obj/item/seeds/watermelonseed,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -87353,6 +87364,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -108259,15 +108275,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bkb
+bkb
+bkb
+bkb
+bkb
+bkb
+bkb
+bkb
+bkb
 aaa
 aaa
 aah
@@ -108516,15 +108532,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bkb
+aHq
+bzI
+vDk
+bkb
+ygy
+nFG
+qvb
+bkb
 aaa
 aaa
 aah
@@ -108773,15 +108789,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bkb
+onV
+bHA
+bHA
+xXl
+icK
+bHA
+kmt
+bkb
 aaa
 aaa
 aah
@@ -109030,15 +109046,15 @@ aah
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bkb
+jQM
+uHF
+bHA
+bHA
+bGC
+aNe
+bHA
+bkb
 aaa
 aaa
 aah
@@ -109287,15 +109303,15 @@ aah
 aah
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bkb
+woE
+gNl
+bGn
+bkb
+bFW
+bHD
+sfp
+bkb
 aaa
 aaa
 aah
@@ -113462,10 +113478,10 @@ kYG
 bWY
 bHS
 asw
-bHq
+aIR
 aws
-bGq
-bHq
+bek
+aIR
 bAc
 lHr
 icr
@@ -115216,14 +115232,14 @@ aqr
 aAH
 aCt
 atp
-aNo
-bGr
-bGr
-bGr
-bFW
-bFW
-bFW
-bFW
+ayr
+adW
+adW
+adW
+adW
+adW
+adW
+adW
 uBq
 clo
 aCu
@@ -115472,15 +115488,15 @@ cIb
 aqz
 are
 ash
-auQ
+atr
 aNr
-bGr
+aBO
 bnA
 nYP
 wjo
 bHK
 bIO
-bFW
+adW
 alZ
 aYi
 aCu
@@ -115728,16 +115744,16 @@ apV
 aoY
 aqz
 asF
-atN
-atr
-aNo
-bGr
-bGn
-bGw
+rsD
+auQ
+ayr
+adW
+adW
+adW
+bHV
+bHV
 bHp
-bHp
-bHp
-bFW
+adW
 alZ
 bNg
 ayx
@@ -115988,13 +116004,13 @@ axL
 atN
 atr
 avR
-bGr
+aBO
 bAf
-bHD
+nYP
 bso
 bHV
 bIP
-bFW
+adW
 alZ
 aYi
 aCu
@@ -116243,15 +116259,15 @@ ctq
 ffD
 arl
 yjk
-auS
+aNo
 avQ
-bGr
-bHA
-bGy
+adW
+adW
+adW
 bKR
 bIl
 bIQ
-bFW
+adW
 alZ
 aYi
 hGb
@@ -116502,13 +116518,13 @@ arn
 auc
 atq
 avS
-bGr
+aBO
 ark
-bGC
+nYP
 ayq
-bHt
+bHu
 bIT
-bFW
+adW
 alZ
 aYi
 aCu
@@ -116759,13 +116775,13 @@ asR
 aCO
 aGm
 avV
-bGr
+adW
+adW
+adW
+ayq
+bHu
 bGs
-bFW
-bCi
-bHu
-bHu
-agO
+adW
 alZ
 aYi
 aCu
@@ -117016,13 +117032,13 @@ asU
 aso
 auR
 avW
-bGr
+aBO
 ayn
-bnJ
-bzI
-bHi
+nYP
+ayq
+bHu
 oLn
-agO
+adW
 alZ
 aYi
 aCu
@@ -117273,14 +117289,14 @@ ayr
 ayr
 ayr
 ayr
-bGr
-aBO
-aBO
+adW
+adW
+adW
 bzQ
-aBO
+adW
 aBO
 adW
-adW
+agO
 bNs
 aCu
 aCu
@@ -121182,11 +121198,11 @@ ovb
 aEV
 cdA
 cdA
+aKa
 cdA
+aKa
 cdA
-cdA
-cdA
-cdA
+aKa
 cdA
 cdA
 swb
@@ -121437,14 +121453,14 @@ cea
 aIR
 ovb
 bht
-cdA
-aHq
+bHq
+mlb
 aIu
 sxb
-cdA
+aIu
 aJV
-aKa
-aNe
+aIu
+mlb
 cdA
 amR
 bHM
@@ -121690,18 +121706,18 @@ aRR
 bst
 aML
 aTR
+jhA
 aIR
-aIR
-ovb
+cxv
 bht
-cdA
+bHq
 qob
-cce
-cce
 bJd
-cdE
-cce
-qvb
+bnJ
+bJd
+bHt
+bJd
+qob
 cdA
 cdP
 bLt
@@ -121947,18 +121963,18 @@ cro
 bsq
 cro
 cro
-cro
+bGq
 cro
 bye
-bht
-cdA
-swb
-aHk
-cce
-cce
-pib
 oLb
-cce
+bCi
+bGy
+aHk
+bGw
+bGr
+pib
+qob
+qob
 cdA
 cdP
 bLt
@@ -122204,17 +122220,17 @@ aMN
 dif
 aRD
 aPE
+bXR
 aPE
-cxv
 bME
 cMQ
 cdA
 mXb
 pjb
 mlb
-cdA
+qob
 aEq
-kEb
+bHi
 aIA
 cdA
 cLk
@@ -122467,11 +122483,11 @@ bIS
 bIS
 bIS
 bIS
-bIS
+lqv
 bIS
 cdA
 cdA
-jhA
+cdA
 cdA
 cdA
 cLn

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10433,6 +10433,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "redcorner"
@@ -10640,10 +10641,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Holodeck East";
-	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
@@ -14086,14 +14083,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "ayn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -36637,12 +36635,18 @@
 	},
 /area/station/bridge)
 "bnA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -9;
-	pixel_y = 1
+/obj/item/weapon/haircomb,
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/device/cardpay{
+	dir = 8;
+	pixel_x = -3;
+	pixel_y = 15
 	},
-/turf/simulated/wall/r_wall,
-/area/station/bridge/teleporter)
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "bnB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36732,6 +36736,7 @@
 	buildable_sign = 0;
 	pixel_x = -13
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -39143,6 +39148,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/shieldwallgen,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bsd" = (
@@ -39219,6 +39225,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/shieldwallgen,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bsm" = (
@@ -42073,11 +42080,6 @@
 	dir = 4;
 	pixel_x = -4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 3;
-	pixel_y = -1
-	},
 /turf/simulated/wall/r_wall,
 /area/station/security/blueshield)
 "bxd" = (
@@ -43575,6 +43577,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -47259,16 +47265,6 @@
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
 "bGn" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/structure/dryer{
-	pixel_y = 14
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -47369,15 +47365,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bGw" = (
-/obj/machinery/disposal,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/soft_cap_pop_art{
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
@@ -47445,6 +47435,9 @@
 "bGC" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
+	},
+/obj/machinery/light/smart{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
@@ -47833,17 +47826,6 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "bHp" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/item/weapon/haircomb,
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/cardpay{
-	dir = 8;
-	pixel_x = -3;
-	pixel_y = 15
-	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -50088,10 +50070,6 @@
 	},
 /area/station/security/prison)
 "bLy" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/structure/filingcabinet/chestdrawer/black{
 	dir = 1
 	},
@@ -56597,6 +56575,11 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"cbh" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/spawner/lootdrop,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "cbi" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -70135,6 +70118,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
+"dFQ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "dHv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79932,8 +79922,19 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nYP" = (
-/obj/effect/spawner/lootdrop,
-/turf/simulated/floor/plating,
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/structure/dryer{
+	pixel_y = 14
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/civilian/barbershop)
 "nZb" = (
 /obj/machinery/door/airlock/maintenance{
@@ -83031,6 +83032,10 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "rzr" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -83084,7 +83089,16 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "rCb" = (
-/turf/simulated/floor/plating,
+/obj/structure/sign/poster/official/soft_cap_pop_art{
+	pixel_x = -32
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
 /area/station/civilian/barbershop)
 "rCh" = (
 /obj/structure/cable{
@@ -84294,11 +84308,11 @@
 	},
 /area/station/medical/virology)
 "sNO" = (
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/machinery/camera{
+	c_tag = "Xenobiology Module SW";
+	dir = 4;
+	network = list("SS13","Research")
 	},
-/obj/structure/table,
-/obj/item/weapon/crowbar/red,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "sOb" = (
@@ -87258,6 +87272,7 @@
 	},
 /obj/structure/table,
 /obj/item/weapon/hand_tele,
+/obj/item/weapon/crowbar/red,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "xZt" = (
@@ -114678,7 +114693,7 @@ bLx
 bNr
 ayr
 aqf
-atc
+cbh
 cgt
 alZ
 alZ
@@ -115191,10 +115206,10 @@ aNo
 bGr
 bGr
 bGr
-nYP
-rCb
-rCb
-rCb
+bFW
+bFW
+bFW
+bFW
 uBq
 clo
 aCu
@@ -115446,11 +115461,11 @@ ash
 auQ
 aNr
 bGr
-bFW
-bFW
-bFW
-bFW
-bFW
+nYP
+rCb
+bnA
+bHK
+bIO
 bFW
 alZ
 aYi
@@ -115706,8 +115721,8 @@ bGr
 bGn
 bGw
 bHp
-bHK
-bIO
+bHp
+bHp
 bFW
 alZ
 bNg
@@ -119040,7 +119055,7 @@ aqi
 aqi
 byE
 byE
-byE
+dFQ
 kNr
 byE
 byE
@@ -121095,7 +121110,7 @@ apJ
 aqB
 arM
 byE
-bnA
+byE
 byE
 byE
 afl

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -37990,6 +37990,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "bqo" = (

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11400,6 +11400,7 @@
 	},
 /area/station/security/prison)
 "atq" = (
+/obj/item/weapon/beach_ball/holoball,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11546,9 +11546,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11606,7 +11603,7 @@
 	},
 /obj/item/weapon/folder/purple,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
 "atH" = (
@@ -12434,7 +12431,7 @@
 "avj" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor,
-/area/station/maintenance/dormitory)
+/area/station/bridge/teleporter)
 "avk" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -13733,7 +13730,8 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
 "axx" = (
@@ -14000,7 +13998,8 @@
 	},
 /obj/item/weapon/folder/purple,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
 "ayb" = (
@@ -14825,7 +14824,8 @@
 	},
 /obj/structure/closet/secure_closet/iaa,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
 "azE" = (
@@ -14909,7 +14909,8 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
 "azK" = (
@@ -18423,11 +18424,6 @@
 	},
 /area/station/storage/tech)
 "aGx" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -5;
-	pixel_y = 4
-	},
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = -24
 	},
@@ -34860,14 +34856,9 @@
 	},
 /area/station/cargo/storage)
 "bkt" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/spray/extinguisher{
-	pixel_y = 6
-	},
-/obj/item/weapon/reagent_containers/spray/extinguisher,
-/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "bku" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -36395,14 +36386,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bmS" = (
-/obj/machinery/door_control{
-	id = "lawyer_blast";
-	name = "Privacy Shutters";
-	pixel_y = 32;
-	req_access = list(38)
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/iaa_office)
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -43513,10 +43499,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bzC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/faxmachine{
-	department = "Internal Affairs"
-	},
 /obj/machinery/light/smart{
 	dir = 8
 	},
@@ -44612,6 +44594,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bBD" = (
@@ -44707,8 +44692,27 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
 "bBM" = (
+/obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/item/tableclock{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/obj/item/device/flashlight/lamp/small{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/weapon/stamp/iaa{
+	pixel_x = -8
+	},
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4
+	},
+/obj/item/newtons_pendulum{
+	pixel_x = 6;
+	pixel_y = -8
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -47065,30 +47069,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
-"bFU" = (
-/obj/structure/table/woodentable,
-/obj/item/pens_bin{
-	pixel_x = 8;
-	pixel_y = -10
-	},
-/obj/item/weapon/pen/red{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/weapon/pen{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen/blue{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/ashtray/plastic{
-	pixel_x = 5;
-	pixel_y = 12
-	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/iaa_office)
 "bFV" = (
 /obj/machinery/requests_console/tech_storage{
 	pixel_y = -32
@@ -47375,7 +47355,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
 "bGy" = (
@@ -47753,32 +47733,16 @@
 	},
 /area/station/civilian/chapel/office)
 "bHl" = (
-/obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/item/tableclock{
-	pixel_x = 4;
-	pixel_y = 12
-	},
-/obj/item/device/flashlight/lamp/small{
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/obj/item/weapon/stamp/iaa{
-	pixel_x = -8
-	},
-/obj/item/weapon/stamp/denied{
-	pixel_x = 4
-	},
-/obj/item/newtons_pendulum{
-	pixel_x = 6;
-	pixel_y = -8
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -50007,17 +49971,6 @@
 	icon_state = "brownold"
 	},
 /area/station/security/prison)
-"bLy" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/iaa_office)
 "bLz" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -53992,14 +53945,6 @@
 	icon_state = "green"
 	},
 /area/station/hallway/primary/starboard)
-"bSY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/emergency3)
 "bSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -56647,7 +56592,7 @@
 /area/station/maintenance/portsolar)
 "cbz" = (
 /turf/simulated/wall,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cbB" = (
 /turf/simulated/floor/airless/ceiling,
 /area/station/cargo/recycler)
@@ -56938,7 +56883,7 @@
 /obj/item/clothing/head/hardhat/red,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "ccT" = (
 /obj/machinery/door/airlock/glass{
 	dir = 4;
@@ -57326,8 +57271,16 @@
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
 "cer" = (
-/turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
+/area/station/security/iaa_office)
 "ces" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -57347,13 +57300,17 @@
 /turf/simulated/floor/engine/carbon_dioxide,
 /area/station/engineering/atmos)
 "cew" = (
-/obj/structure/closet,
-/obj/item/clothing/shoes/boxing,
-/obj/item/clothing/mask/luchador/tecnicos,
-/obj/item/clothing/under/boxing,
-/obj/item/clothing/gloves/fingerless,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "apc right";
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cex" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -57725,7 +57682,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cfC" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -57736,19 +57693,22 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cfD" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "apc right";
-	pixel_x = 28
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/nutrient/l4z,
+/obj/item/nutrient/rh,
+/obj/item/nutrient/l4z,
+/obj/item/nutrient/l4z,
+/obj/item/nutrient/rh,
+/obj/item/nutrient/ez,
+/obj/item/nutrient/ez,
+/obj/item/nutrient/ez,
+/obj/item/nutrient/ez,
+/obj/item/nutrient/ez,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cfH" = (
 /obj/structure/stool/bed/chair{
 	dir = 4
@@ -58707,9 +58667,11 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "cil" = (
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cim" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -62678,8 +62640,9 @@
 /obj/machinery/door/airlock{
 	name = "Firefighting equipment"
 	},
+/obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "csB" = (
 /obj/machinery/porta_turret/station_default,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
@@ -63071,6 +63034,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/environment/space,
 /area/space)
+"ctm" = (
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/security/iaa_office)
 "ctn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -63415,11 +63384,15 @@
 /area/station/medical/genetics)
 "cuo" = (
 /obj/item/weapon/cigbutt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cuq" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -64567,13 +64540,9 @@
 	},
 /area/station/rnd/xenobiology)
 "cya" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/space_heater,
+/obj/machinery/vending/hydroseeds,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cyd" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -65533,8 +65502,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cAM" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -65715,12 +65685,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cBj" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -66890,18 +66861,17 @@
 "cEy" = (
 /obj/structure/stool,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cEz" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
-"cEB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/storage/emergency3)
 "cEC" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -68366,15 +68336,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cKi" = (
 /obj/structure/table,
-/obj/item/device/t_scanner,
-/obj/item/weapon/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/flashlight,
+/obj/item/weapon/reagent_containers/food/snacks/grown/chili,
+/obj/item/weapon/reagent_containers/food/snacks/grown/chili,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cKl" = (
 /obj/item/trash/raisins,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68432,11 +68401,12 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "cKv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "cKy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69569,6 +69539,11 @@
 	icon_state = "whiteblue"
 	},
 /area/station/hallway/secondary/exit)
+"ddK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "dex" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -70998,6 +70973,14 @@
 	icon_state = "blue"
 	},
 /area/station/medical/genetics)
+"eJE" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/environment/space,
+/area/station/civilian/hydroponics/old)
 "eKb" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -71023,6 +71006,11 @@
 "eKS" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -71873,6 +71861,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"fIz" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/station/civilian/hydroponics/old)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -72035,6 +72027,23 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"fQq" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/machinery/faxmachine{
+	department = "Internal Affairs"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
+/area/station/security/iaa_office)
 "fRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/turf_decal/set_damaged,
@@ -74462,6 +74471,12 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
+"itg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "itt" = (
 /obj/item/weapon/table_parts/wood/fancy,
 /obj/effect/decal/cleanable/blood/oil,
@@ -75092,7 +75107,7 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/emergency3)
+/area/station/civilian/hydroponics/old)
 "iVS" = (
 /obj/machinery/power/grounding_rod,
 /obj/structure/cable{
@@ -76251,6 +76266,17 @@
 	icon_state = "red"
 	},
 /area/station/medical/reception)
+"kdJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "kdQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -76587,6 +76613,12 @@
 /obj/effect/landmark/start/botanist,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
+"ksB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "ksR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -76893,6 +76925,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
+"kJV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "kKb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79770,16 +79809,31 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "nSy" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 4
+/obj/structure/table/woodentable,
+/obj/item/pens_bin{
+	pixel_x = 8;
+	pixel_y = -10
 	},
-/obj/effect/landmark/start{
-	name = "Internal Affairs Agent"
+/obj/item/weapon/pen/red{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/pen{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/ashtray/plastic{
+	pixel_x = 5;
+	pixel_y = 12
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -80243,6 +80297,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"oqv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "orb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -80680,6 +80740,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"oWQ" = (
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "oXb" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/smart{
@@ -80803,6 +80867,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"peN" = (
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "pfz" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -82068,6 +82135,15 @@
 "qFO" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/crematorium)
+"qFY" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/environment/space,
+/area/station/civilian/hydroponics/old)
 "qGb" = (
 /obj/structure/stool/bed,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -82097,7 +82173,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
-/area/station/maintenance/dormitory)
+/area/station/bridge/teleporter)
 "qJb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82998,12 +83074,8 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "rzr" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
 "rAb" = (
@@ -84638,6 +84710,10 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
+"tfv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "tfA" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -84662,6 +84738,14 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
+"tgl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "tgJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86862,6 +86946,26 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"xpu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	pixel_y = 32;
+	req_access = list(38)
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "xqb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -111931,8 +112035,8 @@ axo
 bhX
 bzC
 aGx
+fQq
 axN
-bmS
 bfn
 bHa
 cbf
@@ -112187,10 +112291,10 @@ axN
 axw
 bAD
 bBC
-biL
+ctm
 rzr
 axN
-bfn
+xpu
 cap
 ciO
 bqo
@@ -112445,7 +112549,7 @@ aya
 biL
 bBM
 nSy
-bLy
+bGx
 axN
 bfn
 bIZ
@@ -112701,8 +112805,8 @@ axN
 azD
 bjH
 bHl
-bFU
-bGx
+eKS
+cer
 axN
 aMj
 cfq
@@ -112958,7 +113062,7 @@ axN
 azJ
 biL
 atB
-eKS
+biL
 atG
 axN
 bQl
@@ -121135,7 +121239,7 @@ byE
 byE
 byE
 byE
-afl
+byE
 afl
 bGu
 bzy
@@ -131999,10 +132103,10 @@ aHG
 cIQ
 jhb
 bFo
-aaa
-aaa
-aaa
-aaa
+aah
+aah
+aah
+aah
 aah
 aaa
 aaa
@@ -132256,10 +132360,10 @@ cbz
 cbz
 cbz
 cbz
-aaa
-aaa
-aaa
-aaa
+cbz
+cbz
+cbz
+cbz
 aah
 aaa
 aaa
@@ -132512,11 +132616,11 @@ csA
 cAL
 cBh
 cuo
-bSY
-aaa
-aaa
-aaa
-aaa
+bmS
+bmS
+bmS
+bmS
+cbz
 aah
 aaa
 aaa
@@ -132768,12 +132872,12 @@ cak
 cbz
 cKv
 iUO
-cEB
-bSY
-aah
-aah
-aah
-aah
+kJV
+bkt
+peN
+bkt
+ksB
+fIz
 aah
 aaa
 aaa
@@ -133026,11 +133130,11 @@ cbz
 cEy
 cfB
 cil
-cbz
-aaa
-aaa
-aah
-aaa
+tfv
+ddK
+tfv
+itg
+eJE
 aah
 aaa
 aaa
@@ -133280,14 +133384,14 @@ bFo
 lOb
 cbz
 cKi
-cer
+oqv
 cfC
 bkt
-cbz
-aah
-aah
-aah
-aah
+peN
+bkt
+peN
+bkt
+qFY
 aah
 aah
 aah
@@ -133537,14 +133641,14 @@ bFo
 lOb
 cbz
 cKh
-cer
-cfB
-cer
+kdJ
+tgl
+peN
+bkt
+oWQ
+peN
+ksB
 cbz
-aaa
-aaa
-aah
-aaa
 aah
 aaa
 aaa
@@ -133797,11 +133901,11 @@ ccR
 cew
 cfD
 cya
+bmS
+bmS
+bmS
+bmS
 cbz
-aaa
-aaa
-aah
-aaa
 aah
 aaa
 aaa
@@ -134055,10 +134159,10 @@ cbz
 cbz
 cbz
 cbz
-aaa
-aaa
-aah
-aaa
+cbz
+cbz
+fIz
+cbz
 aah
 aaa
 aaa

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10983,7 +10983,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "asx" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -13129,11 +13129,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "IAA Office";
+	req_one_access = list(19, 38);
+	req_access = list(19, 38)
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "awt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13147,7 +13153,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/black,
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "awv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -21474,15 +21480,15 @@
 /area/station/maintenance/chapel)
 "aMj" = (
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -31052,13 +31058,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"bdu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/blueshield)
 "bdv" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -31883,7 +31882,7 @@
 "beM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/black,
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "beN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32227,6 +32226,20 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"bfn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bfo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36735,12 +36748,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/barbershop)
-"bnK" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/bridge/teleporter)
 "bnL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -43813,7 +43820,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/wall/r_wall,
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "bAe" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -47306,7 +47313,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "bGr" = (
 /turf/simulated/wall/r_wall,
 /area/station/civilian/barbershop)
@@ -47855,7 +47862,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "bHr" = (
 /obj/effect/decal/turf_decal/alpha/black{
 	dir = 1;
@@ -49178,7 +49185,7 @@
 "bJM" = (
 /obj/structure/cable,
 /turf/simulated/floor/carpet/black,
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "bJN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52166,10 +52173,12 @@
 	},
 /area/station/medical/surgeryobs)
 "bPg" = (
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 4
 	},
-/area/station/security/iaa_office)
+/turf/simulated/wall/r_wall,
+/area/station/security/blueshield)
 "bPh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69257,8 +69266,7 @@
 	},
 /area/station/hallway/primary/central)
 "cMR" = (
-/obj/machinery/idpainter,
-/turf/simulated/floor,
+/turf/environment/space,
 /area/station/bridge/hop_office)
 "cMW" = (
 /obj/structure/table/woodentable,
@@ -78566,19 +78574,11 @@
 	},
 /area/station/civilian/locker)
 "msQ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/light/smart{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/turf/simulated/floor,
+/area/station/bridge/teleporter)
 "mtb" = (
 /obj/structure/bookcase{
 	name = "bookcase (Religious)"
@@ -83026,6 +83026,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"rzr" = (
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/iaa_office)
 "rAb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -85173,7 +85178,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/iaa_office)
 "udR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -111626,7 +111631,7 @@ axN
 axN
 axN
 bQl
-aMj
+bfn
 bHa
 cbf
 ccd
@@ -111883,7 +111888,7 @@ bzC
 aGx
 axN
 axN
-aMj
+bfn
 bHa
 cbf
 cvf
@@ -112138,9 +112143,9 @@ axw
 bAD
 bBC
 biL
-bPg
+rzr
 axN
-aMj
+bfn
 cap
 ciO
 bqo
@@ -112397,7 +112402,7 @@ bBM
 nSy
 bLy
 axN
-aMj
+bfn
 bIZ
 bIZ
 bIZ
@@ -112654,7 +112659,7 @@ bHl
 bFU
 bGx
 axN
-msQ
+aMj
 cfq
 byU
 bps
@@ -113161,7 +113166,7 @@ aSM
 aSM
 aSM
 aMR
-aNU
+axN
 udd
 beM
 awt
@@ -113418,12 +113423,12 @@ sVa
 aIR
 kYG
 bWY
-aNU
+axN
 asw
 bHq
 aws
 bGq
-aNU
+axN
 bAc
 lHr
 icr
@@ -116246,7 +116251,7 @@ bcO
 bra
 bra
 bra
-bra
+cMR
 bra
 bra
 bzN
@@ -119333,7 +119338,7 @@ bdc
 cea
 cea
 cea
-bdu
+bPg
 cea
 cea
 aIR
@@ -120311,7 +120316,7 @@ apG
 aqC
 arK
 byE
-bnK
+msQ
 aZb
 bsl
 bAb

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -8692,6 +8692,7 @@
 "aop" = (
 /obj/structure/table,
 /obj/item/weapon/storage/pill_bottle/dice,
+/obj/item/weapon/storage/fancy/donut_box,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aoq" = (
@@ -9092,6 +9093,7 @@
 "apc" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/item/weapon/storage/box/cups,
 /turf/simulated/floor,
 /area/station/security/prison)
 "apd" = (
@@ -9563,10 +9565,14 @@
 	},
 /area/station/security/lobby)
 "apV" = (
-/obj/structure/table,
-/obj/item/weapon/storage/fancy/donut_box,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/station/security/prison)
+/area/station/security/visiting_room)
 "apW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -9764,6 +9770,7 @@
 /area/station/security/forensic_office)
 "aqr" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aqs" = (
@@ -10238,7 +10245,8 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "are" = (
-/obj/structure/window/thin/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/beach_ball/holoball,
 /turf/simulated/floor,
 /area/station/security/prison)
 "arf" = (
@@ -10306,13 +10314,6 @@
 	},
 /area/station/rnd/xenobiology)
 "arn" = (
-/obj/structure/closet,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/sugar,
-/obj/item/weapon/reagent_containers/food/condiment/sugar,
-/obj/item/weapon/reagent_containers/food/drinks/milk,
-/obj/item/weapon/reagent_containers/food/drinks/milk,
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor{
 	dir = 5;
@@ -10864,6 +10865,15 @@
 	name = "Station Intercom (General)";
 	pixel_x = 31
 	},
+/obj/structure/stool/bed/chair/pedalgen{
+	anchored = 1;
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11162,11 +11172,15 @@
 	},
 /area/station/rnd/xenobiology)
 "asR" = (
-/obj/structure/table,
 /obj/structure/window/thin/reinforced,
-/obj/item/weapon/kitchen/rollingpin{
-	force = 1
-	},
+/obj/structure/closet,
+/obj/item/weapon/reagent_containers/food/drinks/milk,
+/obj/item/weapon/reagent_containers/food/drinks/milk,
+/obj/item/weapon/reagent_containers/food/condiment/sugar,
+/obj/item/weapon/reagent_containers/food/condiment/sugar,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -11191,11 +11205,13 @@
 /area/station/civilian/hydroponics)
 "asU" = (
 /obj/structure/table,
-/obj/item/weapon/storage/fancy/egg_box,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme{
 	layer = 5
 	},
 /obj/structure/window/thin/reinforced,
+/obj/item/weapon/kitchen/rollingpin{
+	force = 1
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -11406,7 +11422,6 @@
 	},
 /area/station/security/prison)
 "atq" = (
-/obj/item/weapon/beach_ball/holoball,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11837,11 +11852,6 @@
 /area/station/hallway/primary/fore)
 "auc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "red"
@@ -12242,8 +12252,10 @@
 	},
 /area/station/security/prison)
 "auR" = (
-/obj/structure/holohoop{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -14130,9 +14142,9 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -15380,10 +15392,10 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aAH" = (
-/obj/structure/window/thin/reinforced,
-/obj/structure/table,
-/obj/item/weapon/storage/box/donkpockets,
-/obj/item/weapon/storage/box/cups,
+/obj/structure/holohoop{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aAI" = (
@@ -16311,6 +16323,7 @@
 "aCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "black"
@@ -16507,8 +16520,9 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -18268,13 +18282,15 @@
 /area/station/maintenance/medbay)
 "aGm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/stool/bed/chair/pedalgen{
-	anchored = 1;
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -47839,6 +47855,11 @@
 /area/station/maintenance/atmos)
 "bHu" = (
 /obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "bHv" = (
@@ -74727,15 +74748,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"iFQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "iFS" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "2,3"
@@ -82864,6 +82876,7 @@
 /area/shuttle/supply/station)
 "rsD" = (
 /obj/structure/dumbbells_rack,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "black"
@@ -84716,6 +84729,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
+"tiY" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "tkb" = (
 /obj/machinery/shower{
 	dir = 1
@@ -86674,6 +86691,20 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"wKR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "wLi" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
@@ -86849,20 +86880,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
-"xov" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "xoA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -86923,15 +86940,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"xse" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "xtY" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,6"
@@ -87403,11 +87411,6 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "yjk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -115783,10 +115786,10 @@ ani
 ani
 ani
 aOk
-apV
+asF
 aoY
 aqz
-asF
+axL
 rsD
 auQ
 ayr
@@ -116564,8 +116567,8 @@ avS
 aBO
 ark
 nYP
-iFQ
-bHu
+apV
+tiY
 bIT
 adW
 alZ
@@ -116821,8 +116824,8 @@ avV
 adW
 adW
 adW
-ayq
-xse
+wKR
+bHu
 bGs
 adW
 alZ
@@ -117078,8 +117081,8 @@ avW
 aBO
 ayn
 nYP
-xov
-bHu
+ayq
+tiY
 oLn
 adW
 alZ

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11434,11 +11434,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -14165,11 +14160,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -18865,16 +18855,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/genetics_cloning)
-"aHq" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -43611,16 +43591,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
-"bzI" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/prison)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -43710,7 +43680,8 @@
 "bzQ" = (
 /obj/machinery/door/airlock/security{
 	name = "Visiting Room";
-	req_access = list(1)
+	req_access = list(1);
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47110,14 +47081,20 @@
 	},
 /area/station/storage/tech)
 "bFW" = (
-/obj/structure/table/reinforced,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
@@ -72901,6 +72878,20 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"gNl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "gOl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -75987,15 +75978,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"jQM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76444,6 +76426,16 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"kmt" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79580,14 +79572,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"nFG" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable,
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -83577,6 +83561,15 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"sfp" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "sfM" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "2,0"
@@ -85566,6 +85559,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"uHF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "uIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -86372,6 +86379,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"woE" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable,
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "woS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -87299,20 +87314,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ygy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -115446,9 +115447,9 @@ cIb
 aqz
 are
 ash
-bzI
+atr
 aNr
-nFG
+woE
 bnA
 nYP
 wjo
@@ -115960,9 +115961,9 @@ apc
 cIb
 axL
 atN
-atr
+bFW
 avR
-aHq
+kmt
 bAf
 nYP
 bso
@@ -116476,10 +116477,10 @@ arn
 auc
 atq
 avS
-nFG
+woE
 ark
 nYP
-jQM
+ayq
 bHu
 bIT
 adW
@@ -116736,8 +116737,8 @@ avV
 adW
 adW
 adW
-ayq
-bFW
+uHF
+sfp
 bGs
 adW
 alZ
@@ -116990,10 +116991,10 @@ asU
 aso
 auR
 avW
-aHq
+kmt
 ayn
 nYP
-ygy
+gNl
 bHu
 oLn
 adW

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -19329,10 +19329,11 @@
 	},
 /area/station/medical/hallway)
 "aIu" = (
-/obj/structure/table/glass,
-/obj/structure/mirror{
-	pixel_x = -32
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -43653,13 +43654,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/teleporter)
-"bAc" = (
-/obj/random/vending/snack,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "neutral"
-	},
-/area/station/civilian/barbershop)
 "bAd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47617,13 +47611,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "bHq" = (
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/station/civilian/barbershop)
 "bHr" = (
@@ -80834,6 +80824,15 @@
 	icon_state = "white"
 	},
 /area/station/rnd/xenobiology)
+"pjb" = (
+/obj/structure/table/glass,
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "pjk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81732,6 +81731,7 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "qob" = (
+/obj/random/vending/snack,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "neutral"
@@ -82063,9 +82063,9 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
@@ -121564,11 +121564,11 @@ ovb
 bhv
 bAa
 bAa
-bHq
+aIu
 sxb
-aIu
+pjb
 aJV
-aIu
+pjb
 mlb
 auc
 amR
@@ -121819,9 +121819,9 @@ jhA
 aIR
 cxv
 bhv
-qob
-qob
 bHq
+bHq
+aIu
 bnJ
 bJd
 bHt
@@ -122333,7 +122333,7 @@ bXR
 aPE
 bME
 cMQ
-bAc
+qob
 mXb
 auc
 cRb

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -2333,7 +2333,7 @@
 /area/station/security/brig)
 "adW" = (
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "adX" = (
 /obj/structure/rack,
 /obj/structure/window/thin/reinforced{
@@ -10281,7 +10281,7 @@
 	dir = 1;
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "arl" = (
 /obj/item/weapon/cigbutt{
 	pixel_x = 5;
@@ -12818,8 +12818,8 @@
 /obj/structure/stool/bed/chair/metal/red,
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
-	name = "Chamber One";
+	frequency = 1482;
+	name = "Chamber Two";
 	pixel_x = -26
 	},
 /turf/simulated/floor{
@@ -12830,8 +12830,8 @@
 /obj/structure/stool/bed/chair/metal/red,
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
-	name = "Chamber One";
+	frequency = 1484;
+	name = "Chamber Three";
 	pixel_x = -26
 	},
 /turf/simulated/floor{
@@ -12868,8 +12868,8 @@
 /obj/structure/stool/bed/chair/metal/red,
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
-	name = "Chamber One";
+	frequency = 1486;
+	name = "Chamber Four";
 	pixel_x = -26
 	},
 /turf/simulated/floor{
@@ -14105,7 +14105,7 @@
 	dir = 1;
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "ayo" = (
 /obj/item/weapon/flora/pottedplant{
 	icon_state = "plant-22"
@@ -14129,8 +14129,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "ayr" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prison)
@@ -16007,7 +16012,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "aBP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -36665,7 +36670,7 @@
 	dir = 1;
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bnB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -39255,7 +39260,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bsp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -43673,8 +43678,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bzR" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -43827,7 +43837,7 @@
 	dir = 1;
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bAg" = (
 /obj/structure/closet/fireaxecabinet{
 	pixel_y = -32
@@ -47299,10 +47309,11 @@
 	name = "Brig dark down APC";
 	pixel_y = -27
 	},
+/obj/structure/cable,
 /turf/simulated/floor{
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bGt" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -47789,7 +47800,7 @@
 /turf/simulated/floor{
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bHq" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -47829,7 +47840,7 @@
 "bHu" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bHv" = (
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
@@ -48002,7 +48013,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bHL" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor{
@@ -48112,7 +48123,7 @@
 /area/station/civilian/bar)
 "bHV" = (
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bHW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48295,7 +48306,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bIm" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -48623,13 +48634,13 @@
 /turf/simulated/floor{
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bIP" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bIQ" = (
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Brig Desk";
@@ -48639,7 +48650,7 @@
 /turf/simulated/floor{
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bIR" = (
 /obj/item/weapon/folder/white,
 /obj/item/device/radio/headset/headset_medsci,
@@ -48670,7 +48681,7 @@
 /turf/simulated/floor{
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bIU" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -49665,7 +49676,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "bKS" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -74716,6 +74727,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"iFQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "iFS" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "2,3"
@@ -79863,7 +79883,7 @@
 	name = "Confession Booth"
 	},
 /turf/environment/space,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "nZb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -80537,7 +80557,7 @@
 /turf/simulated/floor{
 	icon_state = "black"
 	},
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "oMb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -86287,7 +86307,7 @@
 "wjo" = (
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor,
-/area/station/maintenance/eva)
+/area/station/security/visiting_room)
 "wjr" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,3"
@@ -86829,6 +86849,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"xov" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "xoA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -86889,6 +86923,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"xse" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "xtY" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,6"
@@ -116521,7 +116564,7 @@ avS
 aBO
 ark
 nYP
-ayq
+iFQ
 bHu
 bIT
 adW
@@ -116779,7 +116822,7 @@ adW
 adW
 adW
 ayq
-bHu
+xse
 bGs
 adW
 alZ
@@ -117035,7 +117078,7 @@ avW
 aBO
 ayn
 nYP
-ayq
+xov
 bHu
 oLn
 adW

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -43648,7 +43648,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/primary/central)
 "bAb" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/window/thin/reinforced{
@@ -44759,7 +44759,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/primary/central)
 "bCj" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -47209,7 +47209,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/primary/central)
 "bGz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47620,7 +47620,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/primary/central)
 "bHr" = (
 /obj/effect/decal/turf_decal/alpha/black{
 	dir = 1;
@@ -78963,7 +78963,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/primary/central)
 "mXO" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -81751,7 +81751,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/primary/central)
 "qoN" = (
 /obj/machinery/light/smart,
 /obj/structure/closet,
@@ -121320,8 +121320,8 @@ cea
 aPG
 ovb
 aEV
-auc
-auc
+aMR
+aMR
 auc
 auc
 auc

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9564,6 +9564,20 @@
 	icon_state = "red"
 	},
 /area/station/security/lobby)
+"apV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "apW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -10953,9 +10967,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "asw" = (
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11433,6 +11444,11 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -18868,6 +18884,13 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/genetics_cloning)
+"aHq" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -43593,14 +43616,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
-"bzI" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable,
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -47095,6 +47110,20 @@
 	icon_state = "dark"
 	},
 /area/station/storage/tech)
+"bFW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
@@ -47271,6 +47300,14 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
+"bGn" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable,
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "bGo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47929,20 +47966,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
-"bHD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "bHE" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -74201,13 +74224,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"icK" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -76463,14 +76479,15 @@
 	},
 /area/station/medical/reception)
 "kmt" = (
-/obj/structure/table/reinforced,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -85591,16 +85608,11 @@
 	},
 /area/station/civilian/toilet)
 "uHF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -87337,21 +87349,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ygy" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/prison)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -113477,7 +113474,7 @@ bHS
 asw
 aIR
 aws
-bek
+aIR
 aIR
 bAc
 lHr
@@ -115485,9 +115482,9 @@ cIb
 aqz
 are
 ash
-atr
+kmt
 aNr
-bzI
+bGn
 bnA
 nYP
 wjo
@@ -115999,7 +115996,7 @@ apc
 cIb
 axL
 atN
-ygy
+atr
 avR
 aBO
 bAf
@@ -116515,7 +116512,7 @@ arn
 auc
 atq
 avS
-bzI
+bGn
 ark
 nYP
 ayq
@@ -116775,8 +116772,8 @@ avV
 adW
 adW
 adW
-bHD
-kmt
+apV
+uHF
 bGs
 adW
 alZ
@@ -117032,7 +117029,7 @@ avW
 aBO
 ayn
 nYP
-uHF
+bFW
 bHu
 oLn
 adW
@@ -117291,7 +117288,7 @@ adW
 adW
 bzQ
 adW
-icK
+aHq
 adW
 agO
 bNs

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36064,8 +36064,8 @@
 /area/station/medical/reception)
 "bmu" = (
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkblue"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/bridge/teleporter)
 "bmv" = (
@@ -47881,6 +47881,9 @@
 "bHK" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
+	},
+/obj/structure/grille{
+	destroyed = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
@@ -73645,6 +73648,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"hHE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "hIb" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -77071,6 +77083,12 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"kYM" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "kZn" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
@@ -80301,12 +80319,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"ovw" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "ovR" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prison/toilet)
@@ -80622,6 +80634,15 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"oQk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "oQM" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
@@ -81758,6 +81779,12 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"qnb" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "qnN" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,5"
@@ -83514,15 +83541,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"rXD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "rXE" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/decal/turf_decal/wood{
@@ -84437,15 +84455,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
-"sQp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/dormitory)
 "sRb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -84724,23 +84733,6 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
-"tfe" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "tfv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -86287,12 +86279,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
-"wej" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/bridge/teleporter)
 "wfg" = (
 /obj/structure/table/woodentable,
 /obj/item/folder_holder{
@@ -86417,6 +86403,23 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/teleporter)
+"wja" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "wjr" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,3"
@@ -118734,12 +118737,12 @@ aua
 bbb
 aef
 ayu
-sQp
+hHE
 bAH
-sQp
-sQp
-sQp
-sQp
+hHE
+hHE
+hHE
+hHE
 bNP
 aeJ
 aeJ
@@ -119500,7 +119503,7 @@ aoz
 arJ
 byE
 sNO
-ovw
+kYM
 rEq
 jtE
 byE
@@ -119757,7 +119760,7 @@ ajo
 arI
 byE
 xZq
-wej
+bmu
 brZ
 mAJ
 byE
@@ -120271,7 +120274,7 @@ apb
 arL
 byE
 asZ
-wej
+bmu
 bsb
 bHz
 byE
@@ -120528,7 +120531,7 @@ aqC
 arK
 byE
 msQ
-wej
+bmu
 bsl
 bAb
 byE
@@ -121041,7 +121044,7 @@ ajo
 apb
 aql
 byE
-bmu
+qnb
 arT
 whD
 avj
@@ -122119,11 +122122,11 @@ qBb
 xTO
 cro
 bye
-rXD
-rXD
+oQk
+oQk
 bGq
-rXD
-tfe
+oQk
+wja
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -39889,9 +39889,12 @@
 /turf/environment/space,
 /area/shuttle/administration/station)
 "btE" = (
-/obj/machinery/pdapainter,
-/turf/simulated/floor,
-/area/station/bridge/hop_office)
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/sign/poster/contraband/syndicate_recruitment{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "btF" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -66674,13 +66677,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"cEq" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_y = 31
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "cEr" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
@@ -70117,10 +70113,6 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage_secure)
-"dVq" = (
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "dWb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -71160,6 +71152,13 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
+"fdo" = (
+/obj/structure/stool/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "fec" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor{
@@ -71717,15 +71716,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "fIz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/pdapainter,
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/bridge/hop_office)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -72106,6 +72099,10 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"gdl" = (
+/obj/structure/table,
+/turf/simulated/floor,
+/area/station/security/prison)
 "geb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -74856,10 +74853,9 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "iQf" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/cups,
-/turf/simulated/floor,
-/area/station/security/prison)
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "iRb" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79634,6 +79630,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/construction)
+"nMi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "nMk" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -80325,6 +80331,11 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/medbreak)
+"owZ" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/cups,
+/turf/simulated/floor,
+/area/station/security/prison)
 "oxb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -80371,13 +80382,6 @@
 /obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/storage_secure)
-"ozt" = (
-/obj/structure/stool/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "ozz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -82076,14 +82080,14 @@
 /turf/simulated/wall,
 /area/station/civilian/chapel/crematorium)
 "qFY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
 	},
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/turf/environment/space,
+/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "qGb" = (
 /obj/structure/stool/bed,
@@ -82961,10 +82965,6 @@
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"ruE" = (
-/obj/structure/table,
-/turf/simulated/floor,
-/area/station/security/prison)
 "rvb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 1
@@ -113859,7 +113859,7 @@ blR
 blR
 blR
 blR
-fIz
+nMi
 bHF
 cux
 boW
@@ -115361,7 +115361,7 @@ aob
 apS
 cmc
 aqr
-iQf
+owZ
 aCt
 nYP
 atp
@@ -115408,7 +115408,7 @@ bpA
 bra
 pUb
 bmk
-btE
+fIz
 bwM
 bvn
 bzK
@@ -115872,7 +115872,7 @@ ani
 ani
 ani
 aOk
-ruE
+gdl
 aoY
 axL
 asF
@@ -116394,8 +116394,8 @@ yjk
 aNo
 atp
 adW
-dVq
-ozt
+iQf
+fdo
 hdb
 alZ
 bCL
@@ -116651,7 +116651,7 @@ ayq
 atq
 avS
 adW
-cEq
+btE
 alZ
 alZ
 aKY

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -14094,8 +14094,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 9;
+	icon_state = "whitepurple"
 	},
 /area/station/civilian/barbershop)
 "ayo" = (
@@ -15990,8 +15990,8 @@
 /area/station/civilian/kitchen)
 "aBO" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/station/civilian/barbershop)
 "aBP" = (
@@ -36635,18 +36635,35 @@
 	},
 /area/station/bridge)
 "bnA" = (
-/obj/item/weapon/haircomb,
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/cardpay{
-	dir = 8;
-	pixel_x = -3;
-	pixel_y = 15
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bsentry";
+	name = "Blueshield Office Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Blueshield Office";
+	req_access = list(42)
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "darkbluefull"
 	},
-/area/station/civilian/barbershop)
+/area/station/security/blueshield)
 "bnB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36739,7 +36756,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "whitepurple"
 	},
 /area/station/civilian/barbershop)
 "bnL" = (
@@ -37765,16 +37782,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
 "bpE" = (
-/obj/machinery/door_control{
-	id = "bsstorage";
-	name = "Storage Shutter";
-	pixel_y = 26;
-	req_access = list(42)
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -37811,21 +37819,12 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
 	},
 /area/station/security/blueshield)
 "bpJ" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	dir = 8;
-	name = "Brig dark left APC";
-	pixel_x = -27
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -42080,6 +42079,11 @@
 	dir = 4;
 	pixel_x = -4
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 3;
+	pixel_y = -1
+	},
 /turf/simulated/wall/r_wall,
 /area/station/security/blueshield)
 "bxd" = (
@@ -42194,9 +42198,6 @@
 /area/station/cargo/storage)
 "bxl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43584,7 +43585,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "whitepurple"
 	},
 /area/station/civilian/barbershop)
 "bzJ" = (
@@ -43689,8 +43690,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/station/civilian/barbershop)
 "bzR" = (
@@ -43783,11 +43784,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -47755,7 +47751,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "whitepurple"
 	},
 /area/station/civilian/barbershop)
 "bHj" = (
@@ -56575,11 +56571,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
-"cbh" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/effect/spawner/lootdrop,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "cbi" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -70118,13 +70109,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
-"dFQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/station/bridge/teleporter)
 "dHv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74025,6 +74009,13 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"hTF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "hUb" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -79457,6 +79448,11 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/hallway)
+"nwi" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/spawner/lootdrop,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "nws" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80598,8 +80594,8 @@
 "oLn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 10;
+	icon_state = "whitepurple"
 	},
 /area/station/civilian/barbershop)
 "oMb" = (
@@ -82976,6 +82972,22 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"rwJ" = (
+/obj/item/weapon/haircomb,
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/device/cardpay{
+	dir = 8;
+	pixel_x = -3;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "rxb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -86649,6 +86661,16 @@
 "wLi" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
+"wLk" = (
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	dir = 8;
+	name = "Brig dark left APC";
+	pixel_x = -32;
+	pixel_y = -6
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/blueshield)
 "wLY" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -114693,7 +114715,7 @@ bLx
 bNr
 ayr
 aqf
-cbh
+nwi
 cgt
 alZ
 alZ
@@ -115463,7 +115485,7 @@ aNr
 bGr
 nYP
 rCb
-bnA
+rwJ
 bHK
 bIO
 bFW
@@ -119055,7 +119077,7 @@ aqi
 aqi
 byE
 byE
-dFQ
+hTF
 kNr
 byE
 byE
@@ -120132,7 +120154,7 @@ afz
 cea
 bxc
 cea
-avF
+bnA
 cea
 cea
 bPp
@@ -120643,7 +120665,7 @@ bdc
 jWb
 jZb
 tnb
-cea
+wLk
 aDZ
 bjz
 avq

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10641,6 +10641,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/camera{
+	c_tag = "Holodeck East";
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "arU" = (
@@ -13099,15 +13103,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
-"awr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/station/bridge/teleporter)
 "aws" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28614,12 +28609,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
-"aZb" = (
-/obj/machinery/camera{
-	c_tag = "Teleporter"
-	},
-/turf/simulated/floor,
-/area/station/bridge/teleporter)
 "aZc" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior";
@@ -39108,6 +39097,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bsa" = (
@@ -39134,8 +39129,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
@@ -39145,11 +39140,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 9
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
@@ -39224,7 +39216,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -42997,6 +42989,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
@@ -76993,6 +76991,12 @@
 	name = "Teleport Access";
 	req_access = list(17)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "kNR" = (
@@ -83159,6 +83163,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "rFb" = (
@@ -86254,8 +86264,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
@@ -119803,7 +119811,7 @@ aqA
 aqk
 byE
 bBU
-bmu
+aRs
 byH
 bHs
 byE
@@ -120060,7 +120068,7 @@ apb
 arL
 byE
 asZ
-aRs
+bmu
 bsb
 bHz
 byE
@@ -120317,7 +120325,7 @@ aqC
 arK
 byE
 msQ
-aZb
+bmu
 bsl
 bAb
 byE
@@ -121089,7 +121097,7 @@ arM
 byE
 bnA
 byE
-awr
+byE
 afl
 afl
 bGu

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -45094,10 +45094,8 @@
 	},
 /area/station/rnd/hor)
 "bCL" = (
-/obj/structure/stool/bed/chair{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/table,
+/obj/item/device/taperecorder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bCM" = (
@@ -47909,9 +47907,13 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "bHV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
 /area/station/maintenance/eva)
 "bHW" = (
 /obj/structure/cable{
@@ -49444,17 +49446,8 @@
 	},
 /area/station/rnd/mixing)
 "bKT" = (
-/obj/structure/table,
-/obj/item/weapon/stamp/denied{
-	pixel_x = -6
-	},
-/obj/effect/decal/turf_decal/set_burned,
-/obj/item/toy/figure/iaa{
-	pixel_y = 8
-	},
-/obj/item/weapon/stamp/approve{
-	pixel_x = 7
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bKU" = (
@@ -69128,19 +69121,14 @@
 	},
 /area/station/hallway/primary/fore)
 "cRb" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/effect/decal/remains/human/burned,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
-"cRS" = (
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
+/obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 4
 	},
-/obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/maintenance/eva)
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "cSb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -69937,12 +69925,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
-"dMt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "dNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -72827,11 +72809,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"gSE" = (
-/obj/structure/table,
-/obj/item/device/taperecorder,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "gSN" = (
 /obj/machinery/door/poddoor{
 	id = "disvent";
@@ -73642,16 +73619,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"hKr" = (
-/obj/structure/table,
-/obj/item/weapon/cigbutt/cigarbutt{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/effect/decal/turf_decal/set_burned,
-/obj/item/trash/candle/red,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "hLb" = (
 /obj/machinery/gateway/center/station,
 /turf/simulated/floor{
@@ -74468,6 +74435,16 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
+"iAe" = (
+/obj/structure/table,
+/obj/item/weapon/cigbutt/cigarbutt{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/trash/candle/red,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "iAL" = (
 /obj/item/weapon/reagent_containers/spray/plantbgone{
 	pixel_y = 3
@@ -74810,6 +74787,10 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge)
+"iQf" = (
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/eva)
 "iRb" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -76736,6 +76717,12 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
+"kIM" = (
+/obj/structure/stool/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "kJn" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -77216,6 +77203,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"lkh" = (
+/obj/machinery/light/smart,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "lkl" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor{
@@ -77354,12 +77347,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"luU" = (
-/obj/structure/stool/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "lvb" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -77794,6 +77781,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lNp" = (
+/obj/structure/stool/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/set_damaged,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "lNB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -79643,11 +79637,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"nQU" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/evidence,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "nSy" = (
 /obj/structure/table/woodentable,
 /obj/item/pens_bin{
@@ -80114,19 +80103,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"onH" = (
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed";
-	name = "Clothing Storage"
-	},
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/random/cloth/random_cloth_safe,
-/obj/item/weapon/storage/briefcase,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "oob" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -81675,15 +81651,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"qmX" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "qnN" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,5"
@@ -81748,6 +81715,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/singularity)
+"qqn" = (
+/obj/structure/table,
+/obj/item/weapon/stamp/denied{
+	pixel_x = -6
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/toy/figure/iaa{
+	pixel_y = 8
+	},
+/obj/item/weapon/stamp/approve{
+	pixel_x = 7
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "qrb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -81983,6 +81964,11 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"qEB" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/evidence,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "qFq" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -82161,6 +82147,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/arrival)
+"qOU" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "qPb" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -82229,6 +82224,17 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics_cloning)
+"qQG" = (
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "qRb" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -83943,6 +83949,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"szd" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/computerframe{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "szj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -84032,16 +84045,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
-"sDU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "sEb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -84758,10 +84761,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
-"toC" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/eva)
 "tpb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -84828,6 +84827,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"tzJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "tCO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85536,17 +85545,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"uGa" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
-/obj/structure/cable,
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "uHk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -86197,6 +86195,11 @@
 	icon_state = "blue"
 	},
 /area/station/engineering/engine)
+"wgs" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/decal/remains/human/burned,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "wgu" = (
 /obj/machinery/field_generator,
 /obj/machinery/camera{
@@ -86393,6 +86396,19 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/altar)
+"wqD" = (
+/obj/structure/closet{
+	icon_closed = "cabinet_closed";
+	icon_opened = "cabinet_open";
+	icon_state = "cabinet_closed";
+	name = "Clothing Storage"
+	},
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/random/cloth/random_cloth_safe,
+/obj/item/weapon/storage/briefcase,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "wrF" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -86451,6 +86467,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
+"wyC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "wyS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -87049,13 +87071,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"xKJ" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/structure/computerframe{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "xLk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -115469,11 +115484,11 @@ ash
 atr
 aNr
 adW
-onH
-cRb
+wqD
+wgs
 alZ
 alZ
-xKJ
+szd
 agO
 alZ
 aYi
@@ -115727,8 +115742,8 @@ auQ
 atp
 adW
 atc
-bCL
-luU
+lNp
+kIM
 alZ
 atc
 bHK
@@ -115984,8 +115999,8 @@ auQ
 atp
 adW
 alZ
-hKr
-bKT
+iAe
+qqn
 alZ
 alZ
 agO
@@ -116244,7 +116259,7 @@ alZ
 hdb
 hdb
 alZ
-gSE
+bCL
 agO
 alZ
 aYi
@@ -116496,12 +116511,12 @@ arn
 ayq
 atq
 avS
-toC
+iQf
 atc
 alZ
 alZ
 alZ
-nQU
+qEB
 agO
 alZ
 aYi
@@ -117011,11 +117026,11 @@ aso
 auR
 avW
 adW
-bHV
-bHV
-bHV
-bHV
-dMt
+bKT
+bKT
+bKT
+bKT
+wyC
 agO
 alZ
 aYi
@@ -117268,11 +117283,11 @@ ayr
 ayr
 ayr
 adW
-cRS
+bHV
 agO
 bzQ
 agO
-cRS
+bHV
 agO
 agO
 bNs
@@ -121695,7 +121710,7 @@ bnJ
 bJd
 bHt
 bJd
-qob
+lkh
 auc
 cdP
 bLt
@@ -121951,8 +121966,8 @@ aHk
 bGw
 bGr
 pib
-sDU
-uGa
+tzJ
+qQG
 auc
 cdP
 bLt
@@ -122205,8 +122220,8 @@ cMQ
 auc
 mXb
 pjb
-mlb
-qmX
+cRb
+qOU
 aEq
 bHi
 aIA

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36062,7 +36062,7 @@
 /area/station/medical/reception)
 "bmu" = (
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
 	icon_state = "darkblue"
 	},
 /area/station/bridge/teleporter)
@@ -42631,9 +42631,7 @@
 	sortType = "Barbershop"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -43701,9 +43699,8 @@
 	},
 /area/station/security/blueshield)
 "bAa" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/light/smart{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
@@ -69206,7 +69203,6 @@
 	},
 /area/station/hallway/primary/fore)
 "cRb" = (
-/obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
 	dir = 4
 	},
@@ -71188,12 +71184,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
-"fai" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "fbb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -71696,23 +71686,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"fEW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "fFb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73972,12 +73945,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
-"hXS" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/bridge/teleporter)
 "hYb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -77569,15 +77536,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/station/civilian/fitness)
-"lzi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "lzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79738,6 +79696,25 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"nOu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "nPb" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -82291,6 +82268,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -83452,6 +83433,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"rRZ" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/bridge/teleporter)
 "rSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84002,6 +83989,12 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/aft)
+"stk" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "stq" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin/reinforced,
@@ -87052,6 +87045,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"xrZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "xtY" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,6"
@@ -119485,7 +119487,7 @@ aoz
 arJ
 byE
 sNO
-fai
+bmu
 rEq
 jtE
 byE
@@ -119742,7 +119744,7 @@ ajo
 arI
 byE
 xZq
-hXS
+rRZ
 brZ
 mAJ
 byE
@@ -120256,7 +120258,7 @@ apb
 arL
 byE
 asZ
-hXS
+rRZ
 bsb
 bHz
 byE
@@ -120513,7 +120515,7 @@ aqC
 arK
 byE
 msQ
-hXS
+rRZ
 bsl
 bAb
 byE
@@ -121026,7 +121028,7 @@ ajo
 apb
 aql
 byE
-bmu
+stk
 arT
 whD
 avj
@@ -122103,12 +122105,12 @@ cro
 qBb
 xTO
 cro
-bye
-lzi
-lzi
+nOu
+xrZ
+xrZ
 bGq
-lzi
-fEW
+xrZ
+bye
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -45094,16 +45094,12 @@
 	},
 /area/station/rnd/hor)
 "bCL" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
+/obj/structure/stool/bed/chair{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/obj/effect/decal/turf_decal/set_damaged,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "bCM" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -47913,10 +47909,8 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "bHV" = (
-/obj/structure/stool/bed/chair{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bHW" = (
@@ -49451,7 +49445,16 @@
 /area/station/rnd/mixing)
 "bKT" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/evidence,
+/obj/item/weapon/stamp/denied{
+	pixel_x = -6
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/toy/figure/iaa{
+	pixel_y = 8
+	},
+/obj/item/weapon/stamp/approve{
+	pixel_x = 7
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bKU" = (
@@ -69125,9 +69128,18 @@
 	},
 /area/station/hallway/primary/fore)
 "cRb" = (
-/obj/structure/table,
-/obj/item/device/taperecorder,
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/decal/remains/human/burned,
 /turf/simulated/floor/plating,
+/area/station/maintenance/eva)
+"cRS" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
 /area/station/maintenance/eva)
 "cSb" = (
 /obj/structure/sink{
@@ -69925,6 +69937,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
+"dMt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "dNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -72809,6 +72827,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"gSE" = (
+/obj/structure/table,
+/obj/item/device/taperecorder,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "gSN" = (
 /obj/machinery/door/poddoor{
 	id = "disvent";
@@ -73008,13 +73031,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"hbB" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/structure/computerframe{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "hbR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -73264,20 +73280,6 @@
 	icon_state = "2,4"
 	},
 /area/shuttle/supply/station)
-"hpY" = (
-/obj/structure/table,
-/obj/item/weapon/stamp/denied{
-	pixel_x = -6
-	},
-/obj/effect/decal/turf_decal/set_burned,
-/obj/item/toy/figure/iaa{
-	pixel_y = 8
-	},
-/obj/item/weapon/stamp/approve{
-	pixel_x = 7
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "hqb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -73352,15 +73354,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
-"hti" = (
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
-	},
-/obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/maintenance/eva)
 "huy" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "1,3"
@@ -73649,6 +73642,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"hKr" = (
+/obj/structure/table,
+/obj/item/weapon/cigbutt/cigarbutt{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/trash/candle/red,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "hLb" = (
 /obj/machinery/gateway/center/station,
 /turf/simulated/floor{
@@ -76413,6 +76416,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "bsentry";
+	name = "Blueshield Office Shutters";
+	opacity = 0
+	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Blueshield Maintenance";
 	req_access = list(42)
@@ -77344,6 +77354,12 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"luU" = (
+/obj/structure/stool/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "lvb" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -77931,12 +77947,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/morgue)
-"lWj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "lXb" = (
 /obj/item/weapon/pen,
 /obj/structure/table/glass,
@@ -78797,11 +78807,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"mQa" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/effect/decal/remains/human/burned,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "mQb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -79638,6 +79643,11 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"nQU" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/evidence,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "nSy" = (
 /obj/structure/table/woodentable,
 /obj/item/pens_bin{
@@ -80104,6 +80114,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"onH" = (
+/obj/structure/closet{
+	icon_closed = "cabinet_closed";
+	icon_opened = "cabinet_open";
+	icon_state = "cabinet_closed";
+	name = "Clothing Storage"
+	},
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/random/cloth/random_cloth_safe,
+/obj/item/weapon/storage/briefcase,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "oob" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -81652,6 +81675,15 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"qmX" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "qnN" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,5"
@@ -84000,6 +84032,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"sDU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "sEb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -84090,16 +84132,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"sJh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "sJr" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green{
@@ -84489,16 +84521,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"tbV" = (
-/obj/structure/table,
-/obj/item/weapon/cigbutt/cigarbutt{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/effect/decal/turf_decal/set_burned,
-/obj/item/trash/candle/red,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "tcb" = (
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -84736,6 +84758,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
+"toC" = (
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/eva)
 "tpb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -85009,10 +85035,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/locker)
-"tRU" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/eva)
 "tSb" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -85514,6 +85536,17 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"uGa" = (
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "uHk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -85724,11 +85757,6 @@
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"vmn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "vmY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/barricade/wooden,
@@ -85816,15 +85844,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"vBK" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "vBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86463,19 +86482,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
-"wCv" = (
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed";
-	name = "Clothing Storage"
-	},
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/random/cloth/random_cloth_safe,
-/obj/item/weapon/storage/briefcase,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "wCF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -87043,6 +87049,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"xKJ" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/computerframe{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "xLk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -87320,12 +87333,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ydF" = (
-/obj/structure/stool/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -115462,11 +115469,11 @@ ash
 atr
 aNr
 adW
-wCv
-mQa
+onH
+cRb
 alZ
 alZ
-hbB
+xKJ
 agO
 alZ
 aYi
@@ -115720,8 +115727,8 @@ auQ
 atp
 adW
 atc
-bHV
-ydF
+bCL
+luU
 alZ
 atc
 bHK
@@ -115977,8 +115984,8 @@ auQ
 atp
 adW
 alZ
-tbV
-hpY
+hKr
+bKT
 alZ
 alZ
 agO
@@ -116237,7 +116244,7 @@ alZ
 hdb
 hdb
 alZ
-cRb
+gSE
 agO
 alZ
 aYi
@@ -116489,12 +116496,12 @@ arn
 ayq
 atq
 avS
-tRU
+toC
 atc
 alZ
 alZ
 alZ
-bKT
+nQU
 agO
 alZ
 aYi
@@ -117004,11 +117011,11 @@ aso
 auR
 avW
 adW
-vmn
-vmn
-vmn
-vmn
-lWj
+bHV
+bHV
+bHV
+bHV
+dMt
 agO
 alZ
 aYi
@@ -117261,11 +117268,11 @@ ayr
 ayr
 ayr
 adW
-hti
+cRS
 agO
 bzQ
 agO
-hti
+cRS
 agO
 agO
 bNs
@@ -121944,8 +121951,8 @@ aHk
 bGw
 bGr
 pib
-sJh
-bCL
+sDU
+uGa
 auc
 cdP
 bLt
@@ -122199,7 +122206,7 @@ auc
 mXb
 pjb
 mlb
-vBK
+qmX
 aEq
 bHi
 aIA

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -39889,12 +39889,10 @@
 /turf/environment/space,
 /area/shuttle/administration/station)
 "btE" = (
-/obj/structure/stool/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/obj/structure/table,
+/obj/item/weapon/storage/box/cups,
+/turf/simulated/floor,
+/area/station/security/prison)
 "btF" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -71709,15 +71707,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "fIz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/pdapainter,
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/bridge/hop_office)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -71907,6 +71899,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"fRM" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/sign/poster/contraband/syndicate_recruitment{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "fRW" = (
 /obj/structure/object_wall/pod{
 	dir = 1;
@@ -74848,9 +74847,15 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "iQf" = (
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "iRb" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -75066,6 +75071,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"iZH" = (
+/obj/structure/stool/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "jab" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78539,6 +78551,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"mym" = (
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "myC" = (
 /obj/machinery/door/airlock/mining/glass{
 	dir = 4;
@@ -79272,6 +79288,10 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"nrM" = (
+/obj/structure/table,
+/turf/simulated/floor,
+/area/station/security/prison)
 "nsb" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/alarm{
@@ -81933,15 +81953,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"qza" = (
-/obj/machinery/pdapainter,
-/turf/simulated/floor,
-/area/station/bridge/hop_office)
-"qAl" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/cups,
-/turf/simulated/floor,
-/area/station/security/prison)
 "qAF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -83531,13 +83542,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"rZg" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_y = 31
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "rZh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85339,10 +85343,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
-"ufK" = (
-/obj/structure/table,
-/turf/simulated/floor,
-/area/station/security/prison)
 "ugb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -113862,7 +113862,7 @@ blR
 blR
 blR
 blR
-fIz
+iQf
 bHF
 cux
 boW
@@ -115364,7 +115364,7 @@ aob
 apS
 cmc
 aqr
-qAl
+btE
 aCt
 nYP
 atp
@@ -115411,7 +115411,7 @@ bpA
 bra
 pUb
 bmk
-qza
+fIz
 bwM
 bvn
 bzK
@@ -115875,7 +115875,7 @@ ani
 ani
 ani
 aOk
-ufK
+nrM
 aoY
 axL
 asF
@@ -116397,8 +116397,8 @@ yjk
 aNo
 atp
 adW
-iQf
-btE
+mym
+iZH
 hdb
 alZ
 bCL
@@ -116654,7 +116654,7 @@ ayq
 atq
 avS
 adW
-rZg
+fRM
 alZ
 alZ
 aKY

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10426,7 +10426,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "redcorner"
@@ -13129,10 +13128,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -15302,9 +15297,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 1
-	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -42219,8 +42212,6 @@
 	},
 /area/station/security/blueshield)
 "bxm" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -42705,6 +42696,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -47267,6 +47263,7 @@
 	},
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/structure/rack,
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bGp" = (
@@ -80789,16 +80786,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Visiting Room";
-	sortType = "Barbershop"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "oZb" = (
@@ -111780,7 +111773,7 @@ axN
 axN
 axN
 axN
-bQl
+cAW
 bfn
 bHa
 cbf

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -42631,7 +42631,9 @@
 	sortType = "Barbershop"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -71186,6 +71188,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"fai" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "fbb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -71688,6 +71696,23 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"fEW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "fFb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73880,25 +73905,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
-"hUd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "hUv" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -73966,6 +73972,12 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"hXS" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/bridge/teleporter)
 "hYb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -77557,6 +77569,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/station/civilian/fitness)
+"lzi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "lzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84911,15 +84932,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"trT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "tso" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -85992,12 +86004,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
-"vCK" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "vDF" = (
 /obj/item/clothing/under/rainbow,
 /turf/simulated/floor/wood,
@@ -86931,12 +86937,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"xdz" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/bridge/teleporter)
 "xeC" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -119485,7 +119485,7 @@ aoz
 arJ
 byE
 sNO
-vCK
+fai
 rEq
 jtE
 byE
@@ -119742,7 +119742,7 @@ ajo
 arI
 byE
 xZq
-xdz
+hXS
 brZ
 mAJ
 byE
@@ -120256,7 +120256,7 @@ apb
 arL
 byE
 asZ
-xdz
+hXS
 bsb
 bHz
 byE
@@ -120513,7 +120513,7 @@ aqC
 arK
 byE
 msQ
-xdz
+hXS
 bsl
 bAb
 byE
@@ -122103,12 +122103,12 @@ cro
 qBb
 xTO
 cro
-hUd
-trT
-trT
-bGq
-trT
 bye
+lzi
+lzi
+bGq
+lzi
+fEW
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -17499,9 +17499,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aEV" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -18713,6 +18710,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass{
+	name = "Barbershop"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -19328,6 +19330,9 @@
 /area/station/medical/hallway)
 "aIu" = (
 /obj/structure/table/glass,
+/obj/structure/mirror{
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -20228,10 +20233,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/arrival)
-"aKa" = (
-/obj/structure/mirror,
-/turf/simulated/wall,
-/area/station/civilian/barbershop)
 "aKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43632,11 +43633,12 @@
 	},
 /area/station/security/blueshield)
 "bAa" = (
-/obj/machinery/light/smart{
-	dir = 8
+/obj/structure/stool/bed/chair/metal/blue{
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/station/civilian/barbershop)
 "bAb" = (
@@ -43652,12 +43654,12 @@
 	},
 /area/station/bridge/teleporter)
 "bAc" = (
-/obj/random/vending/cola,
+/obj/random/vending/snack,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 6;
+	icon_state = "neutral"
 	},
-/area/station/hallway/primary/central)
+/area/station/civilian/barbershop)
 "bAd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44746,9 +44748,6 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "bCi" = (
-/obj/machinery/door/airlock/glass{
-	name = "Barbershop"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44758,7 +44757,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "whitepurple"
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/station/civilian/barbershop)
 "bCj" = (
@@ -47171,6 +47171,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -47195,10 +47199,6 @@
 	},
 /area/station/security/iaa_office)
 "bGy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -47206,6 +47206,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -47616,12 +47617,13 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "bHq" = (
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "whitepurple"
+	icon_state = "purplechecker"
 	},
 /area/station/civilian/barbershop)
 "bHr" = (
@@ -68983,9 +68985,6 @@
 	c_tag = "Central Hallway South-East";
 	dir = 8
 	},
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 1
-	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "neutral"
@@ -69150,6 +69149,10 @@
 "cRb" = (
 /obj/machinery/light/smart{
 	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
@@ -70798,17 +70801,6 @@
 	icon_state = "blue"
 	},
 /area/station/medical/genetics)
-"eJE" = (
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window";
-	pixel_x = -2
-	},
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
 "eKb" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -78305,6 +78297,10 @@
 /area/space)
 "mlb" = (
 /obj/item/weapon/flora/random,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -78963,10 +78959,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "mXb" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/random/vending/cola,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -80841,12 +80834,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/xenobiology)
-"pjb" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "pjk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81746,7 +81733,8 @@
 /area/shuttle/supply/station)
 "qob" = (
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/station/civilian/barbershop)
 "qoN" = (
@@ -82075,9 +82063,9 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/structure/window/fulltile{
+/obj/structure/window/fulltile/reinforced{
 	grilled = 1;
-	icon_state = "gr_window"
+	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
@@ -83993,13 +83981,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "sxb" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/barber,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -111804,7 +111792,7 @@ axN
 axN
 axN
 axN
-cAW
+axN
 bfn
 bHa
 cbf
@@ -113346,7 +113334,7 @@ beM
 awt
 bJM
 axN
-aMR
+axN
 aMR
 aMR
 aMR
@@ -113603,7 +113591,7 @@ aIR
 aws
 aIR
 aIR
-bAc
+aIR
 lHr
 icr
 pGk
@@ -121319,11 +121307,11 @@ ovb
 aEV
 auc
 auc
-aKa
 auc
-aKa
 auc
-aKa
+auc
+auc
+auc
 auc
 auc
 swb
@@ -121574,9 +121562,9 @@ cea
 aIR
 ovb
 bhv
-bHq
 bAa
-aIu
+bAa
+bHq
 sxb
 aIu
 aJV
@@ -121831,9 +121819,9 @@ jhA
 aIR
 cxv
 bhv
-bHq
 qob
-bJd
+qob
+bHq
 bnJ
 bJd
 bHt
@@ -122345,9 +122333,9 @@ bXR
 aPE
 bME
 cMQ
-auc
+bAc
 mXb
-pjb
+auc
 cRb
 qOU
 aEq
@@ -133159,7 +133147,7 @@ tfv
 ddK
 tfv
 itg
-eJE
+qFY
 aah
 aaa
 aaa

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -13878,6 +13878,7 @@
 	layer = 4;
 	pixel_x = 32
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -16549,17 +16550,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aCU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door_control{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	pixel_y = 32;
+	req_access = list(38)
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/fore)
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "aCV" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -42065,13 +42063,13 @@
 	},
 /area/station/cargo/storage)
 "bxc" = (
-/obj/machinery/door_control{
-	id = "lawyer_blast";
-	name = "Privacy Shutters";
-	pixel_y = 32;
-	req_access = list(38)
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/security/iaa_office)
 "bxd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -48114,11 +48112,16 @@
 	},
 /area/station/engineering/monitoring)
 "bHS" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "bHT" = (
 /obj/structure/cable{
@@ -77025,15 +77028,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"kRm" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/iaa_office)
 "kSi" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -111914,7 +111908,7 @@ bhX
 bzC
 aGx
 axN
-bxc
+aCU
 bfn
 bHa
 cbf
@@ -113450,7 +113444,7 @@ sVa
 aIR
 kYG
 bWY
-kRm
+bxc
 asw
 bHq
 aws
@@ -117525,8 +117519,8 @@ awG
 aCF
 bCn
 awG
-avI
 awG
+avI
 bLz
 bNt
 bOu
@@ -117782,8 +117776,8 @@ cdX
 cPb
 bCo
 bCL
-aCU
-bKT
+bCL
+bHS
 bKT
 bNy
 awn
@@ -118039,7 +118033,7 @@ ayp
 cQb
 bAF
 auT
-bHS
+auT
 axR
 bLI
 bNI

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11418,12 +11418,27 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/station/security/prison)
 "atr" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -12238,6 +12253,11 @@
 /area/station/civilian/kitchen)
 "auQ" = (
 /mob/living/pbag,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -12247,6 +12267,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -12825,6 +12848,9 @@
 	name = "Chamber Two";
 	pixel_x = -26
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -12836,6 +12862,11 @@
 	frequency = 1484;
 	name = "Chamber Three";
 	pixel_x = -26
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -12874,6 +12905,9 @@
 	frequency = 1486;
 	name = "Chamber Four";
 	pixel_x = -26
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -14131,6 +14165,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -18826,6 +18865,16 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/genetics_cloning)
+"aHq" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "aHr" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -21941,15 +21990,6 @@
 	icon_state = "brownold"
 	},
 /area/station/security/prison)
-"aNe" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "aNf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22045,6 +22085,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/prison)
 "aNp" = (
@@ -22077,6 +22122,11 @@
 	frequency = 1480;
 	name = "Chamber One";
 	pixel_x = -26
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -43561,6 +43611,16 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
+"bzI" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -47049,6 +47109,15 @@
 	icon_state = "dark"
 	},
 /area/station/storage/tech)
+"bFW" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
@@ -72832,20 +72901,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"gNl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "gOl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -75938,11 +75993,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -79530,6 +79580,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"nFG" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable,
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -87241,6 +87299,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ygy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -115374,9 +115446,9 @@ cIb
 aqz
 are
 ash
-atr
+bzI
 aNr
-aBO
+nFG
 bnA
 nYP
 wjo
@@ -115890,7 +115962,7 @@ axL
 atN
 atr
 avR
-aBO
+aHq
 bAf
 nYP
 bso
@@ -116404,10 +116476,10 @@ arn
 auc
 atq
 avS
-aBO
+nFG
 ark
 nYP
-ayq
+jQM
 bHu
 bIT
 adW
@@ -116664,8 +116736,8 @@ avV
 adW
 adW
 adW
-jQM
-aNe
+ayq
+bFW
 bGs
 adW
 alZ
@@ -116918,10 +116990,10 @@ asU
 aso
 auR
 avW
-aBO
+aHq
 ayn
 nYP
-gNl
+ygy
 bHu
 oLn
 adW

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -34731,12 +34731,11 @@
 	},
 /area/station/cargo/storage)
 "bkt" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "apc down";
+	pixel_y = -28
+	},
 /turf/simulated/floor{
 	icon_state = "darkblue"
 	},
@@ -37703,10 +37702,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
 	dir = 1;
-	name = "Brig dark top APC";
-	pixel_y = 27
+	name = "apc top";
+	pixel_y = 28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39891,12 +39889,9 @@
 /turf/environment/space,
 /area/shuttle/administration/station)
 "btE" = (
-/obj/structure/stool/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/obj/machinery/pdapainter,
+/turf/simulated/floor,
+/area/station/bridge/hop_office)
 "btF" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -66679,6 +66674,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"cEq" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/sign/poster/contraband/syndicate_recruitment{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "cEr" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
@@ -70115,6 +70117,10 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage_secure)
+"dVq" = (
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "dWb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -70354,16 +70360,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
-"eiH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "ejb" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -71721,12 +71717,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "fIz" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_y = 31
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -76962,10 +76961,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"kRv" = (
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "kSi" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -80376,6 +80371,13 @@
 /obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/storage_secure)
+"ozt" = (
+/obj/structure/stool/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "ozz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80426,10 +80428,6 @@
 /obj/machinery/telescience_jammer,
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"oBK" = (
-/obj/structure/table,
-/turf/simulated/floor,
-/area/station/security/prison)
 "oCb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /mob/living/simple_animal/cat/dusty,
@@ -80473,10 +80471,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"oGh" = (
-/obj/machinery/pdapainter,
-/turf/simulated/floor,
-/area/station/bridge/hop_office)
 "oGL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -82967,6 +82961,10 @@
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"ruE" = (
+/obj/structure/table,
+/turf/simulated/floor,
+/area/station/security/prison)
 "rvb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 1
@@ -113861,7 +113859,7 @@ blR
 blR
 blR
 blR
-eiH
+fIz
 bHF
 cux
 boW
@@ -115410,7 +115408,7 @@ bpA
 bra
 pUb
 bmk
-oGh
+btE
 bwM
 bvn
 bzK
@@ -115874,7 +115872,7 @@ ani
 ani
 ani
 aOk
-oBK
+ruE
 aoY
 axL
 asF
@@ -116396,8 +116394,8 @@ yjk
 aNo
 atp
 adW
-kRv
-btE
+dVq
+ozt
 hdb
 alZ
 bCL
@@ -116653,7 +116651,7 @@ ayq
 atq
 avS
 adW
-fIz
+cEq
 alZ
 alZ
 aKY

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -34855,10 +34855,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"bkt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
 "bku" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -36386,16 +36382,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bmS" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
-/obj/structure/cable,
-/turf/simulated/floor{
-	icon_state = "darkblue"
-	},
-/area/station/security/iaa_office)
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -47078,7 +47067,6 @@
 /area/station/rnd/telesci)
 "bFU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "bFV" = (
@@ -53958,9 +53946,16 @@
 	},
 /area/station/hallway/primary/starboard)
 "bSY" = (
-/obj/machinery/hydroponics/constructable,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
+/area/station/security/iaa_office)
 "bSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -57286,6 +57281,9 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
+"cer" = (
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "ces" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -62643,7 +62641,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock{
-	name = "Firefighting equipment"
+	name = "Old Hydroponics"
 	},
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
@@ -80877,6 +80875,8 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "peN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "pfz" = (
@@ -112811,7 +112811,7 @@ azD
 bjH
 bHl
 eKS
-bmS
+bSY
 axN
 aMj
 cfq
@@ -132621,10 +132621,10 @@ csA
 cAL
 cBh
 cuo
-bSY
-bSY
-bSY
-bSY
+bmS
+bmS
+bmS
+bmS
 cbz
 aah
 aaa
@@ -132878,9 +132878,9 @@ cbz
 cKv
 iUO
 kJV
-bkt
-peN
-bkt
+bFU
+cer
+bFU
 ksB
 fIz
 aah
@@ -133391,11 +133391,11 @@ cbz
 cKi
 oqv
 cfC
-bkt
-peN
-bkt
-peN
 bFU
+cer
+bFU
+cer
+peN
 qFY
 aah
 aah
@@ -133648,10 +133648,10 @@ cbz
 cKh
 kdJ
 tgl
-peN
-bkt
+cer
+bFU
 oWQ
-peN
+cer
 ksB
 cbz
 aah
@@ -133906,10 +133906,10 @@ ccR
 cew
 cfD
 cya
-bSY
-bSY
-bSY
-bSY
+bmS
+bmS
+bmS
+bmS
 cbz
 aah
 aaa

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9096,7 +9096,6 @@
 "apc" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/security_space_law,
-/obj/item/weapon/storage/box/cups,
 /turf/simulated/floor,
 /area/station/security/prison)
 "apd" = (
@@ -11892,9 +11891,6 @@
 	},
 /area/station/security/prison)
 "aui" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -12673,9 +12669,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -12691,11 +12684,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
@@ -31885,11 +31873,6 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "beQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -32557,11 +32540,6 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bfU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -33113,11 +33091,6 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bgU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -33127,22 +33100,12 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bgV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/light/smart,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bgW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -34593,11 +34556,6 @@
 /turf/simulated/wall,
 /area/space)
 "bkc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -34619,18 +34577,13 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bkf" = (
-/obj/structure/stool/bed/chair/wood/normal{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/stool/bed/chair/wood/normal{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
@@ -35295,11 +35248,6 @@
 	},
 /area/station/bridge/ai_upload)
 "bln" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -37616,11 +37564,6 @@
 	},
 /area/station/medical/surgeryobs)
 "bpv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
 "bpw" = (
@@ -37786,6 +37729,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -39204,9 +39148,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bsp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -39218,6 +39159,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -39947,13 +39891,12 @@
 /turf/environment/space,
 /area/shuttle/administration/station)
 "btE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/stool/bed/chair{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/station/bridge/captain_quarters)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "btF" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -44895,23 +44838,17 @@
 	},
 /area/station/medical/medbreak)
 "bCn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/fore)
 "bCo" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "bCp" = (
@@ -45181,6 +45118,7 @@
 "bCL" = (
 /obj/structure/table,
 /obj/item/device/taperecorder,
+/obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bCM" = (
@@ -70416,6 +70354,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"eiH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "ejb" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -70874,7 +70822,6 @@
 	},
 /area/station/medical/genetics)
 "eJE" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -70882,7 +70829,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/environment/space,
+/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "eKb" = (
 /obj/machinery/recharger{
@@ -71774,9 +71721,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "fIz" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/station/civilian/hydroponics/old)
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/sign/poster/contraband/syndicate_recruitment{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -74907,9 +74857,10 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "iQf" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/eva)
+/obj/structure/table,
+/obj/item/weapon/storage/box/cups,
+/turf/simulated/floor,
+/area/station/security/prison)
 "iRb" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -77011,6 +76962,10 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"kRv" = (
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "kSi" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -80471,6 +80426,10 @@
 /obj/machinery/telescience_jammer,
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"oBK" = (
+/obj/structure/table,
+/turf/simulated/floor,
+/area/station/security/prison)
 "oCb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /mob/living/simple_animal/cat/dusty,
@@ -80514,6 +80473,10 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"oGh" = (
+/obj/machinery/pdapainter,
+/turf/simulated/floor,
+/area/station/bridge/hop_office)
 "oGL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -80744,18 +80707,14 @@
 	},
 /area/station/civilian/playroom)
 "oYb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "oZb" = (
@@ -81570,7 +81529,6 @@
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/photocopier,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -81866,6 +81824,7 @@
 /obj/item/weapon/stamp/approve{
 	pixel_x = 7
 	},
+/obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "qrb" = (
@@ -82123,8 +82082,6 @@
 /turf/simulated/wall,
 /area/station/civilian/chapel/crematorium)
 "qFY" = (
-/obj/structure/lattice,
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -82370,12 +82327,11 @@
 	},
 /area/station/medical/genetics_cloning)
 "qQG" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "apc down";
+	pixel_y = -28
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -83152,9 +83108,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
@@ -84105,6 +84058,7 @@
 /obj/structure/computerframe{
 	dir = 4
 	},
+/obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "szj" = (
@@ -86358,6 +86312,7 @@
 "wgs" = (
 /obj/effect/decal/turf_decal/set_damaged,
 /obj/effect/decal/remains/human/burned,
+/obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "wgu" = (
@@ -113906,7 +113861,7 @@ blR
 blR
 blR
 blR
-bhJ
+eiH
 bHF
 cux
 boW
@@ -115408,13 +115363,13 @@ aob
 apS
 cmc
 aqr
-asF
+iQf
 aCt
 nYP
 atp
 adW
 adW
-agO
+adW
 agO
 agO
 agO
@@ -115455,7 +115410,7 @@ bpA
 bra
 pUb
 bmk
-bvn
+oGh
 bwM
 bvn
 bzK
@@ -115672,7 +115627,7 @@ aNr
 adW
 wqD
 wgs
-alZ
+aKY
 alZ
 szd
 agO
@@ -115919,7 +115874,7 @@ ani
 ani
 ani
 aOk
-asF
+oBK
 aoY
 axL
 asF
@@ -115930,7 +115885,7 @@ adW
 atc
 lNp
 kIM
-alZ
+aKY
 atc
 bHK
 alZ
@@ -116187,8 +116142,8 @@ adW
 alZ
 iAe
 qqn
-alZ
-alZ
+aKY
+aKY
 agO
 alZ
 aYi
@@ -116441,8 +116396,8 @@ yjk
 aNo
 atp
 adW
-alZ
-hdb
+kRv
+btE
 hdb
 alZ
 bCL
@@ -116697,11 +116652,11 @@ arn
 ayq
 atq
 avS
-iQf
-atc
+adW
+fIz
 alZ
 alZ
-alZ
+aKY
 qEB
 agO
 alZ
@@ -116957,8 +116912,8 @@ avV
 adW
 bLk
 aKY
-aKY
-aKY
+alZ
+alZ
 aKY
 agO
 alZ
@@ -117212,10 +117167,10 @@ aso
 auR
 avW
 adW
+aKY
+alZ
 bKT
-bKT
-bKT
-bKT
+aKY
 wyC
 agO
 alZ
@@ -120844,7 +120799,7 @@ beC
 blp
 bkf
 bpv
-btE
+bfC
 beQ
 bfU
 bgV
@@ -134244,7 +134199,7 @@ cbz
 cbz
 cbz
 cbz
-fIz
+cbz
 cbz
 aah
 aaa

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11525,7 +11525,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkblue"
+	},
 /area/station/security/iaa_office)
 "atC" = (
 /obj/machinery/light/small{
@@ -13101,7 +13104,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/iaa_office)
 "awv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -14823,7 +14828,7 @@
 	req_access = list(38)
 	},
 /turf/simulated/floor{
-	dir = 1;
+	dir = 5;
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
@@ -31833,7 +31838,9 @@
 	name = "Internal Affairs";
 	opacity = 0
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/iaa_office)
 "beN" = (
 /obj/structure/cable{
@@ -48872,7 +48879,9 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/iaa_office)
 "bJN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81189,6 +81198,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
+"pEj" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/station/security/iaa_office)
 "pEt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/status_display{
@@ -113073,9 +113088,9 @@ asa
 bEW
 axN
 azJ
-biL
+pEj
 atB
-biL
+pEj
 atG
 axN
 bIZ

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10256,7 +10256,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "arl" = (
 /obj/item/weapon/cigbutt{
@@ -10606,7 +10609,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "arT" = (
 /obj/machinery/light_switch{
@@ -10617,7 +10623,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "arU" = (
 /obj/machinery/door_control{
@@ -11229,7 +11238,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "ata" = (
 /obj/machinery/vending/hydroseeds,
@@ -12378,7 +12390,11 @@
 /area/station/maintenance/dormitory)
 "avj" = (
 /obj/structure/closet/crate,
-/turf/simulated/floor,
+/obj/item/weapon/coin/iron,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "avk" = (
 /obj/machinery/status_display{
@@ -14814,6 +14830,12 @@
 	},
 /area/station/civilian/gym)
 "azJ" = (
+/obj/machinery/door_control{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	pixel_y = 32;
+	req_access = list(38)
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkblue"
@@ -24147,7 +24169,10 @@
 /area/station/rnd/hor)
 "aRs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "aRt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36026,7 +36051,10 @@
 	},
 /area/station/medical/reception)
 "bmu" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "bmv" = (
 /obj/machinery/camera{
@@ -39011,7 +39039,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "bsa" = (
 /obj/structure/disposalpipe/segment{
@@ -39040,7 +39071,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "bsc" = (
 /obj/structure/cable{
@@ -39052,7 +39086,10 @@
 	dir = 9
 	},
 /obj/machinery/shieldwallgen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "bsd" = (
 /turf/simulated/floor{
@@ -39129,7 +39166,10 @@
 	dir = 4
 	},
 /obj/machinery/shieldwallgen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "bsm" = (
 /obj/machinery/mass_driver{
@@ -42873,7 +42913,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/bridge/teleporter)
 "byI" = (
 /obj/machinery/door/firedoor,
@@ -43647,7 +43690,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "bAc" = (
 /obj/random/vending/cola,
@@ -44625,7 +44670,13 @@
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
-/turf/simulated/floor,
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/multitool,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "bBV" = (
 /obj/machinery/light/small{
@@ -47627,7 +47678,9 @@
 	icon_state = "warn"
 	},
 /obj/machinery/teleport/hub,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "bHt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -47697,7 +47750,9 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/weapon/tank/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "bHB" = (
 /obj/machinery/door/airlock/mining{
@@ -75420,7 +75475,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "jub" = (
 /obj/structure/stool,
@@ -78396,7 +78454,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "mtb" = (
 /obj/structure/bookcase{
@@ -78511,7 +78572,9 @@
 	icon_state = "warn"
 	},
 /obj/machinery/teleport/station,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "mAO" = (
 /turf/simulated/shuttle/floor/cargo{
@@ -82023,7 +82086,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "qJb" = (
 /obj/machinery/light/small{
@@ -83109,7 +83174,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "rFb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -83248,6 +83316,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"rOU" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "rPb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84248,7 +84322,10 @@
 	dir = 4;
 	network = list("SS13","Research")
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "sOb" = (
 /obj/structure/stool/bed/chair/office/light,
@@ -84794,6 +84871,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/singularity)
+"twk" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "tyb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 1
@@ -86252,7 +86335,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "wjr" = (
 /turf/simulated/shuttle/floor/cargo{
@@ -87295,8 +87381,10 @@
 	},
 /obj/structure/table,
 /obj/item/weapon/hand_tele,
-/obj/item/weapon/crowbar/red,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkblue"
+	},
 /area/station/bridge/teleporter)
 "xZt" = (
 /turf/simulated/shuttle/floor/cargo{
@@ -119335,7 +119423,7 @@ aoz
 arJ
 byE
 sNO
-bmu
+twk
 rEq
 jtE
 byE
@@ -120876,7 +120964,7 @@ ajo
 apb
 aql
 byE
-bmu
+rOU
 arT
 whD
 avj

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9401,6 +9401,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "apD" = (
@@ -11806,9 +11807,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "aub" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11816,6 +11814,9 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -13209,6 +13210,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -14114,9 +14116,6 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "ayu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -36062,8 +36061,8 @@
 /area/station/medical/reception)
 "bmu" = (
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/bridge/teleporter)
 "bmv" = (
@@ -42631,7 +42630,9 @@
 	sortType = "Barbershop"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -44033,7 +44034,6 @@
 /area/station/medical/cryo)
 "bAH" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -44539,9 +44539,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -44552,6 +44549,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -51041,6 +51041,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "bNz" = (
@@ -51156,9 +51159,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -51245,9 +51245,6 @@
 /area/station/engineering/atmos)
 "bNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/structure/cable{
@@ -70929,6 +70926,15 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
+"eNW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "ePa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
@@ -77243,6 +77249,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"liX" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "ljb" = (
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
@@ -78969,6 +78981,15 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"mWL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "mXb" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -79696,25 +79717,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"nOu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "nPb" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -79792,6 +79794,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/starboardsolar)
+"nTX" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "nUb" = (
 /obj/structure/closet/l3closet/general,
 /obj/item/clothing/mask/gas/coloured,
@@ -83433,12 +83441,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"rRZ" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/bridge/teleporter)
 "rSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83989,12 +83991,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/aft)
-"stk" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "stq" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin/reinforced,
@@ -87045,15 +87041,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"xrZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "xtY" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "9,6"
@@ -87472,6 +87459,23 @@
 /obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall,
 /area/station/cargo/recycleroffice)
+"ybT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "ycW" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -118721,12 +118725,12 @@ aua
 bbb
 aef
 ayu
-avE
+eNW
 bAH
-avE
-avE
-avE
-avE
+eNW
+eNW
+eNW
+eNW
 bNP
 aeJ
 aeJ
@@ -119487,7 +119491,7 @@ aoz
 arJ
 byE
 sNO
-bmu
+liX
 rEq
 jtE
 byE
@@ -119744,7 +119748,7 @@ ajo
 arI
 byE
 xZq
-rRZ
+bmu
 brZ
 mAJ
 byE
@@ -120258,7 +120262,7 @@ apb
 arL
 byE
 asZ
-rRZ
+bmu
 bsb
 bHz
 byE
@@ -120515,7 +120519,7 @@ aqC
 arK
 byE
 msQ
-rRZ
+bmu
 bsl
 bAb
 byE
@@ -121028,7 +121032,7 @@ ajo
 apb
 aql
 byE
-stk
+nTX
 arT
 whD
 avj
@@ -122105,12 +122109,12 @@ cro
 qBb
 xTO
 cro
-nOu
-xrZ
-xrZ
-bGq
-xrZ
 bye
+mWL
+mWL
+bGq
+mWL
+ybT
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -14080,19 +14080,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aym" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/structure/rack,
+/obj/item/weapon/crowbar/red,
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/cargo)
 "ayn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21471,7 +21462,17 @@
 	icon_state = "browncorner"
 	},
 /area/station/cargo/storage)
-"aMh" = (
+"aMi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/chapel)
+"aMj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -21485,16 +21486,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"aMi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/chapel)
 "aMk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -31062,9 +31053,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bdu" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/blueshield)
 "bdv" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -32233,11 +32227,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
-"bfn" = (
-/obj/structure/grille,
-/obj/item/weapon/shard,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "bfo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36746,6 +36735,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/barbershop)
+"bnK" = (
+/obj/machinery/light/smart{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/bridge/teleporter)
 "bnL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -47832,13 +47827,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
-"bHo" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/blueshield)
 "bHp" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -52177,6 +52165,11 @@
 	icon_state = "blue"
 	},
 /area/station/medical/surgeryobs)
+"bPg" = (
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/iaa_office)
 "bPh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78572,6 +78565,20 @@
 	icon_state = "barber"
 	},
 /area/station/civilian/locker)
+"msQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "mtb" = (
 /obj/structure/bookcase{
 	name = "bookcase (Religious)"
@@ -79813,7 +79820,7 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/carpet/black,
-/area/station/civilian/barbershop)
+/area/station/security/iaa_office)
 "nSP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
@@ -81030,12 +81037,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"pvb" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/bridge/teleporter)
 "pvI" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
@@ -83025,11 +83026,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"rzr" = (
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/iaa_office)
 "rAb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -111365,10 +111361,10 @@ bDn
 bDn
 aSM
 bDk
-bdu
+bEW
 sCd
-bfn
-aSM
+bEW
+bEW
 bBw
 qaV
 tFz
@@ -111622,7 +111618,7 @@ bET
 bGt
 aGn
 bDk
-bEW
+aym
 axN
 axN
 axN
@@ -111630,7 +111626,7 @@ axN
 axN
 axN
 bQl
-aMh
+aMj
 bHa
 cbf
 ccd
@@ -111887,7 +111883,7 @@ bzC
 aGx
 axN
 axN
-aMh
+aMj
 bHa
 cbf
 cvf
@@ -112142,9 +112138,9 @@ axw
 bAD
 bBC
 biL
-rzr
+bPg
 axN
-aMh
+aMj
 cap
 ciO
 bqo
@@ -112401,7 +112397,7 @@ bBM
 nSy
 bLy
 axN
-aMh
+aMj
 bIZ
 bIZ
 bIZ
@@ -112658,7 +112654,7 @@ bHl
 bFU
 bGx
 axN
-aym
+msQ
 cfq
 byU
 bps
@@ -119337,7 +119333,7 @@ bdc
 cea
 cea
 cea
-bHo
+bdu
 cea
 cea
 aIR
@@ -120315,7 +120311,7 @@ apG
 aqC
 arK
 byE
-pvb
+bnK
 aZb
 bsl
 bAb

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9764,7 +9764,6 @@
 /area/station/security/forensic_office)
 "aqr" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/window/thin/reinforced,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aqs" = (
@@ -9890,11 +9889,6 @@
 	icon_state = "red"
 	},
 /area/station/security/lobby)
-"aqz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/station/security/prison)
 "aqA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -10238,14 +10232,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"are" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/beach_ball/holoball,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/security/prison)
 "arf" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -10272,24 +10258,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
-"ark" = (
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1484;
-	name = "Chamber Three";
-	pixel_x = -26
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/security/visiting_room)
 "arl" = (
 /obj/item/weapon/cigbutt{
 	pixel_x = 5;
@@ -10301,10 +10269,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "arm" = (
 /obj/machinery/light/smart{
@@ -10816,14 +10781,14 @@
 /turf/simulated/floor,
 /area/station/maintenance/science)
 "ash" = (
+/obj/structure/window/thin/reinforced{
+	dir = 1
+	},
 /obj/structure/stacklifter,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "asi" = (
 /obj/effect/decal/cleanable/generic,
@@ -10881,11 +10846,18 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/security/prison)
 "asp" = (
 /obj/machinery/door/window/westright{
@@ -11422,28 +11394,15 @@
 	},
 /area/station/security/prison)
 "atq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor{
-	icon_state = "black"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/station/security/prison)
 "atr" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/mob/living/pbag,
 /turf/simulated/floor{
-	icon_state = "black"
+	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
 "ats" = (
@@ -11667,8 +11626,10 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "atN" = (
-/mob/living/pbag,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/security/prison)
 "atO" = (
 /obj/machinery/door/window/northleft{
@@ -12241,26 +12202,19 @@
 	},
 /area/station/civilian/kitchen)
 "auQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
-	icon_state = "black"
+	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
 "auR" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "black"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/prison)
 "auS" = (
@@ -12833,49 +12787,10 @@
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"avR" = (
-/obj/machinery/camera{
-	c_tag = "Prison Rec Room South";
-	dir = 1;
-	network = list("SS13","Prison")
-	},
-/obj/structure/stool/bed/chair/metal/red,
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1482;
-	name = "Chamber Two";
-	pixel_x = -26
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/security/prison)
 "avS" = (
-/obj/structure/stool/bed/chair/metal/red,
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1484;
-	name = "Chamber Three";
-	pixel_x = -26
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "red"
 	},
 /area/station/security/prison)
 "avT" = (
@@ -12900,23 +12815,17 @@
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/library)
 "avV" = (
-/obj/machinery/light/smart,
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "red"
+	},
 /area/station/security/prison)
 "avW" = (
-/obj/structure/stool/bed/chair/metal/red,
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1486;
-	name = "Chamber Four";
-	pixel_x = -26
+/obj/structure/stool/bed/chair/pedalgen{
+	anchored = 1;
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
+/obj/structure/cable,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -14143,24 +14052,6 @@
 /obj/item/weapon/crowbar/red,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ayn" = (
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1486;
-	name = "Chamber Four";
-	pixel_x = -26
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/security/visiting_room)
 "ayo" = (
 /obj/item/weapon/flora/pottedplant{
 	icon_state = "plant-22"
@@ -14178,19 +14069,17 @@
 	},
 /area/station/hallway/primary/fore)
 "ayq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/station/security/prison)
 "ayr" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prison)
@@ -15429,16 +15318,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
-"aAH" = (
-/obj/structure/holohoop{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/security/prison)
 "aAI" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -16362,15 +16241,13 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aCt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+/obj/item/weapon/flora/random,
+/obj/structure/window/thin/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "black"
 	},
 /area/station/security/prison)
 "aCu" = (
@@ -16559,16 +16436,15 @@
 /turf/simulated/floor,
 /area/station/security/range)
 "aCO" = (
-/obj/structure/stool/bed/chair/pedalgen{
-	anchored = 1;
-	dir = 8
-	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "red"
+	},
 /area/station/security/prison)
 "aCP" = (
 /obj/structure/cable{
@@ -18323,18 +18199,12 @@
 /area/station/maintenance/medbay)
 "aGm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/holohoop{
+	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "black"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/station/security/prison)
 "aGn" = (
@@ -22080,16 +21950,6 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -22115,25 +21975,11 @@
 /turf/simulated/floor,
 /area/station/civilian/garden)
 "aNr" = (
+/obj/structure/weightlifter,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/obj/structure/stool/bed/chair/metal/red,
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "Chamber One";
-	pixel_x = -26
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "aNs" = (
 /obj/machinery/door/airlock/security/glass{
@@ -36695,24 +36541,6 @@
 	icon_state = "darkred"
 	},
 /area/station/bridge)
-"bnA" = (
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "Chamber One";
-	pixel_x = -26
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/security/visiting_room)
 "bnB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -39298,12 +39126,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"bso" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "bsp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -39320,13 +39142,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/blueshield)
-"bsq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/security/prison)
 "bsr" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -43602,14 +43417,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
-"bzI" = (
-/obj/structure/cable,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/visiting_room)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -43697,24 +43504,9 @@
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "bzQ" = (
-/obj/machinery/door/airlock/security{
-	name = "Visiting Room";
-	req_access = list(1);
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	dir = 4;
+	req_access = list(12)
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -43855,24 +43647,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"bAf" = (
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1482;
-	name = "Chamber Two";
-	pixel_x = -26
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/security/visiting_room)
 "bAg" = (
 /obj/structure/closet/fireaxecabinet{
 	pixel_y = -32
@@ -47093,12 +46867,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
-"bFU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/thin/reinforced,
-/turf/simulated/floor,
-/area/station/security/prison)
 "bFV" = (
 /obj/machinery/requests_console/tech_storage{
 	pixel_y = -32
@@ -47316,17 +47084,6 @@
 	icon_state = "purplechecker"
 	},
 /area/station/civilian/barbershop)
-"bGs" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
-/obj/structure/cable,
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/visiting_room)
 "bGt" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -47797,14 +47554,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
-"bHp" = (
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/visiting_room)
 "bHq" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -47841,10 +47590,6 @@
 	icon_state = "purplechecker"
 	},
 /area/station/civilian/barbershop)
-"bHu" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "bHv" = (
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
@@ -48002,14 +47747,7 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "bHK" = (
-/obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -6
-	},
-/obj/item/weapon/pen{
-	pixel_x = 6
-	},
-/turf/simulated/floor,
+/turf/simulated/wall,
 /area/station/security/visiting_room)
 "bHL" = (
 /obj/structure/stool/bar,
@@ -48298,12 +48036,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/patient_a)
-"bIl" = (
-/obj/structure/window/thin/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "bIm" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -48626,28 +48358,6 @@
 	icon_state = "white"
 	},
 /area/station/civilian/dormitories)
-"bIO" = (
-/obj/structure/table,
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/visiting_room)
-"bIP" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/visiting_room)
-"bIQ" = (
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Visiting Room";
-	req_access = list(63);
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/visiting_room)
 "bIR" = (
 /obj/item/weapon/folder/white,
 /obj/item/device/radio/headset/headset_medsci,
@@ -48674,11 +48384,6 @@
 "bIS" = (
 /turf/simulated/wall,
 /area/station/medical/storage)
-"bIT" = (
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/visiting_room)
 "bIU" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -49666,15 +49371,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/cryo)
-"bKR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "bKS" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -69195,15 +68891,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
-"cMR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "cMW" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/red,
@@ -74242,20 +73929,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"icK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -76527,13 +76200,6 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
-"kmt" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79989,12 +79655,13 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nYP" = (
-/obj/machinery/door/morgue{
-	dir = 8;
-	name = "Confession Booth"
+/obj/machinery/light/smart{
+	dir = 8
 	},
-/turf/environment/space,
-/area/station/security/visiting_room)
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "nZb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -80662,15 +80329,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"oLn" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/visiting_room)
 "oMb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -82981,8 +82639,10 @@
 /area/shuttle/supply/station)
 "rsD" = (
 /obj/structure/dumbbells_rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/security/prison)
 "rsM" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -85713,21 +85373,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
-"uHF" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "black"
-	},
-/area/station/security/prison)
 "uIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -86416,10 +86061,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
-"wjo" = (
-/obj/structure/window/thin/reinforced,
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "wjr" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,3"
@@ -87495,15 +87136,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ygy" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -87516,10 +87148,13 @@
 "yjk" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/security/prison)
 "yjn" = (
 /obj/structure/disposalpipe/segment{
@@ -115375,17 +115010,17 @@ aob
 apS
 cmc
 aqr
-aAH
+asF
 aCt
+nYP
 atp
-ayr
 adW
 adW
-adW
-adW
-adW
-adW
-adW
+bHK
+bHK
+bHK
+bHK
+bHK
 uBq
 clo
 aCu
@@ -115631,18 +115266,18 @@ awH
 aLs
 aoo
 cIb
-bFU
-are
+axL
+asF
 ash
 atr
 aNr
-bzI
-bnA
-nYP
-wjo
-bHK
-bIO
 adW
+bHV
+bHV
+bHV
+bHV
+bHV
+bHK
 alZ
 aYi
 aCu
@@ -115888,18 +115523,18 @@ ani
 aOk
 asF
 aoY
-aqz
-bsq
+axL
+asF
 rsD
 auQ
-ayr
-adW
-adW
+atp
 adW
 bHV
 bHV
-bHp
-adW
+bHV
+bHV
+bHV
+bHK
 alZ
 bNg
 ayx
@@ -116146,17 +115781,17 @@ amG
 aop
 apc
 cIb
-bsq
+asF
 atN
-uHF
-avR
-bzI
-bAf
-nYP
-bso
-bHV
-bIP
+auQ
+atp
 adW
+bHV
+bHV
+bHV
+bHV
+bHV
+bHK
 alZ
 aYi
 aCu
@@ -116406,14 +116041,14 @@ ffD
 arl
 yjk
 aNo
-ayr
+atp
 adW
-adW
-adW
-bKR
-bIl
-bIQ
-adW
+bHV
+bHV
+bHV
+bHV
+bHV
+bHK
 alZ
 aYi
 hGb
@@ -116661,16 +116296,16 @@ aou
 cId
 cId
 arn
-axL
+ayq
 atq
 avS
-bzI
-ark
-nYP
-cMR
-bHu
-bIT
 adW
+bHV
+bHV
+bHV
+bHV
+bHV
+bHK
 alZ
 aYi
 aCu
@@ -116922,12 +116557,12 @@ aCO
 aGm
 avV
 adW
-adW
-adW
-ayq
-ygy
-bGs
-adW
+bHV
+bHV
+bHV
+bHV
+bHV
+bHK
 alZ
 aYi
 aCu
@@ -117178,13 +116813,13 @@ asU
 aso
 auR
 avW
-bzI
-ayn
-nYP
-icK
-bHu
-oLn
 adW
+bHV
+bHV
+bHV
+bHV
+bHV
+bHK
 alZ
 aYi
 aCu
@@ -117436,12 +117071,12 @@ ayr
 ayr
 ayr
 adW
-adW
-adW
+bHV
+bHV
 bzQ
-adW
-kmt
-adW
+bHV
+bHV
+bHK
 agO
 bNs
 aCu

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -39889,10 +39889,10 @@
 /turf/environment/space,
 /area/shuttle/administration/station)
 "btE" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_y = 31
+/obj/structure/stool/bed/chair{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "btF" = (
@@ -40028,9 +40028,6 @@
 	},
 /area/station/security/checkpoint)
 "btQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
@@ -63281,7 +63278,6 @@
 	},
 /area/station/bridge/hop_office)
 "cux" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
@@ -63289,6 +63285,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "cuB" = (
@@ -70812,7 +70811,8 @@
 "eJE" = (
 /obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window"
+	icon_state = "gr_window";
+	pixel_x = -2
 	},
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -71152,13 +71152,6 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
-"fdo" = (
-/obj/structure/stool/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "fec" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor{
@@ -71716,9 +71709,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "fIz" = (
-/obj/machinery/pdapainter,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
-/area/station/bridge/hop_office)
+/area/station/hallway/primary/central)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -72099,10 +72098,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"gdl" = (
-/obj/structure/table,
-/turf/simulated/floor,
-/area/station/security/prison)
 "geb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79630,16 +79625,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/construction)
-"nMi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "nMk" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -80331,11 +80316,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/medbreak)
-"owZ" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/cups,
-/turf/simulated/floor,
-/area/station/security/prison)
 "oxb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -81953,6 +81933,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"qza" = (
+/obj/machinery/pdapainter,
+/turf/simulated/floor,
+/area/station/bridge/hop_office)
+"qAl" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/cups,
+/turf/simulated/floor,
+/area/station/security/prison)
 "qAF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -83542,6 +83531,13 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"rZg" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/sign/poster/contraband/syndicate_recruitment{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "rZh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84507,6 +84503,9 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
 "sVa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -85340,6 +85339,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"ufK" = (
+/obj/structure/table,
+/turf/simulated/floor,
+/area/station/security/prison)
 "ugb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -113859,7 +113862,7 @@ blR
 blR
 blR
 blR
-nMi
+fIz
 bHF
 cux
 boW
@@ -115361,7 +115364,7 @@ aob
 apS
 cmc
 aqr
-owZ
+qAl
 aCt
 nYP
 atp
@@ -115408,7 +115411,7 @@ bpA
 bra
 pUb
 bmk
-fIz
+qza
 bwM
 bvn
 bzK
@@ -115872,7 +115875,7 @@ ani
 ani
 ani
 aOk
-gdl
+ufK
 aoY
 axL
 asF
@@ -116395,7 +116398,7 @@ aNo
 atp
 adW
 iQf
-fdo
+btE
 hdb
 alZ
 bCL
@@ -116651,7 +116654,7 @@ ayq
 atq
 avS
 adW
-btE
+rZg
 alZ
 alZ
 aKY

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10605,9 +10605,7 @@
 "arS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -10617,11 +10615,6 @@
 "arT" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -37997,9 +37990,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "bqo" = (
@@ -39036,15 +39026,15 @@
 	},
 /area/station/bridge/teleporter)
 "bsc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/shieldwallgen,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -52857,11 +52847,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -86358,11 +86348,6 @@
 /turf/simulated/floor,
 /area/station/cargo/office)
 "whD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -5246,6 +5246,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10238,7 +10241,10 @@
 "are" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/beach_ball/holoball,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/security/prison)
 "arf" = (
 /obj/structure/disposalpipe/trunk{
@@ -10276,9 +10282,12 @@
 	name = "Chamber Three";
 	pixel_x = -26
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/visiting_room)
 "arl" = (
@@ -10292,7 +10301,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/security/prison)
 "arm" = (
 /obj/machinery/light/smart{
@@ -10306,6 +10318,9 @@
 /area/station/rnd/xenobiology)
 "arn" = (
 /obj/structure/window/thin/reinforced,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -10425,6 +10440,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -10802,7 +10820,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/security/prison)
 "asi" = (
 /obj/effect/decal/cleanable/generic,
@@ -10864,9 +10885,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "asp" = (
 /obj/machinery/door/window/westright{
@@ -10901,9 +10920,6 @@
 "asr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -11405,7 +11421,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "black"
 	},
 /area/station/security/prison)
 "atq" = (
@@ -11414,26 +11430,23 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "black"
 	},
 /area/station/security/prison)
 "atr" = (
+/obj/structure/cable,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/area/station/security/prison)
+/turf/simulated/floor/plating,
+/area/station/security/visiting_room)
 "ats" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=EVA";
@@ -11448,11 +11461,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Blueshield Office";
-	sortType = "Blueshield Office"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "att" = (
@@ -11659,10 +11668,8 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "atN" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
+/mob/living/pbag,
+/turf/simulated/floor,
 /area/station/security/prison)
 "atO" = (
 /obj/machinery/door/window/northleft{
@@ -11824,9 +11831,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "aub" = (
@@ -11841,21 +11845,18 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/fore)
 "auc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "red"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/area/station/security/prison)
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "aud" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12245,15 +12246,10 @@
 	},
 /area/station/civilian/kitchen)
 "auQ" = (
-/mob/living/pbag,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor,
 /area/station/security/prison)
 "auR" = (
 /obj/structure/cable{
@@ -12265,7 +12261,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "black"
 	},
 /area/station/security/prison)
 "auS" = (
@@ -12481,15 +12477,15 @@
 /turf/simulated/wall,
 /area/station/civilian/fitness)
 "avq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -12722,6 +12718,9 @@
 	name = "Blueshield Office";
 	req_access = list(42)
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -12841,11 +12840,12 @@
 	name = "Chamber Two";
 	pixel_x = -26
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "black"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/prison)
 "avS" = (
@@ -12856,14 +12856,12 @@
 	name = "Chamber Three";
 	pixel_x = -26
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/prison)
 "avT" = (
@@ -12902,7 +12900,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "dark"
 	},
 /area/station/security/prison)
@@ -14134,9 +14136,12 @@
 	name = "Chamber Four";
 	pixel_x = -26
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/visiting_room)
 "ayo" = (
@@ -14524,6 +14529,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28;
 	pixel_y = -5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -15417,7 +15426,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/security/prison)
 "aAI" = (
 /obj/machinery/alarm{
@@ -16040,12 +16052,15 @@
 	},
 /area/station/civilian/kitchen)
 "aBO" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/structure/cable,
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/plating,
 /area/station/security/visiting_room)
 "aBP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16346,9 +16361,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/prison)
 "aCu" = (
@@ -16546,10 +16564,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "red"
-	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "aCP" = (
 /obj/structure/cable{
@@ -17260,7 +17275,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "aEr" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
@@ -18315,8 +18330,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "black"
 	},
 /area/station/security/prison)
 "aGn" = (
@@ -18800,7 +18814,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "aHl" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/fore)
@@ -19415,7 +19429,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "aIv" = (
 /turf/simulated/floor,
 /area/station/civilian/fitness)
@@ -19468,7 +19482,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "aIB" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -20257,7 +20271,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "aJW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -20315,7 +20329,7 @@
 "aKa" = (
 /obj/structure/mirror,
 /turf/simulated/wall,
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "aKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22067,12 +22081,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor{
+	icon_state = "black"
 	},
-/turf/simulated/floor,
 /area/station/security/prison)
 "aNp" = (
 /obj/structure/closet{
@@ -22105,12 +22116,10 @@
 	name = "Chamber One";
 	pixel_x = -26
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
 	},
-/turf/simulated/floor,
 /area/station/security/prison)
 "aNs" = (
 /obj/machinery/door/airlock/security/glass{
@@ -36682,9 +36691,12 @@
 	name = "Chamber One";
 	pixel_x = -26
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/visiting_room)
 "bnB" = (
@@ -36778,7 +36790,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bnL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -37866,6 +37878,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -38135,6 +38148,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "bqo" = (
@@ -38225,9 +38241,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -39281,8 +39294,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -39290,15 +39307,18 @@
 	},
 /area/station/security/blueshield)
 "bsq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/obj/structure/closet/crate,
+/obj/item/device/multitool,
+/obj/item/device/flashlight,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bsr" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -39316,6 +39336,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -43118,9 +43141,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/closet/crate,
-/obj/item/device/multitool,
-/obj/item/device/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "byP" = (
@@ -43575,14 +43595,19 @@
 	},
 /area/station/bridge)
 "bzI" = (
+/obj/structure/cable{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/plating,
 /area/station/security/visiting_room)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
@@ -43766,31 +43791,29 @@
 	},
 /area/station/tcommsat/cyborg)
 "bzY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/security/blueshield)
 "bzZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/security/blueshield)
 "bAa" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/security/brig)
+/area/station/security/visiting_room)
 "bAb" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/window/thin/reinforced{
@@ -43837,9 +43860,12 @@
 	name = "Chamber Two";
 	pixel_x = -26
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
+	dir = 4;
+	icon_state = "dark"
 	},
 /area/station/security/visiting_room)
 "bAg" = (
@@ -44093,12 +44119,6 @@
 	},
 /area/station/medical/genetics)
 "bAD" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Internal Affairs Agent"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -44596,6 +44616,9 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
 	},
+/obj/effect/landmark/start{
+	name = "Internal Affairs Agent"
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bBD" = (
@@ -44898,7 +44921,7 @@
 /turf/simulated/floor{
 	icon_state = "whitepurple"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bCj" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -44967,9 +44990,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -44990,11 +45010,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Visiting Room";
-	sortType = "Barbershop"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "bCp" = (
@@ -47069,10 +47085,8 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "bFU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
+/turf/simulated/wall,
+/area/station/civilian/barbershop)
 "bFV" = (
 /obj/machinery/requests_console/tech_storage{
 	pixel_y = -32
@@ -47289,7 +47303,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bGs" = (
 /obj/machinery/power/apc{
 	custom_smartlight_preset = "Dark Brig";
@@ -47343,7 +47357,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bGx" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder{
@@ -47373,7 +47387,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bGz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47714,7 +47728,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bHj" = (
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -47787,7 +47801,7 @@
 /turf/simulated/floor{
 	icon_state = "whitepurple"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bHr" = (
 /obj/effect/decal/turf_decal/alpha/black{
 	dir = 1;
@@ -47814,7 +47828,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bHu" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor,
@@ -48743,7 +48757,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "bJe" = (
 /turf/simulated/wall,
 /area/station/civilian/janitor)
@@ -63038,6 +63052,9 @@
 "ctm" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -77596,6 +77613,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
+"lxk" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "lxr" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -78416,7 +78442,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "mlh" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -79064,7 +79090,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "mXO" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -80916,7 +80942,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "piY" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -80928,7 +80954,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "pjk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81601,6 +81627,7 @@
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/photocopier,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -81830,7 +81857,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "qoN" = (
 /obj/machinery/light/smart,
 /obj/structure/closet,
@@ -82938,10 +82965,7 @@
 "rsD" = (
 /obj/structure/dumbbells_rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "rsM" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -83095,6 +83119,13 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"rAh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/security/prison)
 "rBb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84037,7 +84068,7 @@
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
-/area/station/maintenance/atmos)
+/area/station/civilian/barbershop)
 "sxr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -85426,6 +85457,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
+"umQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "unb" = (
 /obj/structure/table/woodentable,
 /obj/item/device/paicard{
@@ -85672,18 +85721,8 @@
 	},
 /area/station/civilian/toilet)
 "uHF" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "black"
 	},
 /area/station/security/prison)
 "uIm" = (
@@ -87051,7 +87090,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/photocopier,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -87460,10 +87498,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
+/turf/simulated/floor,
 /area/station/security/prison)
 "yjn" = (
 /obj/structure/disposalpipe/segment{
@@ -108168,7 +108203,7 @@ bIM
 bJX
 rnx
 bDp
-bdE
+bsq
 tgJ
 bNk
 bsT
@@ -113826,7 +113861,7 @@ cro
 oYb
 bxe
 bVa
-bVa
+umQ
 pOb
 cro
 cro
@@ -115575,10 +115610,10 @@ awH
 aLs
 aoo
 cIb
-aqz
+auQ
 are
 ash
-atr
+uHF
 aNr
 aBO
 bnA
@@ -115833,11 +115868,11 @@ aOk
 asF
 aoY
 aqz
-axL
+rAh
 rsD
-auQ
+uHF
 ayr
-adW
+bAa
 adW
 adW
 bHV
@@ -116090,7 +116125,7 @@ amG
 aop
 apc
 cIb
-axL
+rAh
 atN
 uHF
 avR
@@ -116351,7 +116386,7 @@ arl
 yjk
 aNo
 avQ
-adW
+bAa
 adW
 adW
 bKR
@@ -116605,10 +116640,10 @@ aou
 cId
 cId
 arn
-auc
+axL
 atq
 avS
-aBO
+bzI
 ark
 nYP
 cMR
@@ -116865,7 +116900,7 @@ asR
 aCO
 aGm
 avV
-adW
+bAa
 adW
 adW
 ayq
@@ -117122,7 +117157,7 @@ asU
 aso
 auR
 avW
-bzI
+atr
 ayn
 nYP
 icK
@@ -118398,7 +118433,7 @@ alj
 adM
 ami
 aqE
-bAa
+adJ
 arC
 ati
 ati
@@ -121286,15 +121321,15 @@ cea
 aPG
 ovb
 aEV
-cdA
-cdA
+bFU
+bFU
 aKa
-cdA
+bFU
 aKa
-cdA
+bFU
 aKa
-cdA
-cdA
+bFU
+bFU
 swb
 vFP
 mpb
@@ -121544,14 +121579,14 @@ aIR
 ovb
 bht
 bHq
-mlb
+lxk
 aIu
 sxb
 aIu
 aJV
 aIu
 mlb
-cdA
+bFU
 amR
 bHM
 bMl
@@ -121808,7 +121843,7 @@ bJd
 bHt
 bJd
 qob
-cdA
+bFU
 cdP
 bLt
 bSV
@@ -122050,7 +122085,7 @@ cro
 qBb
 xTO
 cro
-bsq
+bye
 cro
 cro
 bGq
@@ -122065,7 +122100,7 @@ bGr
 pib
 qob
 qob
-cdA
+bFU
 cdP
 bLt
 bSV
@@ -122314,7 +122349,7 @@ bXR
 aPE
 bME
 cMQ
-cdA
+bFU
 mXb
 pjb
 mlb
@@ -122322,7 +122357,7 @@ qob
 aEq
 bHi
 aIA
-cdA
+bFU
 cLk
 bLt
 bSV
@@ -132871,7 +132906,7 @@ cEB
 cer
 cEB
 ksB
-fIz
+cbz
 aah
 aaa
 aaa
@@ -133384,7 +133419,7 @@ cEB
 cer
 cEB
 cer
-bFU
+cEB
 qFY
 aah
 aah
@@ -133895,7 +133930,7 @@ ccR
 cew
 cfD
 cya
-bSY
+auc
 bSY
 bSY
 bSY

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -35421,11 +35421,6 @@
 	name = "Captain's Office Maintenance";
 	req_access = list(20)
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -42566,13 +42566,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -87126,15 +87125,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -47070,7 +47070,7 @@
 /area/station/rnd/telesci)
 "bFU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/sink,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "bFV" = (

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36340,10 +36340,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bmS" = (
-/obj/machinery/power/apc{
-	pixel_y = 2
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/security/iaa_office)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
@@ -43797,13 +43800,13 @@
 	},
 /area/station/hallway/primary/central)
 "bAd" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
+/obj/machinery/door_control{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	pixel_y = 32;
+	req_access = list(38)
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/wall/r_wall,
 /area/station/security/iaa_office)
 "bAe" = (
 /obj/effect/decal/turf_decal{
@@ -72364,6 +72367,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"gmm" = (
+/obj/machinery/power/apc{
+	pixel_y = 2
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "gmI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -86790,15 +86799,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"xdE" = (
-/obj/machinery/door_control{
-	id = "lawyer_blast";
-	name = "Privacy Shutters";
-	pixel_y = 32;
-	req_access = list(38)
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/iaa_office)
 "xeC" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -111923,7 +111923,7 @@ bhX
 bzC
 aGx
 axN
-xdE
+bAd
 bfn
 bHa
 cbf
@@ -112437,7 +112437,7 @@ biL
 bBM
 nSy
 bLy
-bmS
+gmm
 bfn
 bIZ
 bIZ
@@ -113459,7 +113459,7 @@ sVa
 aIR
 kYG
 bWY
-bAd
+bmS
 asw
 bHq
 aws
@@ -115259,7 +115259,7 @@ bpA
 bra
 pUb
 bmk
-cMR
+bvn
 bwM
 bvn
 bzK

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -50966,6 +50966,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellow"
@@ -51553,6 +51558,7 @@
 	name = "apc left";
 	pixel_x = -28
 	},
+/obj/structure/cable,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -73307,23 +73313,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"hnm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "hnr" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -79125,15 +79114,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/xenobiology)
-"nfu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "nfZ" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "8,7"
@@ -80321,6 +80301,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"ovw" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "ovR" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prison/toilet)
@@ -82757,12 +82743,6 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/maintenance/cargo)
-"rkC" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/bridge/teleporter)
 "rlb" = (
 /obj/structure/sink{
 	pixel_x = 6;
@@ -83534,6 +83514,15 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"rXD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "rXE" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/decal/turf_decal/wood{
@@ -84448,6 +84437,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"sQp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "sRb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -84726,6 +84724,23 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
+"tfe" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "tfv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -85880,12 +85895,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"vea" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "vhl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/polarized{
@@ -86278,6 +86287,12 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"wej" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/bridge/teleporter)
 "wfg" = (
 /obj/structure/table/woodentable,
 /obj/item/folder_holder{
@@ -87168,15 +87183,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
-"xHA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/dormitory)
 "xHP" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -118728,12 +118734,12 @@ aua
 bbb
 aef
 ayu
-xHA
+sQp
 bAH
-xHA
-xHA
-xHA
-xHA
+sQp
+sQp
+sQp
+sQp
 bNP
 aeJ
 aeJ
@@ -119494,7 +119500,7 @@ aoz
 arJ
 byE
 sNO
-vea
+ovw
 rEq
 jtE
 byE
@@ -119751,7 +119757,7 @@ ajo
 arI
 byE
 xZq
-rkC
+wej
 brZ
 mAJ
 byE
@@ -120265,7 +120271,7 @@ apb
 arL
 byE
 asZ
-rkC
+wej
 bsb
 bHz
 byE
@@ -120522,7 +120528,7 @@ aqC
 arK
 byE
 msQ
-rkC
+wej
 bsl
 bAb
 byE
@@ -122113,11 +122119,11 @@ qBb
 xTO
 cro
 bye
-nfu
-nfu
+rXD
+rXD
 bGq
-nfu
-hnm
+rXD
+tfe
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11552,6 +11552,11 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "atC" = (
@@ -13169,6 +13174,11 @@
 	id = "lawyer_blast";
 	name = "Internal Affairs";
 	opacity = 0
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -43591,6 +43601,16 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge)
+"bzI" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "bzJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -44697,6 +44717,11 @@
 "bBM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -47080,21 +47105,6 @@
 	icon_state = "dark"
 	},
 /area/station/storage/tech)
-"bFW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/prison)
 "bFX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
@@ -47271,6 +47281,21 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
+"bGn" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/prison)
 "bGo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47766,6 +47791,11 @@
 /obj/item/newtons_pendulum{
 	pixel_x = 6;
 	pixel_y = -8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -49995,6 +50025,7 @@
 	},
 /area/station/security/prison)
 "bLy" = (
+/obj/structure/cable,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72878,20 +72909,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"gNl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "gOl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -74172,6 +74189,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"icK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "idb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -76426,16 +76457,6 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
-"kmt" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79572,6 +79593,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"nFG" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable,
+/turf/simulated/wall/r_wall,
+/area/station/security/visiting_room)
 "nGb" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
@@ -79741,6 +79770,11 @@
 	},
 /obj/effect/landmark/start{
 	name = "Internal Affairs Agent"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -83561,15 +83595,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"sfp" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "sfM" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "2,0"
@@ -86379,14 +86404,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
-"woE" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/structure/cable,
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
 "woS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -87314,6 +87331,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ygy" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -115449,7 +115475,7 @@ are
 ash
 atr
 aNr
-woE
+nFG
 bnA
 nYP
 wjo
@@ -115961,9 +115987,9 @@ apc
 cIb
 axL
 atN
-bFW
+bGn
 avR
-kmt
+bzI
 bAf
 nYP
 bso
@@ -116477,7 +116503,7 @@ arn
 auc
 atq
 avS
-woE
+nFG
 ark
 nYP
 ayq
@@ -116738,7 +116764,7 @@ adW
 adW
 adW
 uHF
-sfp
+ygy
 bGs
 adW
 alZ
@@ -116991,10 +117017,10 @@ asU
 aso
 auR
 avW
-kmt
+bzI
 ayn
 nYP
-gNl
+icK
 bHu
 oLn
 adW

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -2333,7 +2333,7 @@
 /area/station/security/brig)
 "adW" = (
 /turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
+/area/station/maintenance/eva)
 "adX" = (
 /obj/structure/rack,
 /obj/structure/window/thin/reinforced{
@@ -14103,6 +14103,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -43509,7 +43514,7 @@
 	req_access = list(12)
 	},
 /turf/simulated/floor,
-/area/station/security/visiting_room)
+/area/station/maintenance/eva)
 "bzR" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -43631,11 +43636,6 @@
 "bAd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -43943,6 +43943,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "bAI" = (
@@ -44446,6 +44451,11 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "bBI" = (
@@ -44773,11 +44783,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blue"
@@ -44786,11 +44791,6 @@
 "bCo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -45061,16 +45061,18 @@
 	},
 /area/station/rnd/hor)
 "bCL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet{
+	icon_closed = "cabinet_closed";
+	icon_opened = "cabinet_open";
+	icon_state = "cabinet_closed";
+	name = "Clothing Storage"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/fore)
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/random/cloth/random_cloth_safe,
+/obj/item/weapon/storage/briefcase,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "bCM" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -47747,8 +47749,11 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "bHK" = (
-/turf/simulated/wall,
-/area/station/security/visiting_room)
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "bHL" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor{
@@ -47857,8 +47862,12 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "bHV" = (
-/turf/simulated/floor,
-/area/station/security/visiting_room)
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/computerframe{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "bHW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49380,16 +49389,13 @@
 	},
 /area/station/rnd/mixing)
 "bKT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/barricade/wooden,
 /turf/simulated/floor,
-/area/station/hallway/primary/fore)
+/area/station/maintenance/eva)
 "bKU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -50803,11 +50809,6 @@
 /area/station/maintenance/eva)
 "bNt" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -50890,15 +50891,14 @@
 /area/station/hallway/primary/starboard)
 "bNy" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
@@ -51018,6 +51018,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -51072,6 +51077,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "bNN" = (
@@ -51098,6 +51108,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -51392,7 +51407,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "bOu" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "apc left";
@@ -69048,10 +69062,11 @@
 	},
 /area/station/hallway/primary/fore)
 "cRb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
-/area/station/maintenance/dormitory)
+/area/station/maintenance/eva)
 "cSb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -69622,6 +69637,16 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
+"dxK" = (
+/obj/structure/table,
+/obj/item/weapon/cigbutt/cigarbutt{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/trash/candle/red,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "dyb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -71940,6 +71965,11 @@
 	icon_state = "redfull"
 	},
 /area/station/medical/reception)
+"gaJ" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/decal/remains/human/burned,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "gbb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -72502,6 +72532,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"gHp" = (
+/obj/structure/table,
+/obj/item/device/taperecorder,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "gHx" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -72978,6 +73013,11 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"heP" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/evidence,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "hga" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Engineering Department.";
@@ -81664,6 +81704,11 @@
 	},
 /turf/environment/space,
 /area/space)
+"qvj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "qwb" = (
 /obj/item/weapon/cigbutt,
 /obj/structure/disposalpipe/segment{
@@ -83281,6 +83326,20 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"rZJ" = (
+/obj/structure/table,
+/obj/item/weapon/stamp/denied{
+	pixel_x = -6
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/toy/figure/iaa{
+	pixel_y = 8
+	},
+/obj/item/weapon/stamp/approve{
+	pixel_x = 7
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "sab" = (
 /obj/machinery/computer/centrifuge,
 /turf/simulated/floor{
@@ -85630,6 +85689,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
+"vwP" = (
+/obj/structure/stool/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/set_damaged,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "vyg" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "4,0"
@@ -85907,6 +85973,10 @@
 	icon_state = "0,2"
 	},
 /area/shuttle/supply/station)
+"wcp" = (
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/eva)
 "wcU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86261,6 +86331,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
+"wyf" = (
+/obj/structure/stool/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "wyS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -115016,11 +115092,11 @@ nYP
 atp
 adW
 adW
-bHK
-bHK
-bHK
-bHK
-bHK
+agO
+agO
+agO
+agO
+agO
 uBq
 clo
 aCu
@@ -115272,12 +115348,12 @@ ash
 atr
 aNr
 adW
+bCL
+gaJ
+alZ
+alZ
 bHV
-bHV
-bHV
-bHV
-bHV
-bHK
+agO
 alZ
 aYi
 aCu
@@ -115529,11 +115605,11 @@ rsD
 auQ
 atp
 adW
-bHV
-bHV
-bHV
-bHV
-bHV
+atc
+vwP
+wyf
+alZ
+atc
 bHK
 alZ
 bNg
@@ -115786,12 +115862,12 @@ atN
 auQ
 atp
 adW
-bHV
-bHV
-bHV
-bHV
-bHV
-bHK
+alZ
+dxK
+rZJ
+alZ
+alZ
+agO
 alZ
 aYi
 aCu
@@ -116043,12 +116119,12 @@ yjk
 aNo
 atp
 adW
-bHV
-bHV
-bHV
-bHV
-bHV
-bHK
+alZ
+hdb
+hdb
+alZ
+gHp
+agO
 alZ
 aYi
 hGb
@@ -116299,13 +116375,13 @@ arn
 ayq
 atq
 avS
-adW
-bHV
-bHV
-bHV
-bHV
-bHV
-bHK
+wcp
+atc
+alZ
+alZ
+alZ
+heP
+agO
 alZ
 aYi
 aCu
@@ -116557,12 +116633,12 @@ aCO
 aGm
 avV
 adW
-bHV
-bHV
-bHV
-bHV
-bHV
-bHK
+bLk
+aKY
+aKY
+aKY
+aKY
+agO
 alZ
 aYi
 aCu
@@ -116814,12 +116890,12 @@ aso
 auR
 avW
 adW
-bHV
-bHV
-bHV
-bHV
-bHV
-bHK
+qvj
+qvj
+qvj
+qvj
+cRb
+agO
 alZ
 aYi
 aCu
@@ -117071,12 +117147,12 @@ ayr
 ayr
 ayr
 adW
-bHV
-bHV
+bKT
+agO
 bzQ
-bHV
-bHV
-bHK
+agO
+bKT
+agO
 agO
 bNs
 aCu
@@ -117588,10 +117664,10 @@ aOQ
 cdX
 cPb
 bCo
-bCL
-bCL
+aOQ
+aOQ
 bAd
-bKT
+cdX
 bNy
 awn
 azo
@@ -118357,12 +118433,12 @@ aua
 bbb
 aef
 ayu
-cRb
+avE
 bAH
-cRb
-cRb
-cRb
-cRb
+avE
+avE
+avE
+avE
 bNP
 aeJ
 aeJ

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -14680,6 +14680,10 @@
 /obj/item/portrait/captain{
 	pixel_y = -32
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -36339,15 +36343,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"bmS" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/iaa_office)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -37769,6 +37764,9 @@
 /area/station/medical/surgery)
 "bpE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -37804,6 +37802,12 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	dir = 1;
+	name = "Brig dark top APC";
+	pixel_y = 27
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -42061,17 +42065,14 @@
 	},
 /area/station/cargo/storage)
 "bxc" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 3;
-	pixel_y = -1
+/obj/machinery/door_control{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	pixel_y = 32;
+	req_access = list(38)
 	},
 /turf/simulated/wall/r_wall,
-/area/station/security/blueshield)
+/area/station/security/iaa_office)
 "bxd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -43800,11 +43801,8 @@
 	},
 /area/station/hallway/primary/central)
 "bAd" = (
-/obj/machinery/door_control{
-	id = "lawyer_blast";
-	name = "Privacy Shutters";
-	pixel_y = 32;
-	req_access = list(38)
+/obj/machinery/power/apc{
+	pixel_y = 2
 	},
 /turf/simulated/wall/r_wall,
 /area/station/security/iaa_office)
@@ -44743,7 +44741,7 @@
 "bBU" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_y = 20
+	pixel_y = 24
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
@@ -72367,12 +72365,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"gmm" = (
-/obj/machinery/power/apc{
-	pixel_y = 2
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/iaa_office)
 "gmI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -77034,15 +77026,14 @@
 	},
 /area/station/security/brig)
 "kRm" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	dir = 8;
-	name = "Brig dark left APC";
-	pixel_x = -32;
-	pixel_y = -6
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
 	},
-/turf/simulated/wall/r_wall,
-/area/station/security/blueshield)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/iaa_office)
 "kSi" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -111923,7 +111914,7 @@ bhX
 bzC
 aGx
 axN
-bAd
+bxc
 bfn
 bHa
 cbf
@@ -112437,7 +112428,7 @@ biL
 bBM
 nSy
 bLy
-gmm
+bAd
 bfn
 bIZ
 bIZ
@@ -113459,7 +113450,7 @@ sVa
 aIR
 kYG
 bWY
-bmS
+kRm
 asw
 bHq
 aws
@@ -120143,7 +120134,7 @@ bBd
 bEa
 afz
 cea
-bxc
+cea
 cea
 rCb
 cea
@@ -120656,7 +120647,7 @@ bdc
 jWb
 jZb
 tnb
-kRm
+cea
 aDZ
 bjz
 avq

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36635,35 +36635,20 @@
 	},
 /area/station/bridge)
 "bnA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/mirror{
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/dryer{
+	pixel_y = 14
 	},
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bsentry";
-	name = "Blueshield Office Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/command{
-	dir = 4;
-	name = "Blueshield Office";
-	req_access = list(42)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor{
-	icon_state = "darkbluefull"
+	icon_state = "purplechecker"
 	},
-/area/station/security/blueshield)
+/area/station/civilian/barbershop)
 "bnB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -74009,13 +73994,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"hTF" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/station/bridge/teleporter)
 "hUb" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -75629,6 +75607,9 @@
 	icon_state = "warn"
 	},
 /obj/machinery/computer/teleporter,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "jub" = (
@@ -75712,14 +75693,10 @@
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
 "jzM" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/spawner/lootdrop,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "jAb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/medical{
@@ -77056,6 +77033,16 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"kRm" = (
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	dir = 8;
+	name = "Brig dark left APC";
+	pixel_x = -32;
+	pixel_y = -6
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/blueshield)
 "kSi" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -79448,11 +79435,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/hallway)
-"nwi" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/effect/spawner/lootdrop,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "nws" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79918,15 +79900,12 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nYP" = (
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/structure/sign/poster/official/soft_cap_pop_art{
+	pixel_x = -32
 	},
-/obj/structure/dryer{
-	pixel_y = 14
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
@@ -82972,22 +82951,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
-"rwJ" = (
-/obj/item/weapon/haircomb,
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/cardpay{
-	dir = 8;
-	pixel_x = -3;
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "rxb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -83101,17 +83064,35 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "rCb" = (
-/obj/structure/sign/poster/official/soft_cap_pop_art{
-	pixel_x = -32
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/civilian/barbershop)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bsentry";
+	name = "Blueshield Office Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Blueshield Office";
+	req_access = list(42)
+	},
+/turf/simulated/floor{
+	icon_state = "darkbluefull"
+	},
+/area/station/security/blueshield)
 "rCh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85940,6 +85921,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"vFW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/simulated/wall/r_wall,
+/area/station/bridge/teleporter)
 "vIi" = (
 /obj/structure/closet/crate/freezer,
 /obj/random/foods/drink_can,
@@ -86300,6 +86288,22 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
+"wjo" = (
+/obj/item/weapon/haircomb,
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/device/cardpay{
+	dir = 8;
+	pixel_x = -3;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "wjr" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "3,3"
@@ -86661,16 +86665,6 @@
 "wLi" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
-"wLk" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	dir = 8;
-	name = "Brig dark left APC";
-	pixel_x = -32;
-	pixel_y = -6
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/blueshield)
 "wLY" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -114715,7 +114709,7 @@ bLx
 bNr
 ayr
 aqf
-nwi
+jzM
 cgt
 alZ
 alZ
@@ -115483,9 +115477,9 @@ ash
 auQ
 aNr
 bGr
+bnA
 nYP
-rCb
-rwJ
+wjo
 bHK
 bIO
 bFW
@@ -119077,7 +119071,7 @@ aqi
 aqi
 byE
 byE
-hTF
+vFW
 kNr
 byE
 byE
@@ -120154,7 +120148,7 @@ afz
 cea
 bxc
 cea
-bnA
+rCb
 cea
 cea
 bPp
@@ -120665,7 +120659,7 @@ bdc
 jWb
 jZb
 tnb
-wLk
+kRm
 aDZ
 bjz
 avq
@@ -121696,7 +121690,7 @@ bDK
 aML
 aRR
 bst
-jzM
+aML
 aTR
 aIR
 aIR

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9571,6 +9571,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "apW" = (
@@ -14140,11 +14145,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
@@ -47855,11 +47855,6 @@
 /area/station/maintenance/atmos)
 "bHu" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "bHv" = (
@@ -48664,7 +48659,7 @@
 /area/station/security/visiting_room)
 "bIQ" = (
 /obj/machinery/door/window/brigdoor/northright{
-	name = "Brig Desk";
+	name = "Visiting Room";
 	req_access = list(63);
 	dir = 4
 	},
@@ -70565,6 +70560,15 @@
 /obj/random/vending/cola,
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
+"ekS" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "elb" = (
 /obj/machinery/vending/coffee,
 /obj/item/portrait/captain{
@@ -81549,6 +81553,20 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
+"qeY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/security/visiting_room)
 "qgb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/chief_engineer,
@@ -84729,10 +84747,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
-"tiY" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "tkb" = (
 /obj/machinery/shower{
 	dir = 1
@@ -86691,20 +86705,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"wKR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/security/visiting_room)
 "wLi" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
@@ -116567,8 +116567,8 @@ avS
 aBO
 ark
 nYP
-apV
-tiY
+ayq
+bHu
 bIT
 adW
 alZ
@@ -116824,8 +116824,8 @@ avV
 adW
 adW
 adW
-wKR
-bHu
+qeY
+ekS
 bGs
 adW
 alZ
@@ -117081,8 +117081,8 @@ avW
 aBO
 ayn
 nYP
-ayq
-tiY
+apV
+bHu
 oLn
 adW
 alZ

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -16678,6 +16678,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -17488,6 +17493,11 @@
 "aEV" = (
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18690,6 +18700,11 @@
 "aHk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -43513,6 +43528,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/maintenance/eva)
 "bzR" = (
@@ -43560,6 +43578,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bzV" = (
@@ -43998,6 +44021,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -44711,6 +44739,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "whitepurple"
 	},
@@ -45061,18 +45094,16 @@
 	},
 /area/station/rnd/hor)
 "bCL" = (
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed";
-	name = "Clothing Storage"
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
 	},
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/random/cloth/random_cloth_safe,
-/obj/item/weapon/storage/briefcase,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "bCM" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -47082,6 +47113,11 @@
 /area/station/hallway/primary/central)
 "bGr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -47125,6 +47161,11 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -47155,6 +47196,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -47164,6 +47210,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/trash/candy,
 /mob/living/simple_animal/mouse,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bGA" = (
@@ -47862,10 +47913,10 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "bHV" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/structure/computerframe{
+/obj/structure/stool/bed/chair{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bHW" = (
@@ -49051,6 +49102,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bKl" = (
@@ -49260,6 +49316,11 @@
 "bKD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bKE" = (
@@ -49389,12 +49450,9 @@
 	},
 /area/station/rnd/mixing)
 "bKT" = (
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
-	},
-/obj/structure/barricade/wooden,
-/turf/simulated/floor,
+/obj/structure/table,
+/obj/item/weapon/storage/box/evidence,
+/turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bKU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -49838,6 +49896,11 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -69062,9 +69125,8 @@
 	},
 /area/station/hallway/primary/fore)
 "cRb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
+/obj/structure/table,
+/obj/item/device/taperecorder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "cSb" = (
@@ -69637,16 +69699,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
-"dxK" = (
-/obj/structure/table,
-/obj/item/weapon/cigbutt/cigarbutt{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/effect/decal/turf_decal/set_burned,
-/obj/item/trash/candle/red,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "dyb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -71965,11 +72017,6 @@
 	icon_state = "redfull"
 	},
 /area/station/medical/reception)
-"gaJ" = (
-/obj/effect/decal/turf_decal/set_damaged,
-/obj/effect/decal/remains/human/burned,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "gbb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -72532,11 +72579,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"gHp" = (
-/obj/structure/table,
-/obj/item/device/taperecorder,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "gHx" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -72966,6 +73008,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"hbB" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/structure/computerframe{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "hbR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -73013,11 +73062,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"heP" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/evidence,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "hga" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Engineering Department.";
@@ -73220,6 +73264,20 @@
 	icon_state = "2,4"
 	},
 /area/shuttle/supply/station)
+"hpY" = (
+/obj/structure/table,
+/obj/item/weapon/stamp/denied{
+	pixel_x = -6
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/toy/figure/iaa{
+	pixel_y = 8
+	},
+/obj/item/weapon/stamp/approve{
+	pixel_x = 7
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "hqb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -73294,6 +73352,15 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
+"hti" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/maintenance/eva)
 "huy" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "1,3"
@@ -77864,6 +77931,12 @@
 	icon_state = "white"
 	},
 /area/station/medical/morgue)
+"lWj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "lXb" = (
 /obj/item/weapon/pen,
 /obj/structure/table/glass,
@@ -78481,6 +78554,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/meter,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "mFb" = (
@@ -78719,6 +78797,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"mQa" = (
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/decal/remains/human/burned,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "mQb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -80364,6 +80447,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -80650,6 +80738,11 @@
 "pib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
@@ -81704,11 +81797,6 @@
 	},
 /turf/environment/space,
 /area/space)
-"qvj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "qwb" = (
 /obj/item/weapon/cigbutt,
 /obj/structure/disposalpipe/segment{
@@ -83326,20 +83414,6 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"rZJ" = (
-/obj/structure/table,
-/obj/item/weapon/stamp/denied{
-	pixel_x = -6
-	},
-/obj/effect/decal/turf_decal/set_burned,
-/obj/item/toy/figure/iaa{
-	pixel_y = 8
-	},
-/obj/item/weapon/stamp/approve{
-	pixel_x = 7
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "sab" = (
 /obj/machinery/computer/centrifuge,
 /turf/simulated/floor{
@@ -84016,6 +84090,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"sJh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "sJr" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green{
@@ -84405,6 +84489,16 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"tbV" = (
+/obj/structure/table,
+/obj/item/weapon/cigbutt/cigarbutt{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/obj/item/trash/candle/red,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "tcb" = (
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -84915,6 +85009,10 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/locker)
+"tRU" = (
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/eva)
 "tSb" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -85626,6 +85724,11 @@
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"vmn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "vmY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/barricade/wooden,
@@ -85689,13 +85792,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
-"vwP" = (
-/obj/structure/stool/bed/chair{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/set_damaged,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "vyg" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "4,0"
@@ -85720,6 +85816,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"vBK" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "vBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85973,10 +86078,6 @@
 	icon_state = "0,2"
 	},
 /area/shuttle/supply/station)
-"wcp" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/eva)
 "wcU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86331,12 +86432,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
-"wyf" = (
-/obj/structure/stool/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
 "wyS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -86368,6 +86463,19 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
+"wCv" = (
+/obj/structure/closet{
+	icon_closed = "cabinet_closed";
+	icon_opened = "cabinet_open";
+	icon_state = "cabinet_closed";
+	name = "Clothing Storage"
+	},
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/random/cloth/random_cloth_safe,
+/obj/item/weapon/storage/briefcase,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "wCF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -87212,6 +87320,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ydF" = (
+/obj/structure/stool/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -115348,11 +115462,11 @@ ash
 atr
 aNr
 adW
-bCL
-gaJ
+wCv
+mQa
 alZ
 alZ
-bHV
+hbB
 agO
 alZ
 aYi
@@ -115606,8 +115720,8 @@ auQ
 atp
 adW
 atc
-vwP
-wyf
+bHV
+ydF
 alZ
 atc
 bHK
@@ -115863,8 +115977,8 @@ auQ
 atp
 adW
 alZ
-dxK
-rZJ
+tbV
+hpY
 alZ
 alZ
 agO
@@ -116123,7 +116237,7 @@ alZ
 hdb
 hdb
 alZ
-gHp
+cRb
 agO
 alZ
 aYi
@@ -116375,12 +116489,12 @@ arn
 ayq
 atq
 avS
-wcp
+tRU
 atc
 alZ
 alZ
 alZ
-heP
+bKT
 agO
 alZ
 aYi
@@ -116890,11 +117004,11 @@ aso
 auR
 avW
 adW
-qvj
-qvj
-qvj
-qvj
-cRb
+vmn
+vmn
+vmn
+vmn
+lWj
 agO
 alZ
 aYi
@@ -117147,11 +117261,11 @@ ayr
 ayr
 ayr
 adW
-bKT
+hti
 agO
 bzQ
 agO
-bKT
+hti
 agO
 agO
 bNs
@@ -121309,7 +121423,7 @@ cea
 cea
 aIR
 ovb
-bht
+bhv
 bHq
 bAa
 aIu
@@ -121566,7 +121680,7 @@ aTR
 jhA
 aIR
 cxv
-bht
+bhv
 bHq
 qob
 bJd
@@ -121830,8 +121944,8 @@ aHk
 bGw
 bGr
 pib
-qob
-qob
+sJh
+bCL
 auc
 cdP
 bLt
@@ -122085,7 +122199,7 @@ auc
 mXb
 pjb
 mlb
-qob
+vBK
 aEq
 bHi
 aIA

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -34855,6 +34855,17 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"bkt" = (
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "Dark Brig";
+	name = "Brig dark down APC";
+	pixel_y = -27
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "darkblue"
+	},
+/area/station/security/iaa_office)
 "bku" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -36381,10 +36392,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"bmS" = (
-/obj/machinery/hydroponics/constructable,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -47067,6 +47074,7 @@
 /area/station/rnd/telesci)
 "bFU" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "bFV" = (
@@ -53946,16 +53954,9 @@
 	},
 /area/station/hallway/primary/starboard)
 "bSY" = (
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "Dark Brig";
-	name = "Brig dark down APC";
-	pixel_y = -27
-	},
-/obj/structure/cable,
-/turf/simulated/floor{
-	icon_state = "darkblue"
-	},
-/area/station/security/iaa_office)
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "bSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -66875,6 +66876,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
+"cEB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "cEC" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -69454,10 +69459,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/chiefs_office)
-"cXG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
 "cXS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -80874,11 +80875,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"peN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
 "pfz" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -84719,6 +84715,10 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
+"tfv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics/old)
 "tfA" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -86378,10 +86378,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
@@ -112811,7 +112807,7 @@ azD
 bjH
 bHl
 eKS
-bSY
+bkt
 axN
 aMj
 cfq
@@ -132621,10 +132617,10 @@ csA
 cAL
 cBh
 cuo
-bmS
-bmS
-bmS
-bmS
+bSY
+bSY
+bSY
+bSY
 cbz
 aah
 aaa
@@ -132878,9 +132874,9 @@ cbz
 cKv
 iUO
 kJV
-bFU
+cEB
 cer
-bFU
+cEB
 ksB
 fIz
 aah
@@ -133135,9 +133131,9 @@ cbz
 cEy
 cfB
 cil
-cXG
+tfv
 ddK
-cXG
+tfv
 itg
 eJE
 aah
@@ -133391,11 +133387,11 @@ cbz
 cKi
 oqv
 cfC
-bFU
+cEB
+cer
+cEB
 cer
 bFU
-cer
-peN
 qFY
 aah
 aah
@@ -133649,7 +133645,7 @@ cKh
 kdJ
 tgl
 cer
-bFU
+cEB
 oWQ
 cer
 ksB
@@ -133906,10 +133902,10 @@ ccR
 cew
 cfD
 cya
-bmS
-bmS
-bmS
-bmS
+bSY
+bSY
+bSY
+bSY
 cbz
 aah
 aaa

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -10613,8 +10613,9 @@
 	},
 /area/station/bridge/teleporter)
 "arT" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 22;
+	pixel_y = 1
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -47552,6 +47553,9 @@
 /obj/item/weapon/razor,
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/dropper/precision,
+/obj/machinery/firealarm{
+	pixel_x = 22
+	},
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -56704,12 +56708,14 @@
 /area/station/civilian/garden)
 "ccR" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/weapon/tank/oxygen,
-/obj/item/clothing/mask/gas/coloured,
-/obj/item/weapon/reagent_containers/spray/extinguisher,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/glasses/meson,
+/obj/item/seeds/ambrosiavulgarisseed,
+/obj/item/seeds/gourdseed,
+/obj/item/seeds/tobacco,
+/obj/item/seeds/chiliseed,
+/obj/item/seeds/chiliseed,
+/obj/item/seeds/lemonseed,
+/obj/item/seeds/sugarcaneseed,
+/obj/item/seeds/sugarcaneseed,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "ccT" = (
@@ -64366,7 +64372,7 @@
 	},
 /area/station/rnd/xenobiology)
 "cya" = (
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/biogenerator,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics/old)
 "cyd" = (
@@ -75929,6 +75935,9 @@
 	},
 /area/station/ai_monitored/storage_secure)
 "jUv" = (
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -76453,11 +76462,6 @@
 "ksb" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -85996,13 +86000,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"vFW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/station/bridge/teleporter)
 "vIi" = (
 /obj/structure/closet/crate/freezer,
 /obj/random/foods/drink_can,
@@ -119209,7 +119206,7 @@ aqi
 aqi
 byE
 byE
-vFW
+byE
 kNr
 byE
 byE

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -13131,6 +13131,14 @@
 	req_one_access = list(19, 38);
 	req_access = list(19, 38)
 	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lawyer_blast";
+	name = "Internal Affairs";
+	opacity = 0
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "awv" = (
@@ -16549,15 +16557,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"aCU" = (
-/obj/machinery/door_control{
-	id = "lawyer_blast";
-	name = "Privacy Shutters";
-	pixel_y = 32;
-	req_access = list(38)
-	},
-/turf/simulated/wall/r_wall,
-/area/station/security/iaa_office)
 "aCV" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -31884,6 +31883,14 @@
 /obj/item/weapon/paper_bin{
 	pixel_y = 4
 	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lawyer_blast";
+	name = "Internal Affairs";
+	opacity = 0
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "beN" = (
@@ -36341,6 +36348,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"bmS" = (
+/obj/machinery/door_control{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	pixel_y = 32;
+	req_access = list(38)
+	},
+/turf/simulated/wall/r_wall,
+/area/station/security/iaa_office)
 "bmT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -42063,13 +42079,10 @@
 	},
 /area/station/cargo/storage)
 "bxc" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
+/obj/machinery/power/apc{
+	pixel_y = 2
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/wall/r_wall,
 /area/station/security/iaa_office)
 "bxd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -43799,11 +43812,17 @@
 	},
 /area/station/hallway/primary/central)
 "bAd" = (
-/obj/machinery/power/apc{
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall,
-/area/station/security/iaa_office)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/hallway/primary/fore)
 "bAe" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -48112,17 +48131,14 @@
 	},
 /area/station/engineering/monitoring)
 "bHS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/hallway/primary/fore)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/iaa_office)
 "bHT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -111908,7 +111924,7 @@ bhX
 bzC
 aGx
 axN
-aCU
+bmS
 bfn
 bHa
 cbf
@@ -112422,7 +112438,7 @@ biL
 bBM
 nSy
 bLy
-bAd
+bxc
 bfn
 bIZ
 bIZ
@@ -113444,7 +113460,7 @@ sVa
 aIR
 kYG
 bWY
-bxc
+bHS
 asw
 bHq
 aws
@@ -117777,7 +117793,7 @@ cPb
 bCo
 bCL
 bCL
-bHS
+bAd
 bKT
 bNy
 awn

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36062,8 +36062,8 @@
 /area/station/medical/reception)
 "bmu" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "darkblue"
 	},
 /area/station/bridge/teleporter)
 "bmv" = (
@@ -42631,9 +42631,7 @@
 	sortType = "Barbershop"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -73882,6 +73880,25 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
+"hUd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "hUv" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -73987,23 +74004,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"hYL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "hZb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -80946,15 +80946,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
-"pnF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "pqb" = (
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
@@ -81732,12 +81723,6 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
-"qls" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "qlZ" = (
 /turf/simulated/wall,
 /area/station/cargo/qm)
@@ -82505,12 +82490,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
-"qWI" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "qXb" = (
 /obj/machinery/door/morgue{
 	dir = 4;
@@ -84932,6 +84911,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"trT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "tso" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -86004,6 +85992,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"vCK" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "vDF" = (
 /obj/item/clothing/under/rainbow,
 /turf/simulated/floor/wood,
@@ -86937,6 +86931,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"xdz" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/bridge/teleporter)
 "xeC" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -119485,7 +119485,7 @@ aoz
 arJ
 byE
 sNO
-qWI
+vCK
 rEq
 jtE
 byE
@@ -119742,7 +119742,7 @@ ajo
 arI
 byE
 xZq
-bmu
+xdz
 brZ
 mAJ
 byE
@@ -120256,7 +120256,7 @@ apb
 arL
 byE
 asZ
-bmu
+xdz
 bsb
 bHz
 byE
@@ -120513,7 +120513,7 @@ aqC
 arK
 byE
 msQ
-bmu
+xdz
 bsl
 bAb
 byE
@@ -121026,7 +121026,7 @@ ajo
 apb
 aql
 byE
-qls
+bmu
 arT
 whD
 avj
@@ -122103,12 +122103,12 @@ cro
 qBb
 xTO
 cro
-bye
-pnF
-pnF
+hUd
+trT
+trT
 bGq
-pnF
-hYL
+trT
+bye
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -12220,6 +12220,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light/smart{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -36061,8 +36064,8 @@
 /area/station/medical/reception)
 "bmu" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "darkblue"
 	},
 /area/station/bridge/teleporter)
 "bmv" = (
@@ -70926,15 +70929,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
-"eNW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/dormitory)
 "ePa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
@@ -73313,6 +73307,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"hnm" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Barbershop";
+	sortType = "Barbershop"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "hnr" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -77249,12 +77260,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
-"liX" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "ljb" = (
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
@@ -78981,15 +78986,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"mWL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "mXb" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -79129,6 +79125,15 @@
 	icon_state = "white"
 	},
 /area/station/rnd/xenobiology)
+"nfu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "nfZ" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "8,7"
@@ -79794,12 +79799,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/starboardsolar)
-"nTX" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/teleporter)
 "nUb" = (
 /obj/structure/closet/l3closet/general,
 /obj/item/clothing/mask/gas/coloured,
@@ -82758,6 +82757,12 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/maintenance/cargo)
+"rkC" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/bridge/teleporter)
 "rlb" = (
 /obj/structure/sink{
 	pixel_x = 6;
@@ -85875,6 +85880,12 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"vea" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/teleporter)
 "vhl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/polarized{
@@ -87157,6 +87168,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
+"xHA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "xHP" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -87459,23 +87479,6 @@
 /obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall,
 /area/station/cargo/recycleroffice)
-"ybT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Barbershop";
-	sortType = "Barbershop"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "ycW" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -118725,12 +118728,12 @@ aua
 bbb
 aef
 ayu
-eNW
+xHA
 bAH
-eNW
-eNW
-eNW
-eNW
+xHA
+xHA
+xHA
+xHA
 bNP
 aeJ
 aeJ
@@ -119491,7 +119494,7 @@ aoz
 arJ
 byE
 sNO
-liX
+vea
 rEq
 jtE
 byE
@@ -119748,7 +119751,7 @@ ajo
 arI
 byE
 xZq
-bmu
+rkC
 brZ
 mAJ
 byE
@@ -120262,7 +120265,7 @@ apb
 arL
 byE
 asZ
-bmu
+rkC
 bsb
 bHz
 byE
@@ -120519,7 +120522,7 @@ aqC
 arK
 byE
 msQ
-bmu
+rkC
 bsl
 bAb
 byE
@@ -121032,7 +121035,7 @@ ajo
 apb
 aql
 byE
-nTX
+bmu
 arT
 whD
 avj
@@ -122110,11 +122113,11 @@ qBb
 xTO
 cro
 bye
-mWL
-mWL
+nfu
+nfu
 bGq
-mWL
-ybT
+nfu
+hnm
 oLb
 bCi
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11417,9 +11417,6 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "atp" = (
-/obj/machinery/light/smart{
-	dir = 8
-	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -11430,23 +11427,25 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
 /area/station/security/prison)
 "atr" = (
-/obj/structure/cable,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/turf/simulated/floor{
+	icon_state = "black"
 	},
-/turf/simulated/floor/plating,
-/area/station/security/visiting_room)
+/area/station/security/prison)
 "ats" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=EVA";
@@ -11851,12 +11850,8 @@
 	},
 /area/station/hallway/primary/fore)
 "auc" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics/old)
+/turf/simulated/wall,
+/area/station/civilian/barbershop)
 "aud" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12246,10 +12241,14 @@
 	},
 /area/station/civilian/kitchen)
 "auQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/thin/reinforced,
-/turf/simulated/floor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "black"
+	},
 /area/station/security/prison)
 "auR" = (
 /obj/structure/cable{
@@ -12822,11 +12821,18 @@
 	},
 /area/station/civilian/bar)
 "avQ" = (
-/obj/structure/sign/poster/official/obey{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
 	},
-/turf/simulated/wall/r_wall,
-/area/station/security/prison)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/closet/crate,
+/obj/item/device/multitool,
+/obj/item/device/flashlight,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "avR" = (
 /obj/machinery/camera{
 	c_tag = "Prison Rec Room South";
@@ -12843,6 +12849,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -12858,6 +12867,11 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -13170,6 +13184,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -14903,15 +14920,6 @@
 	},
 /area/station/civilian/gym)
 "azJ" = (
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual/wiki/sop{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/weapon/book/manual/wiki/security_space_law{
-	pixel_x = 4;
-	pixel_y = 3
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkblue"
@@ -16052,16 +16060,12 @@
 	},
 /area/station/civilian/kitchen)
 "aBO" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor/plating,
-/area/station/security/visiting_room)
+/area/station/civilian/hydroponics/old)
 "aBP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -22081,6 +22085,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -22115,6 +22124,11 @@
 	frequency = 1480;
 	name = "Chamber One";
 	pixel_x = -26
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -39307,18 +39321,12 @@
 	},
 /area/station/security/blueshield)
 "bsq" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/closet/crate,
-/obj/item/device/multitool,
-/obj/item/device/flashlight,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/security/prison)
 "bsr" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -43595,14 +43603,7 @@
 	},
 /area/station/bridge)
 "bzI" = (
-/obj/structure/cable{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/cable,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -43712,6 +43713,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/security/visiting_room)
 "bzR" = (
@@ -43807,13 +43811,14 @@
 	},
 /area/station/security/blueshield)
 "bAa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/wall/r_wall,
-/area/station/security/visiting_room)
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "bAb" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/window/thin/reinforced{
@@ -44740,6 +44745,10 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/item/weapon/book/manual/wiki/sop{
+	pixel_x = -7;
+	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -47085,8 +47094,11 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "bFU" = (
-/turf/simulated/wall,
-/area/station/civilian/barbershop)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor,
+/area/station/security/prison)
 "bFV" = (
 /obj/machinery/requests_console/tech_storage{
 	pixel_y = -32
@@ -49087,6 +49099,7 @@
 	name = "Internal Affairs";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bJN" = (
@@ -71001,6 +71014,9 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/environment/space,
 /area/station/civilian/hydroponics/old)
 "eKb" = (
@@ -77016,6 +77032,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "kNR" = (
@@ -77613,15 +77632,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
-"lxk" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "lxr" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -79865,6 +79875,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/item/weapon/book/manual/wiki/security_space_law{
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
@@ -82167,6 +82181,9 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/environment/space,
 /area/station/civilian/hydroponics/old)
 "qGb" = (
@@ -83119,13 +83136,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"rAh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/security/prison)
 "rBb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85298,6 +85308,7 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -85457,24 +85468,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
-"umQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "unb" = (
 /obj/structure/table/woodentable,
 /obj/item/device/paicard{
@@ -85721,6 +85714,16 @@
 	},
 /area/station/civilian/toilet)
 "uHF" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -86648,6 +86651,24 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
+"wCF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "wDF" = (
 /obj/machinery/light{
 	dir = 4
@@ -108203,7 +108224,7 @@ bIM
 bJX
 rnx
 bDp
-bsq
+avQ
 tgJ
 bNk
 bsT
@@ -113861,7 +113882,7 @@ cro
 oYb
 bxe
 bVa
-umQ
+wCF
 pOb
 cro
 cro
@@ -115610,12 +115631,12 @@ awH
 aLs
 aoo
 cIb
-auQ
+bFU
 are
 ash
-uHF
+atr
 aNr
-aBO
+bzI
 bnA
 nYP
 wjo
@@ -115868,11 +115889,11 @@ aOk
 asF
 aoY
 aqz
-rAh
+bsq
 rsD
-uHF
+auQ
 ayr
-bAa
+adW
 adW
 adW
 bHV
@@ -116125,7 +116146,7 @@ amG
 aop
 apc
 cIb
-rAh
+bsq
 atN
 uHF
 avR
@@ -116385,8 +116406,8 @@ ffD
 arl
 yjk
 aNo
-avQ
-bAa
+ayr
+adW
 adW
 adW
 bKR
@@ -116900,7 +116921,7 @@ asR
 aCO
 aGm
 avV
-bAa
+adW
 adW
 adW
 ayq
@@ -117157,7 +117178,7 @@ asU
 aso
 auR
 avW
-atr
+bzI
 ayn
 nYP
 icK
@@ -121321,15 +121342,15 @@ cea
 aPG
 ovb
 aEV
-bFU
-bFU
+auc
+auc
 aKa
-bFU
+auc
 aKa
-bFU
+auc
 aKa
-bFU
-bFU
+auc
+auc
 swb
 vFP
 mpb
@@ -121579,14 +121600,14 @@ aIR
 ovb
 bht
 bHq
-lxk
+bAa
 aIu
 sxb
 aIu
 aJV
 aIu
 mlb
-bFU
+auc
 amR
 bHM
 bMl
@@ -121843,7 +121864,7 @@ bJd
 bHt
 bJd
 qob
-bFU
+auc
 cdP
 bLt
 bSV
@@ -122100,7 +122121,7 @@ bGr
 pib
 qob
 qob
-bFU
+auc
 cdP
 bLt
 bSV
@@ -122349,7 +122370,7 @@ bXR
 aPE
 bME
 cMQ
-bFU
+auc
 mXb
 pjb
 mlb
@@ -122357,7 +122378,7 @@ qob
 aEq
 bHi
 aIA
-bFU
+auc
 cLk
 bLt
 bSV
@@ -133930,7 +133951,7 @@ ccR
 cew
 cfD
 cya
-auc
+aBO
 bSY
 bSY
 bSY


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Исход слегка поменялся...
![image](https://github.com/user-attachments/assets/2b280485-eb82-43f9-aa4f-0527fc124c85)
![image](https://github.com/user-attachments/assets/a444cf64-3601-4c2f-a2b5-f5bca8e61b2c)
![image](https://github.com/user-attachments/assets/fc4da99e-739a-4612-9eff-919e70e75982)
![image](https://github.com/user-attachments/assets/696a3135-ba67-4a6f-a08a-3c1d05c20c8f)
![image](https://github.com/user-attachments/assets/f630f494-6deb-401c-b4b9-c8569823a684)

## Почему и что этот ПР улучшит
Ротации должны повлиять на геймплей и добавить более интересных ситуаций. Блющилд перенесен к "мозгу станции", капитану (считаю это более логичным, чем у брига. Зачем ему там быть?). Телепортационная же на месте БЩ открывает ещё больше возможностей для побега зеков и в целом выглядит как что-то более логичное. АВД переместился немного ближе к главам на место цирюльника, а сама парихмахерская переместилась в старую ботанику, поближе к меду. К слову - она стала выглядеть более красивой! Старую ботанику переместил в центральное экстренное хранилище в немного урезанном виде.
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: maleyvich
- map[link]: На КСН "Исход" произошла значительная ротация отделов.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
