### PR TITLE
"Toggle internals" button fix

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -43,6 +43,11 @@
 			return
 		Remove(owner)
 	owner = T
+	if(istype(src, /datum/action/item_action/hands_free/toggle_internals))
+		if(owner.internal)
+			background_icon_state = "bg_active"
+		else
+			background_icon_state = "bg_default"
 	owner.actions.Add(src)
 	owner.update_action_buttons()
 	return

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -208,6 +208,7 @@
 			TI.background_icon_state = "bg_active"
 		else
 			TI.background_icon_state = "bg_default"
+	T.update_action_buttons()
 
 /obj/item/weapon/tank/remove_air(amount)
 	return air_contents.remove(amount)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -27,7 +27,6 @@
 	//to find it.
 	blinded = null
 	reset_alerts()
-	update_action_buttons()
 
 	//TODO: seperate this out
 	// update the current life tick, can be used to e.g. only do something every 4 ticks
@@ -357,9 +356,15 @@ var/global/list/tourette_bad_words= list(
 
 /mob/living/carbon/human/get_breath_from_internal(volume_needed)
 	if(!internal)
+		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
+			action.background_icon_state = "bg_default"
+		update_action_buttons()
 		return null
 
 	if(!(HAS_TRAIT(src, TRAIT_AV) || (contents.Find(internal) && wear_mask && (wear_mask.flags & MASKINTERNALS))))
+		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
+			action.background_icon_state = "bg_default"
+		update_action_buttons()
 		internal = null
 		return null
 
@@ -944,14 +949,6 @@ var/global/list/tourette_bad_words= list(
 /mob/living/carbon/human/handle_regular_hud_updates()
 	if(!client)
 		return
-
-	if(!internal)
-		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
-			action.background_icon_state = "bg_default"
-
-	if(!(HAS_TRAIT(src, TRAIT_AV) || (contents.Find(internal) && wear_mask && (wear_mask.flags & MASKINTERNALS))))
-		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
-			action.background_icon_state = "bg_default"
 
 	if(stat == UNCONSCIOUS && health <= 0)
 		//Critical damage passage overlay

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -27,6 +27,7 @@
 	//to find it.
 	blinded = null
 	reset_alerts()
+	update_action_buttons()
 
 	//TODO: seperate this out
 	// update the current life tick, can be used to e.g. only do something every 4 ticks
@@ -356,9 +357,13 @@ var/global/list/tourette_bad_words= list(
 
 /mob/living/carbon/human/get_breath_from_internal(volume_needed)
 	if(!internal)
+		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
+			action.background_icon_state = "bg_default"
 		return null
 
 	if(!(HAS_TRAIT(src, TRAIT_AV) || (contents.Find(internal) && wear_mask && (wear_mask.flags & MASKINTERNALS))))
+		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
+			action.background_icon_state = "bg_default"
 		internal = null
 		return null
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -357,13 +357,9 @@ var/global/list/tourette_bad_words= list(
 
 /mob/living/carbon/human/get_breath_from_internal(volume_needed)
 	if(!internal)
-		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
-			action.background_icon_state = "bg_default"
 		return null
 
 	if(!(HAS_TRAIT(src, TRAIT_AV) || (contents.Find(internal) && wear_mask && (wear_mask.flags & MASKINTERNALS))))
-		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
-			action.background_icon_state = "bg_default"
 		internal = null
 		return null
 
@@ -948,6 +944,14 @@ var/global/list/tourette_bad_words= list(
 /mob/living/carbon/human/handle_regular_hud_updates()
 	if(!client)
 		return
+
+	if(!internal)
+		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
+			action.background_icon_state = "bg_default"
+
+	if(!(HAS_TRAIT(src, TRAIT_AV) || (contents.Find(internal) && wear_mask && (wear_mask.flags & MASKINTERNALS))))
+		for(var/datum/action/item_action/hands_free/toggle_internals/action in actions)
+			action.background_icon_state = "bg_default"
 
 	if(stat == UNCONSCIOUS && health <= 0)
 		//Critical damage passage overlay


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Изображение экшен кнопки "Toggle internals" теперь регулярно обновляется, если персонаж не дышит из баллона.
## Почему и что этот ПР улучшит
fixes #12139
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Иконка кнопки "Toggle internals" некорректно обновлялась.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
