### PR TITLE
Квоты для профессий 2.0

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -93,6 +93,9 @@ SUBSYSTEM_DEF(job)
 		player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 		unassigned -= player
 		job.current_positions++
+
+		if(job.quota == 1)
+			job.quota = 0
 		return TRUE
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return FALSE

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -76,6 +76,8 @@
 
 	var/flags = 0
 
+	var/quota = 0 //0 is neutral, 1 is wanted, 2 is unwanted
+
 /datum/job/proc/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -393,11 +393,20 @@
 					for(var/mob/M in player_list) // Only players with the job assigned and AFK for less than 10 minutes count as active
 						if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)
 							active++
+				var/priority = 0
+				var/priority_color = "#ffffff"
+				switch(job.quota)
+					if(1)
+						priority = "!+"
+						priority_color = "#83bf47"
+					if(2)
+						priority = "¡-"
+						priority_color = "#ee0000"
 				if(job.current_positions && active < job.current_positions)
-					dat += "<a class='[position_class]' style='display:block;width:170px' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions])<br><i>(Active: [active])</i></a>"
+					dat += "<a class='[position_class]' style='display:block;width:170px;color:[priority_color];font-weight:[priority ? "bold" : "normal"]' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[priority ? priority : ""] [job.title] ([job.current_positions])<br><i>(Active: [active])</i></a>"
 					number_of_extra_line_breaks++
 				else
-					dat += "<a class='[position_class]' style='display:block;width:170px' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions])</a>"
+					dat += "<a class='[position_class]' style='display:block;width:170px;color:[priority_color];font-weight:[priority ? "bold" : "normal"]' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[priority ? priority : ""] [job.title] ([job.current_positions])</a>"
 				categorizedJobs[jobcat]["jobs"] -= job
 
 			dat += "</fieldset><br>"

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -7,16 +7,31 @@
     Thank you for your patience!
   </p>
 {{else}}
-  {{:helper.link('Access Modification', 'home', {'choice' : 'mode', 'mode_target' : 0}, !data.mode ? 'disabled' : null)}}
-  {{:helper.link('Crew Manifest', 'folder-open', {'choice' : 'mode', 'mode_target' : 1}, data.mode ? 'disabled' : null)}}
+  {{:helper.link('Access Modification', 'home', {'choice' : 'mode', 'mode_target' : 0}, data.mode == 0 ? 'disabled' : null)}}
+  {{:helper.link('Crew Manifest', 'folder-open', {'choice' : 'mode', 'mode_target' : 1}, data.mode == 1 ? 'disabled' : null)}}
+  {{:helper.link('Quotas', 'star', {'choice' : 'mode', 'mode_target' : 2}, data.mode == 2 ? 'disabled' : null)}}
   {{:helper.link('Print', 'print', {'choice' : 'print'}, (data.mode || data.has_modify) ? null : 'disabled')}}
 
-  {{if data.mode}}
+  {{if data.mode == 1}}
     <div class='item'>
       <h2>Crew Manifest</h2>
     </div>
     <div class='item'>
       {{:data.manifest}}
+    </div>
+  {{else data.mode == 2}}
+    <div class='item'>
+      {{for data.all_jobs:category:categ_num}}
+        <table style='margin-left:30%'><tr><td valign='top'><fieldset style='border: 2px solid {{:category.color}}; display: inline;'><legend align='center' style='color: {{:category.color}}'><b>{{:category.title}}</b></legend>
+          {{for data.all_jobs[categ_num].jobs:job}}
+            <div class='item' style='display:block;width:250px;background-color:#40628a;color:#ffffff'>
+              {{:helper.link('', 'arrowthick-1-n', {'choice' : "up_quota", 'quotajob_type' : job.type}, null, job.quota == 1 ? 'selected' : null, null)}}
+              {{:helper.link('', 'arrowthick-1-s', {'choice' : "down_quota", 'quotajob_type' : job.type}, null, job.quota == 2 ? 'selected' : null, null)}}
+              {{:job.name}}
+            </div>
+          {{/for}}
+        </fieldset><br></td></tr></table>
+      {{/for}}
     </div>
   {{else}}
     <div class='item'>


### PR DESCRIPTION
## Описание изменений
Добавил возможность для ГП ставить "лайк" и "дизлайк" нужным и ненужным профессиям:
![image](https://github.com/user-attachments/assets/434784de-5414-4012-975d-1c295d6297bc)
После чего в лобби, в меню Join, мы можем увидеть какие профессии нужны, а какие нежелательны, по мнению ГП:
![image](https://github.com/user-attachments/assets/cc9702d2-6d86-4759-8f09-c4b004eacd79)

## Почему и что этот ПР улучшит
Можно будет увидеть какая профессия нужна в раунде по мнению ГП и зайти на неё. Больше работы хорошему ГП. Теперь он будет ещё и опрашивать отделы и следить за тем какие профессии нужны, а какие - нет.

## Авторство
AndreyGysev

## Чеинжлог
:cl: AndreyGysev
 - rscadd: Добавлена возможность назначить нужные и ненужные работы в раунде, статус которых будет отображаться в меню Join
