### PR TITLE
Blastdoors for nukies shuttle

### DIFF
--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -4550,9 +4550,16 @@
 /turf/environment/space,
 /area/shuttle/vox/arkship)
 "alx" = (
-/obj/item/weapon/reagent_containers/glass/bucket/full,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/item/weapon/mop,
+/obj/effect/decal/turf_decal/metal{
+	dir = 4;
+	icon_state = "siding_thinplating_line"
+	},
+/obj/machinery/door_control{
+	id = "smindicate";
+	name = "external shutters control";
+	pixel_x = 27;
+	req_access = list(150)
+	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor6"
 	},
@@ -4638,6 +4645,7 @@
 	dir = 4;
 	icon_state = "siding_thinplating_line"
 	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor6"
 	},
@@ -22894,6 +22902,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/machinery/door/poddoor{
+	id = "smindicate";
+	name = "Security Door"
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	frequency = 1331;
@@ -22915,6 +22927,10 @@
 /turf/environment/space,
 /area/shuttle/escape/centcom)
 "bRb" = (
+/obj/machinery/door/poddoor{
+	id = "smindicate";
+	name = "Security Door"
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	frequency = 1331;
@@ -86834,7 +86850,7 @@ aHP
 akM
 akM
 akM
-alx
+akM
 akM
 akM
 aJR
@@ -87349,7 +87365,7 @@ akM
 akN
 aGs
 aGx
-aGx
+alx
 anx
 aKv
 als

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -14520,6 +14520,9 @@
 	dir = 4;
 	icon_state = "siding_thinplating_line"
 	},
+/obj/structure/rack,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor6"
 	},
@@ -22904,7 +22907,10 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "smindicate";
-	name = "Security Door"
+	name = "Security Door";
+	density = 0;
+	icon_state = "pdoor0";
+	opacity = 0
 	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -22929,7 +22935,10 @@
 "bRb" = (
 /obj/machinery/door/poddoor{
 	id = "smindicate";
-	name = "Security Door"
+	name = "Security Door";
+	density = 0;
+	icon_state = "pdoor0";
+	opacity = 0
 	},
 /obj/machinery/door/airlock/external{
 	dir = 4;


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Вернул на шаттл нюки укреплённые створки (открываются и закрываются через специальную кнопку в нюкерском ПДА).

![image](https://github.com/user-attachments/assets/e43fc17b-e744-428a-be9d-b2d67a732c01)

## Почему и что этот ПР улучшит
Створки случайно удалили в #9592
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: На шаттл оперативников Синдиката вернулись укреплённые створки. Они открываются и закрываются специальной кнопкой в военном КПК нюкеров!!!
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
