### PR TITLE
Fixed remove uplink button(alternative)

### DIFF
--- a/code/datums/components/gamemodes/syndicate.dm
+++ b/code/datums/components/gamemodes/syndicate.dm
@@ -201,8 +201,8 @@
 		return
 
 	var/obj/item/I = find_syndicate_uplink(traitor_mob)
-	if(I?.hidden_uplink)
-		QDEL_NULL(I.hidden_uplink)
+	if(I)
+		QDEL_NULL(I)
 
 /datum/component/gamemode/syndicate/OnPostSetup(datum/source, laterole)
 	equip_traitor()

--- a/code/datums/components/gamemodes/syndicate.dm
+++ b/code/datums/components/gamemodes/syndicate.dm
@@ -249,5 +249,4 @@
 	if(href_list["removeuplink"])
 		take_uplink(M.current)
 		var/datum/role/role = parent
-		role.antag.memory = null
 		to_chat(M.current, "<span class='warning'>You have been stripped of your uplink.</span>")

--- a/code/datums/components/gamemodes/syndicate.dm
+++ b/code/datums/components/gamemodes/syndicate.dm
@@ -248,5 +248,4 @@
 
 	if(href_list["removeuplink"])
 		take_uplink(M.current)
-		var/datum/role/role = parent
 		to_chat(M.current, "<span class='warning'>You have been stripped of your uplink.</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Чинит функционал кнопки. Так же в отличие от #13341 делает так, что память вовсе не стирается. По просьбе @volas 

## Почему и что этот ПР улучшит

Кнопка будет работать!

## Авторство

@L4rever 

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
- bugfix: админская кнопка remove uplink теперь работает

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
