### PR TITLE
gatfruit nerf.

### DIFF
--- a/code/defines/obj/hydro.dm
+++ b/code/defines/obj/hydro.dm
@@ -80,7 +80,7 @@
 
 /obj/item/seeds/gatfruit
 	name = "pack of gatfruit seeds"
-	desc = "These seeds grow into .357 revolvers."
+	desc = "These seeds grow into a real buck of a shot."
 	icon_state = "seed-gatfruit"
 	species = "gatfruit"
 	plantname = "Gatfruit Tree"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -230,13 +230,6 @@
 	else
 		to_chat(user, "<span class='notice'>[src] is empty.</span>")
 
-/obj/item/weapon/gun/projectile/revolver/empty/atom_init()
-	. = ..()
-	while (get_ammo() > 0)
-		var/obj/item/ammo_casing/CB = magazine.get_round(0)
-		chambered = null
-		qdel(CB)
-
 /obj/item/weapon/gun/projectile/revolver/peacemaker/detective
 	initial_mag = /obj/item/ammo_box/magazine/internal/cylinder/rev45/rubber
 

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -230,6 +230,13 @@
 	else
 		to_chat(user, "<span class='notice'>[src] is empty.</span>")
 
+/obj/item/weapon/gun/projectile/revolver/empty/atom_init()
+	. = ..()
+	while (get_ammo() > 0)
+		var/obj/item/ammo_casing/CB = magazine.get_round(0)
+		chambered = null
+		qdel(CB)
+
 /obj/item/weapon/gun/projectile/revolver/peacemaker/detective
 	initial_mag = /obj/item/ammo_box/magazine/internal/cylinder/rev45/rubber
 

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1137,7 +1137,7 @@
 	icon_state = "gatfruit"
 	potency = 25
 	filling_color = "#020108"
-	trash = /obj/item/weapon/gun/projectile/revolver/empty
+	trash = /obj/item/ammo_box/eight_shells/buckshot
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/gatfruit/atom_init()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1137,7 +1137,7 @@
 	icon_state = "gatfruit"
 	potency = 25
 	filling_color = "#020108"
-	trash = /obj/item/weapon/gun/projectile/revolver
+	trash = /obj/item/weapon/gun/projectile/revolver/empty
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/gatfruit/atom_init()
 	. = ..()


### PR DESCRIPTION
## Описание изменений

Гатфрут спавнит патроны к дробовику вместо револьверов.

Альтернативный ПР: вирусологическая консолька требует доступа вирусолога.

## Почему и что этот ПР улучшит

Нерфит гатфрут позволяя нам оставить остальные фичи пятого дополнения к Вирусологии Дехаки.

Возможно позволит закрыть #13375 

## Чеинжлог

Я думаю без чеинжлога будет смешнее если грифонер пройдёт весь этот квест с выведением гатфрута чтобы получить патроны.