### PR TITLE
Увеличил начальные деньги персонала до 3-х зарплат вместо одной.

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -3,3 +3,7 @@
 #define INSURANCE_NONE "None"
 #define INSURANCE_STANDARD "Standard"
 #define INSURANCE_PREMIUM "Premium"
+
+#define STARTING_MONEY_MULTIPLYER 3
+#define STARTING_MONEY_VARIANCE 5 //in percents
+#define STARTING_MONEY_MINIMUM 50

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -473,7 +473,8 @@ SUBSYSTEM_DEF(job)
 			H.forceMove(spawn_mark.loc, keep_buckled = TRUE)
 
 	//give them an account in the station database
-	var/datum/money_account/M = create_random_account_and_store_in_mind(H, max(round(job.salary * STARTING_MONEY_MULTIPLYER * (1 + rand(-STARTING_MONEY_VARIANCE, STARTING_MONEY_VARIANCE) / 100)) + job.starting_money, STARTING_MONEY_MINIMUM), job.department_stocks)	//starting funds = salary
+	var/startingMoney = max(round(job.salary * STARTING_MONEY_MULTIPLYER * (1 + rand(-STARTING_MONEY_VARIANCE, STARTING_MONEY_VARIANCE) / 100)) + job.starting_money
+	var/datum/money_account/M = create_random_account_and_store_in_mind(H, startingMoney, STARTING_MONEY_MINIMUM), job.department_stocks)	//starting funds = salary
 
 	// If they're head, give them the account info for their department
 	if(H.mind && job.head_position)

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -473,8 +473,8 @@ SUBSYSTEM_DEF(job)
 			H.forceMove(spawn_mark.loc, keep_buckled = TRUE)
 
 	//give them an account in the station database
-	var/startingMoney = max(round(job.salary * STARTING_MONEY_MULTIPLYER * (1 + rand(-STARTING_MONEY_VARIANCE, STARTING_MONEY_VARIANCE) / 100)) + job.starting_money
-	var/datum/money_account/M = create_random_account_and_store_in_mind(H, startingMoney, STARTING_MONEY_MINIMUM), job.department_stocks)	//starting funds = salary
+	var/startingMoney = max(round(job.salary * STARTING_MONEY_MULTIPLYER * (1 + rand(-STARTING_MONEY_VARIANCE, STARTING_MONEY_VARIANCE) / 100)) + job.starting_money, STARTING_MONEY_MINIMUM)
+	var/datum/money_account/M = create_random_account_and_store_in_mind(H, startingMoney, job.department_stocks)	//starting funds = salary
 
 	// If they're head, give them the account info for their department
 	if(H.mind && job.head_position)

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -473,7 +473,7 @@ SUBSYSTEM_DEF(job)
 			H.forceMove(spawn_mark.loc, keep_buckled = TRUE)
 
 	//give them an account in the station database
-	var/datum/money_account/M = create_random_account_and_store_in_mind(H, job.salary + job.starting_money, job.department_stocks)	//starting funds = salary
+	var/datum/money_account/M = create_random_account_and_store_in_mind(H, max(round(job.salary * STARTING_MONEY_MULTIPLYER * (1 + rand(-STARTING_MONEY_VARIANCE, STARTING_MONEY_VARIANCE) / 100)) + job.starting_money, STARTING_MONEY_MINIMUM), job.department_stocks)	//starting funds = salary
 
 	// If they're head, give them the account info for their department
 	if(H.mind && job.head_position)


### PR DESCRIPTION
## Описание изменений
Теперь начальная сумма с которой стартует персонал исчисляется 3-кратной зарплатой +-5% с минимальной суммой в 50 кредитов.

## Почему и что этот ПР улучшит
Не вчера родились и на работе мы имеем деньги из дома.
Ассистухи не имеют зарплаты но имеют деньги с прошлых смен, могут всё ещё какую-нибудь фигню мелкую купить.
Есть начальные деньги в нормальном объёме вокруг которых и можно будет строить экономику.
В плане, не нужно ждать 15 минут чтобы заиметь начальные деньги которые можно на что-то потратить. Плюс логичнее что ты не вчера родился и у тебя не первая зарплата на счету...
Потом уже от этого можно отталкиваться и изменять цены на ту или иную продукцию и вообще.
Плюс, ассистуха не литералли бомж родившийся вчера, а имеет немного, но денег.
Ну и за это проголосовали люди на форуме.
![image](https://github.com/user-attachments/assets/39d93fb7-cdb1-452c-9841-1563fd0b770b)

## Авторство
AndreyGysev

## Чеинжлог
:cl:
 - tweak: Стартовые средства увеличены до 3-х зарплат с минимальной суммой в 50 кредитов
