### PR TITLE
fix reflect

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -210,7 +210,7 @@
 	// Obstacle not on border or null
 	return rollback_obstacle
 
-/turf/Enter(atom/movable/mover as mob|obj, atom/old_loc as mob|obj|turf)
+/turf/Exit(atom/movable/mover as mob|obj, atom/new_loc as mob|obj|turf)
 	if(movement_disabled && usr.ckey != movement_disabled_exception)
 		to_chat(usr, "<span class='warning'>Передвижение отключено администрацией.</span>")//This is to identify lag problems
 		return FALSE
@@ -218,14 +218,17 @@
 	var/atom/bump_target
 
 	if(istype(mover, /obj/item/projectile))
-		bump_target = get_projectile_bump_target(src, mover)
+		bump_target = get_projectile_bump_target(new_loc, mover)
 	else
-		bump_target = get_bump_target(src, mover)
+		bump_target = get_bump_target(new_loc, mover)
 
 	if(bump_target)
 		mover.Bump(bump_target, TRUE)
 		return FALSE
 
+	return TRUE
+
+/turf/Enter(atom/movable/mover as mob|obj, atom/old_loc as mob|obj|turf)
 	return TRUE
 
 /turf/proc/is_mob_placeable(mob/M) // todo: maybe rewrite as COMSIG_ATOM_INTERCEPT_TELEPORT


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я хз как больше половины года не замечали что рефлект не работает, но эта штука фиксит все возможные двойные+ бампы.
По плану ничего не должно сломать так как единственное отличие Exit от Enter в том, что если Enter возвращает FALSE, то бъёнд пытается бампнуть все (density?) объекты на турфе. 
Нужно подержать в тестмерже так как не представляю что это может сломать.

Как это фиксит рефлекты? Лазер ударялся в объект, перемещался в его турф (из-за PROJECTILE_FORCE_MISS), Enter возвращал FALSE, лазер ударялся в лазер.

## Почему и что этот ПР улучшит
fixes #13216

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
 - bugfix: Пофикшен эффект отражения снарядов.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
