### PR TITLE
Фикс медалек

### DIFF
--- a/code/__DEFINES/messages.dm
+++ b/code/__DEFINES/messages.dm
@@ -4,6 +4,7 @@
 #define MAX_NAME_LEN          26
 #define MAX_LNAME_LEN         64
 #define MAX_REV_REASON_LEN    255
+#define MAX_MEDAL_REASON_LEN  128
 
 //#define SHOWMSG_SELF
 #define SHOWMSG_VISUAL (1<<0)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -221,7 +221,7 @@
 		var/input
 		var/awarded_name
 		if(!commended && user != H)
-			awarded_name = sanitize(input(user, "Name of awarded person?", "Name", H.name) as null|text, 100)
+			awarded_name = sanitize(input(user, "Name of awarded person?", "Name", H.name) as null|text, MAX_LNAME_LEN)
 			input = sanitize(input(user, "Reason for this commendation? Describe their accomplishments", "Commendation") as null|text, 100)
 		if(do_after(user, delay, target = H))
 			C.attach_accessory(src, user)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -185,7 +185,7 @@
 	src.key = key
 	src.target_name = target_name
 	src.medal_name = medal_name
-	src.parent_name = sanitize(parent_name)
+	src.parent_name = parent_name
 	src.reason = reason
 	src.image = image
 
@@ -222,7 +222,7 @@
 		var/awarded_name
 		if(!commended && user != H)
 			awarded_name = sanitize(input(user, "Name of awarded person?", "Name", H.name) as null|text, MAX_LNAME_LEN)
-			input = sanitize(input(user, "Reason for this commendation? Describe their accomplishments", "Commendation") as null|text, 100)
+			input = sanitize(input(user, "Reason for this commendation? Describe their accomplishments", "Commendation") as null|text, MAX_MEDAL_REASON_LEN)
 		if(do_after(user, delay, target = H))
 			C.attach_accessory(src, user)
 			if(user != H)
@@ -234,9 +234,10 @@
 					log_game("<b>[key_name(H)]</b> was given the following commendation by <b>[key_name(user)]</b>: [input]")
 					message_admins("<b>[key_name_admin(H)]</b> was given the following commendation by <b>[key_name_admin(user)]</b>: [input]")
 					if(awarded_name)
-						var/datum/medal/medal = new(H.key, awarded_name, name, user.name, input, image(icon, icon_state))
+						var/parent_name = sanitize(user.name)
+						var/datum/medal/medal = new(H.key, awarded_name, name, parent_name, input, image(icon, icon_state))
 						SSticker.medal_list.Add(medal)
-						SSStatistics.add_medal(H.key, awarded_name, name, user.name, input)
+						SSStatistics.add_medal(H.key, awarded_name, name, parent_name, input)
 		return
 
 	..()

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -185,7 +185,7 @@
 	src.key = key
 	src.target_name = target_name
 	src.medal_name = medal_name
-	src.parent_name = parent_name
+	src.parent_name = sanitize(parent_name)
 	src.reason = reason
 	src.image = image
 
@@ -221,8 +221,8 @@
 		var/input
 		var/awarded_name
 		if(!commended && user != H)
-			awarded_name = sanitize(input(user, "Name of awarded person?", "Name", H.name) as null|text)
-			input = sanitize(input(user, "Reason for this commendation? Describe their accomplishments", "Commendation") as null|text)
+			awarded_name = sanitize(input(user, "Name of awarded person?", "Name", H.name) as null|text, 100)
+			input = sanitize(input(user, "Reason for this commendation? Describe their accomplishments", "Commendation") as null|text, 100)
 		if(do_after(user, delay, target = H))
 			C.attach_accessory(src, user)
 			if(user != H)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Фиксит длину в инпутах на 100 символов, больше не будет смешных паст занимающих все титры. Добавил санитайз для имени выдающего.

## Почему и что этот ПР улучшит

Не будет длинных паст в ризоне медалек.

## Авторство

@L4rever 

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
- bugfix: В ризоне медалек нельзя писать больше 100 символов

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
