### PR TITLE
Фикс комнаты детектива на BoxStation: переключатель затемнения окон

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -7948,6 +7948,11 @@
 	pixel_y = 10
 	},
 /obj/item/weapon/reagent_containers/food/drinks/flask/detflask,
+/obj/machinery/windowtint{
+	id = "Detective";
+	pixel_x = -28;
+	pixel_y = -15
+	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
 "anb" = (
@@ -59174,8 +59179,7 @@
 "ciY" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
-	dock_tag = "pod4";
-	name = "Escape Pod 4"
+	dock_tag = "pod4"
 	},
 /turf/simulated/floor/grid_floor,
 /area/station/maintenance/engineering)
@@ -70168,8 +70172,7 @@
 /area/shuttle/escape_pod4/station)
 "dAo" = (
 /obj/machinery/door/airlock/external{
-	dir = 4;
-	name = "Escape Pod 5"
+	dir = 4
 	},
 /obj/machinery/door/firedoor{
 	dir = 4


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил переключатель затемнения для детектива на BoxStation, где-то ранее был утерян. 
Заодно пофиксил названия у юго-западных шлюзов до пода: вместо Escape pod 4 и Escape pod 5 привел как у других к дефолту, external airlock

## Почему и что этот ПР улучшит
Возвращение функционалу окнам с затемнением детективу. 

## Авторство
Ястарк.

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->

:cl:
 - bugfix: Детективу вернули переключатель затемнения окон. 