### PR TITLE
Возможность петь песенки под музычку

### DIFF
--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -147,10 +147,13 @@ var/global/datum/notes_storage/note_cache_storage = new
 					A pause may be denoted by an empty chord: <i>C,E,,C,G</i><br>
 					To make a chord be a different time, end it with /x, where the chord length will be length<br>
 					defined by tempo / x: <i>C,G/2,E/4</i><br>
-					Combined, an example is: <i>E-E4/4,/2,G#/8,B/8,E3-E4/4</i>
+					Combined, an example is: <i>E-E4/4,/2,G#/8,B/8,E3-E4/4</i><br>
 					<br>
-					Lines may be up to [MAX_LINE_SIZE] characters.<br>
-					A song may only contain up to [MAX_LINES_COUNT] lines.<br>
+					Also, you can include some lyrics to sing in the duration of the song.<br>
+					To mark where to start to sing a lyrics line, insert <i>L*number of lyrics line*</i> in the song chords.<br>
+					Mark of lyrics must be separated bu commas, like a chord.<br>
+					Lines of song and lyrics may be up to [MAX_LINE_SIZE] characters.<br>
+					A song and lyrics may only contain up to [MAX_LINES_COUNT] lines.<br>
 					"}
 
 	user.set_machine(instrument)

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -383,7 +383,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 
 	for(var/line_num in 1 to lines.len)
 		if(length(lines[line_num]) > MAX_LINE_SIZE)
-			lines[line_num] = sanitize(copytext(lines[line_num], 1, MAX_LINE_SIZE))
+			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
 
 	song_lines = lines
 
@@ -398,7 +398,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 
 	for(var/line_num in 1 to lines.len)
 		if(length(lines[line_num]) > MAX_LINE_SIZE)
-			lines[line_num] = sanitize(copytext(lines[line_num], 1, MAX_LINE_SIZE))
+			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
 
 	lyrics_lines = lines
 

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -382,7 +382,8 @@ var/global/datum/notes_storage/note_cache_storage = new
 		lines.Cut(MAX_LINES_COUNT + 1)
 
 	for(var/line_num in 1 to lines.len)
-		lines[line_num] = sanitize(lines[line_num] as text|null, MAX_LINE_SIZE)
+		if(length(lines[line_num]) > MAX_LINE_SIZE)
+			lines[line_num] = sanitize(copytext(lines[line_num], 1, MAX_LINE_SIZE))
 
 	song_lines = lines
 
@@ -396,7 +397,8 @@ var/global/datum/notes_storage/note_cache_storage = new
 		lines.Cut(MAX_LINES_COUNT + 1)
 
 	for(var/line_num in 1 to lines.len)
-		lines[line_num] = sanitize(lines[line_num] as text|null, MAX_LINE_SIZE)
+		if(length(lines[line_num]) > MAX_LINE_SIZE)
+			lines[line_num] = sanitize(copytext(lines[line_num], 1, MAX_LINE_SIZE))
 
 	lyrics_lines = lines
 

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -151,7 +151,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 					<br>
 					Also, you can include some lyrics to sing in the duration of the song.<br>
 					To mark where to start to sing a lyrics line, insert <i>L*number of lyrics line*</i> in the song chords.<br>
-					Mark of lyrics must be separated bu commas, like a chord.<br>
+					Mark of lyrics must be separated by commas, like a chord.<br>
 					Lines of song and lyrics may be up to [MAX_LINE_SIZE] characters.<br>
 					A song and lyrics may only contain up to [MAX_LINES_COUNT] lines.<br>
 					"}

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -229,7 +229,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 			if(lyrics_lines.len > MAX_LINES_COUNT)
 				return
 
-			var/newline = sanitize(input("Enter new lyrics line: ") as text|null, MAX_LINE_SIZE, ascii_only = TRUE)
+			var/newline = sanitize(input("Enter new lyrics line: ") as text|null, MAX_LINE_SIZE)
 
 			if(!newline || !instrument.Adjacent(usr))
 				return
@@ -242,7 +242,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 
 		else if(href_list["modify_lyrics_line"])
 			var/line_num = text2num(href_list["modify_lyrics_line"])
-			var/content = sanitize(input("Enter your line: ", "Change lyrics line [line_num]", lyrics_lines[line_num]) as text|null, MAX_LINE_SIZE, ascii_only = TRUE)
+			var/content = sanitize(input("Enter your line: ", "Change lyrics line [line_num]", lyrics_lines[line_num]) as text|null, MAX_LINE_SIZE)
 
 			if (!content || !instrument.Adjacent(usr))
 				return
@@ -272,7 +272,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 			for (var/line in lyrics_lines)
 				lyrics += line + "\n"
 
-			var/lyrics_text = sanitize(input("Please, paste the entire lyrics: ", "Import Lyrics", input_default(lyrics)) as message|null, MAX_SONG_SIZE, extra = FALSE, ascii_only = TRUE)
+			var/lyrics_text = sanitize(input("Please, paste the entire lyrics: ", "Import Lyrics", input_default(lyrics)) as message|null, MAX_SONG_SIZE, extra = FALSE)
 
 			if (!lyrics_text || !instrument.Adjacent(usr))
 				return

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -383,7 +383,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 
 	for(var/line_num in 1 to lines.len)
 		if(length(lines[line_num]) > MAX_LINE_SIZE)
-			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
+			lines[line_num] = sanitize(copytext(lines[line_num], 1, MAX_LINE_SIZE))
 
 	song_lines = lines
 
@@ -398,7 +398,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 
 	for(var/line_num in 1 to lines.len)
 		if(length(lines[line_num]) > MAX_LINE_SIZE)
-			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
+			lines[line_num] = sanitize(copytext(lines[line_num], 1, MAX_LINE_SIZE))
 
 	lyrics_lines = lines
 

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -382,7 +382,8 @@ var/global/datum/notes_storage/note_cache_storage = new
 		lines.Cut(MAX_LINES_COUNT + 1)
 
 	for(var/line_num in 1 to lines.len)
-		lines[line_num] = sanitize(lines[line_num] as text|null, MAX_LINE_SIZE)
+		if(length(lines[line_num]) > MAX_LINE_SIZE)
+			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
 
 	song_lines = lines
 
@@ -396,7 +397,8 @@ var/global/datum/notes_storage/note_cache_storage = new
 		lines.Cut(MAX_LINES_COUNT + 1)
 
 	for(var/line_num in 1 to lines.len)
-		lines[line_num] = sanitize(lines[line_num] as text|null, MAX_LINE_SIZE)
+		if(length(lines[line_num]) > MAX_LINE_SIZE)
+			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
 
 	lyrics_lines = lines
 

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -382,8 +382,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 		lines.Cut(MAX_LINES_COUNT + 1)
 
 	for(var/line_num in 1 to lines.len)
-		if(length(lines[line_num]) > MAX_LINE_SIZE)
-			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
+		lines[line_num] = sanitize(lines[line_num] as text|null, MAX_LINE_SIZE)
 
 	song_lines = lines
 
@@ -397,8 +396,7 @@ var/global/datum/notes_storage/note_cache_storage = new
 		lines.Cut(MAX_LINES_COUNT + 1)
 
 	for(var/line_num in 1 to lines.len)
-		if(length(lines[line_num]) > MAX_LINE_SIZE)
-			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
+		lines[line_num] = sanitize(lines[line_num] as text|null, MAX_LINE_SIZE)
 
 	lyrics_lines = lines
 

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -2542,8 +2542,4 @@
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
 #include "maps\centcom\centcom.dmm"
-#include "maps\delta\job_changes.dm"
-#include "maps\falcon\job_changes.dm"
-#include "maps\stroechka\job_changes.dm"
-#include "maps\testmap\job_changes.dm"
 // END_INCLUDE

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -2541,6 +2541,9 @@
 #include "code\unit_tests\unit_test.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\boxstation\boxstation.dmm"
 #include "maps\centcom\centcom.dmm"
+#include "maps\delta\job_changes.dm"
+#include "maps\falcon\job_changes.dm"
+#include "maps\stroechka\job_changes.dm"
+#include "maps\testmap\job_changes.dm"
 // END_INCLUDE

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -2541,5 +2541,6 @@
 #include "code\unit_tests\unit_test.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
+#include "maps\boxstation\boxstation.dmm"
 #include "maps\centcom\centcom.dmm"
 // END_INCLUDE


### PR DESCRIPTION
## Описание изменений
![Screenshot 2024-08-20 181347](https://github.com/user-attachments/assets/ea60393f-6225-4f32-846d-c5b89c198fe5)
Добавил кнопочки для указания текста песни
Пример (можете запустить на локалке):
[Example.txt](https://github.com/user-attachments/files/16677977/Example.txt)
TODO:
- **(Решено. Но проблема с апострофом остается, и только с ним, почему-то)** _Поется пока только на английском, символы вроде "'" (апостроф) переводятся в UTF-код, но фиксится просто, я думаю_ 
- **(Решено)** _Сделать ингейм подсказочку_

UPD.: Ах, да, еще при импорте песни или текста по дефолту в окошке записан текущий текст (для удобства редактирования)
## Почему и что этот ПР улучшит
Будем петь песни у костра, там типа _Белый снег, серый лед_ или _Spaace asshoole_
## Авторство
Я 
## Чеинжлог
:cl:
- rscadd: Возможность петь песенки на любом инструменте