### PR TITLE
музыкальные инструменты в карго

### DIFF
--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -135,6 +135,34 @@
 	export_types = list(/obj/item/weapon/mining_scanner/improved)
 
 
+// musical instruments
+
+/datum/export/guitar
+	cost = 30
+	unit_name = "guitar"
+	export_types = list(/obj/item/device/guitar)
+
+/datum/export/harmonica
+	cost = 15
+	unit_name = "harmonica"
+	export_types = list(/obj/item/device/harmonica)
+
+/datum/export/synth
+	cost = 30
+	unit_name = "electronic synthesizer"
+	export_types = list(/obj/item/device/synth)
+
+/datum/export/violin
+	cost = 30
+	unit_name = "space violin"
+	export_types = list(/obj/item/device/violin)
+
+/datum/export/paino
+	cost = 200
+	unit_name = "space grand piano"
+	export_types = list(/obj/structure/device/piano/royal)
+
+
 // misc
 
 /datum/export/cryobag

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1786,6 +1786,23 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 //--------------MISCELLANEOUS-------------------
 //----------------------------------------------
 
+/datum/supply_pack/musical_instruments
+	name = "Musician Instruments"
+	contains = list(/obj/item/device/guitar,
+					/obj/item/device/harmonica,
+					/obj/item/device/synth,
+					/obj/item/device/violin)
+	group = "Miscellaneous"
+	crate_type = /obj/structure/closet/crate
+	crate_name = "Musician Instruments"
+
+/datum/supply_pack/piano
+	name = "Piano"
+	contains = list(/obj/structure/device/piano)
+	group = "Miscellaneous"
+	crate_type = /obj/structure/largecrate
+	crate_name = "Piano"
+
 /datum/supply_pack/wizard
 	name = "Wizard costume"
 	contains = list(/obj/item/weapon/staff,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
добавляет возможность покупать и продавать музыкальные инструменты в карго
## Почему и что этот ПР улучшит
мне кажется плохо то что многие муз. инструменты являются строго ограниченными в своём количестве и то что их нигде нельзя достать в случае уничтожения или пропажи.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- tweak: В карго можно покупать и продавать музыкальные инструменты.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
