### PR TITLE
ИВЛ можно начать сразу, как кукла падает в крит

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -73,13 +73,10 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/weapon/W, mob/user)
-	if (istype(W, /obj/item/weapon/reagent_containers))
+	if (istype(W, /obj/item/weapon/reagent_containers/glass/beaker) || istype(W, /obj/item/weapon/reagent_containers/blood) || istype(W, /obj/item/weapon/reagent_containers/glass/bottle))
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
 			return
-		if(istype(W, /obj/item/weapon/reagent_containers/pill/twopart))
-			W.flags &= ~NOREACT
-			W.reagents.handle_reactions()
 		user.drop_from_inventory(W, src)
 		src.beaker = W
 		to_chat(user, "You attach \the [W] to \the [src].")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -40,7 +40,7 @@
 /mob/living/carbon/human/helpReaction(mob/living/carbon/human/attacker, show_message = TRUE)
 	var/target_zone = attacker.get_targetzone()
 	var/obj/item/organ/internal/heart/Heart = organs_by_name[O_HEART]
-	if(health < (config.health_threshold_crit - 30) && target_zone == O_MOUTH)
+	if(health < (config.health_threshold_crit) && target_zone == O_MOUTH)
 		INVOKE_ASYNC(src, PROC_REF(perform_av), attacker)
 		return TRUE
 	if(Heart && Heart.parent_bodypart == target_zone && Heart.heart_status != HEART_NORMAL)


### PR DESCRIPTION
## Описание изменений
ИВЛ теперь можно делать сразу, как только кукла упала в крит. С тошнотой не конфликтует.

## Почему и что этот ПР улучшит
Вообще странно, что до начала ИВЛ нужно было ждать какой-то промежуток времени (- 30). С этим можно поддерживать относительно стабильное состояние куклы до оказания медицинской помощи.

Позволит игрокам более активно и эффективно оказывать первую медицинскую помощь, если такая необходимость появится. Ну и не дать кукле сдохнуть от оксиурона до прибытия в медбэй.

Ишшуй: https://github.com/TauCetiStation/TauCetiClassic/issues/13436

## Авторство
Danistans, DarthSidiousPalpatine

## Чеинжлог
:cl:
 - bugfix: До ПРа кукле можно было вентилировать лёгкие (ИВЛ) только если она какое-то время покоптилась в крите. Сейчас начинать ИВЛ можно сразу, как кукла падает в крит
