### PR TITLE
В капельницу теперь засовываются только предусмотренные контейнеры

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -71,15 +71,11 @@
 		src.attached = over_object
 		update_icon()
 
-
 /obj/machinery/iv_drip/attackby(obj/item/weapon/W, mob/user)
-	if (istype(W, /obj/item/weapon/reagent_containers))
+	if (istype(W, /obj/item/weapon/reagent_containers/glass/beaker) || istype(W, /obj/item/weapon/reagent_containers/blood) || istype(W, /obj/item/weapon/reagent_containers/glass/bottle))
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
 			return
-		if(istype(W, /obj/item/weapon/reagent_containers/pill/twopart))
-			W.flags &= ~NOREACT
-			W.reagents.handle_reactions()
 		user.drop_from_inventory(W, src)
 		src.beaker = W
 		to_chat(user, "You attach \the [W] to \the [src].")

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -73,10 +73,13 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/weapon/W, mob/user)
-	if (istype(W, /obj/item/weapon/reagent_containers/glass/beaker) || istype(W, /obj/item/weapon/reagent_containers/blood) || istype(W, /obj/item/weapon/reagent_containers/glass/bottle))
+	if (istype(W, /obj/item/weapon/reagent_containers))
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
 			return
+		if(istype(W, /obj/item/weapon/reagent_containers/pill/twopart))
+			W.flags &= ~NOREACT
+			W.reagents.handle_reactions()
 		user.drop_from_inventory(W, src)
 		src.beaker = W
 		to_chat(user, "You attach \the [W] to \the [src].")

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -73,13 +73,10 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/weapon/W, mob/user)
-	if (istype(W, /obj/item/weapon/reagent_containers))
+	if (istype(W, /obj/item/weapon/reagent_containers/glass/beaker) || istype(W, /obj/item/weapon/reagent_containers/blood) || istype(W, /obj/item/weapon/reagent_containers/glass/bottle))
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
 			return
-		if(istype(W, /obj/item/weapon/reagent_containers/pill/twopart))
-			W.flags &= ~NOREACT
-			W.reagents.handle_reactions()
 		user.drop_from_inventory(W, src)
 		src.beaker = W
 		to_chat(user, "You attach \the [W] to \the [src].")


### PR DESCRIPTION
## Описание изменений
Изменена проверка вставляемого в капельницу объекта. Раньше это был весь пулл reagent_containers, я уточнил до всего пространства Beaker (бикеры), Bottle (бутыльки) и Blood (пакеты крови, пустые и наполненные любой группой). 

Также удалил строку с проверкой на вставление таблетки (она так или иначе уже не вставится, в этом не видно смысла).

## Почему и что этот ПР улучшит
Этот ПР исправляет баг, при котором можно вставлять таблетки, автоинжекторы и прочие непредусмотренные предметы в капельницу и заполнять её веществами из кукол. Теперь в капельницу можно вставлять только бикеры (Beaker), бутыльки (Bottles) и пакеты крови (Blood packs).

Ишшуй: https://github.com/TauCetiStation/TauCetiClassic/issues/8214

## Авторство
Danistans

## Чеинжлог
:cl:
- bugfix: Исправлен баг, позволявший вставлять непредусмотренные предметы в капельницы медбэя.