### PR TITLE
Убирает штрафы и бонусы от скиллов на лоупопе

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -42,6 +42,7 @@ SUBSYSTEM_DEF(ticker)
 	var/ert_call_in_progress = FALSE //when true players can join ERT
 	var/hacked_apcs = 0 //check the amount of hacked apcs either by a malf ai, or a traitor
 	var/Malf_announce_stage = 0//Used for announcement
+	var/is_lowpop = FALSE
 
 	var/force_end = FALSE // set TRUE to forse round end and show credits
 
@@ -308,6 +309,10 @@ SUBSYSTEM_DEF(ticker)
 		for(var/holidayname in SSholiday.holidays)
 			var/datum/holiday/holiday = SSholiday.holidays[holidayname]
 			to_chat(world, "<h4>[holiday.greet()]</h4>")
+
+	if(totalPlayersReady <= 10)
+		is_lowpop = TRUE
+		to_chat(world, "<span clas='notice'>Система штрафов и бонусов от умений персонажа отключена.</span>")
 
 	spawn(0)//Forking here so we dont have to wait for this to finish
 		mode.PostSetup()

--- a/code/modules/skills/helpers.dm
+++ b/code/modules/skills/helpers.dm
@@ -11,6 +11,8 @@
 
 /proc/apply_skill_bonus(mob/user, value, required_skills, multiplier)
 	var/result = value
+	if(SSticker.is_lowpop)
+		return result
 	for(var/datum/skill/required_skill as anything in required_skills)
 		var/value_with_helpers = get_skill_with_assistance(user, required_skill)
 		result += value * multiplier * (value_with_helpers - required_skills[required_skill])
@@ -21,7 +23,7 @@
 	return do_after(user, delay = apply_skill_bonus(user, delay, required_skills, multiplier), target = target, extra_checks = extra_checks)
 
 /proc/handle_fumbling(mob/user, atom/target, delay, required_skills, message_self = "", text_target = null, check_busy = TRUE, can_move = FALSE)
-	if(is_skill_competent(user, required_skills))
+	if(is_skill_competent(user, required_skills) || SSticker.is_lowpop)
 		return TRUE
 	if(check_busy && user.is_busy())
 		return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если количество реди на начало раунда меньше 11, раунд начнётся с отключённой системой умений.
т.е. ассистент сможет оперировать с такой же скоростью как и медик, чинить стены с такой же скоростью как и инженер и ТД
## Почему и что этот ПР улучшит
Игру на сервере с небольшим онлайном.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- tweak: Отключение системы штрафов и бонусов от скиллов в раундах с малым онлайном.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
