### PR TITLE
Фикс миссклика, когда вас спрашивают

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -639,7 +639,7 @@
 /proc/requestCandidate(mob/M, time_passed, candidates, Question, Ignore_Role, poll_time)
 	M.playsound_local(null, 'sound/misc/notice2.ogg', VOL_EFFECTS_MASTER, vary = FALSE, frequency = null, ignore_environment = TRUE)//Alerting them to their consideration
 	window_flash(M.client)
-	var/ans = tgui_alert(M, Question, "Please answer in [poll_time * 0.1] seconds!", list("Yes", "No", "Not This Round"), poll_time)
+	var/ans = tgui_alert(M, Question, "Please answer in [poll_time * 0.1] seconds!", list("No", "Yes", "Not This Round"), poll_time)
 	switch(ans)
 		if("Yes")
 			to_chat(M, "<span class='notice'>Choice registered: Yes.</span>")
@@ -687,9 +687,9 @@
 /mob/proc/request_n_transfer(mob/M, Question = "Would you like to be a special role?", be_special_type, Ignore_Role, show_warnings = FALSE)
 	var/ans
 	if(Ignore_Role)
-		ans = tgui_alert(M, Question, "[be_special_type] Request", list("Yes", "No", "Not This Round"))
+		ans = tgui_alert(M, Question, "[be_special_type] Request", list("No", "Yes", "Not This Round"))
 	else
-		ans = tgui_alert(M, Question, "[be_special_type] Request", list("Yes", "No"))
+		ans = tgui_alert(M, Question, "[be_special_type] Request", list("No", "Yes"))
 	if(ans == "No")
 		return
 	if(ans == "Not This Round")

--- a/code/datums/components/rites/consent.dm
+++ b/code/datums/components/rites/consent.dm
@@ -27,7 +27,7 @@
 	if(!victim)
 		return
 
-	if(tgui_alert(victim, consent_msg, "Rite", list("Yes", "No")) == "Yes")
+	if(tgui_alert(victim, consent_msg, "Rite", list("No", "Yes")) == "Yes")
 		consent = TRUE
 		to_chat(victim, "<span class='notice'>Вы согласились на ритуал.</span>")
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->

# Игроки, оставьте свой фидбэк, нужно ли это изменение!!!!

Я часто был в ситуации, когда я отправляю сообщение. жму энтер, а там вылазит окошко, ворует фокус и я что-то принимаю. Теперь я мисскликно от этого откажусь.
В другом ПРе это было изменено. я возвращаю так. https://github.com/TauCetiStation/TauCetiClassic/pull/8001
> tweak: Теперь опросник фокусируется на кнопке "Yes"


## Почему и что этот ПР улучшит
QoL

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- tweak: Теперь опросник фокусируется на кнопке "No"
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
