### PR TITLE
рунчат не глотает слова

### DIFF
--- a/code/datums/runechat.dm
+++ b/code/datums/runechat.dm
@@ -151,7 +151,7 @@
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
 
 	// Approximate text height
-	var/complete_text = "<span class='center [extra_classes.Join(" ")]' style='color: [tgt_color]'>[text]</span>"
+	var/complete_text = MAPTEXT("<span class='center [extra_classes.Join(" ")]' style='color: [tgt_color]'>[text]</span>")
 	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(complete_text, null, RUNECHAT_MESSAGE_WIDTH))
 	if(!owner.client)
 		qdel(src)
@@ -192,7 +192,7 @@
 	message.maptext_width = RUNECHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight
 	message.maptext_x = (RUNECHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5
-	message.maptext = MAPTEXT(complete_text)
+	message.maptext = complete_text
 
 	// View the message
 	LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
почему-то измеряется высота текста перед тем, как навесится на него класс `maptext`, где изменяется шрифт и его размер
т.е. конечный текст оказался не конечным

p.s. на тг кстати такой же прикол, но они просто конечную высоту умножают

теперь же конечный текст по-настоящему конечный, и у него мы и замеряем высоту

если рунчат продолжит глотать какие-то предложения - позвоните нам на горячую линию

было
![image](https://github.com/user-attachments/assets/04fc7d0b-1518-4f7a-a042-deda720bbc84)
стало
![image](https://github.com/user-attachments/assets/0cb8a86f-0e1d-4988-a1cb-1611a7659003)

## Почему и что этот ПР улучшит
космонавты перестанут глотать слова, начнут лучше понимать друг друга и улучшится социальный элемент тау цети
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
я не нашел ишуев, это кто-то вообще замечал???
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
