### PR TITLE
Фикс кривого парсинга base64 ССкой

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -23,7 +23,8 @@ var/global/list/bicon_cache = list()
 	var/iconData = iconCache.ExportText(iconKey)
 	var/list/partial = splittext(iconData, "{")
 	var/list/almost_partial = splittext(partial[2], "}")
-	return replacetext(copytext(almost_partial[1], 3, -5), "\n", "")
+	var/base64 = copytext(almost_partial[1], 3, -2)
+	return replacetext(base64, "\n", "")
 
 /proc/bicon(obj, css = "class='icon'", time_stamp = -1) // if you don't want any styling just pass null to css
 	if (!obj)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
раньше строка полученная хаком заканчивалась так nTkSuQmCC\n\"})\n 
теперь она заканчивается так nTkSuQmCC\n\"})\n\ticon_info = \"\\[0xc000151\\]#floor\"\n 
убираем всё что после } и получаем nTkSuQmCC\n\"
теперь убираем 5 последних
nTkSuQ
ТАДАААА конец на Q 
раньше эти 5 последних были \n\"})\n 
теперь обрезается часть закодированной иконки
так как обрезается 3 символа то современные браузеры не воспринимают это как валидный base64 (его длина - мультипликатив 4, а тут получилось 4*n-3) 

## Почему и что этот ПР улучшит
Картиночки будут чуть корректнее

## Авторство
remindme, сломал 3 года назад я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
