### PR TITLE
Фикс блюспейс рюкзака и пересмотренное возвращение механики неисправности интерфейса

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -182,6 +182,12 @@
 /obj/effect/anomaly/bhole/atom_init()
 	. = ..()
 	aSignal.origin_tech = "materials=8;combat=4;engineering=4"
+	
+	START_PROCESSING(SSobj, src)
+	anomalyEffect()
+
+/obj/effect/anomaly/bhole/process() // Thanks to DarkWater
+	anomalyEffect()
 
 /obj/effect/anomaly/bhole/anomalyEffect()
 	..()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -85,10 +85,17 @@
 	warp = new(src)
 	vis_contents += warp
 
+	START_PROCESSING(SSobj, src)
+	anomalyEffect()
+
 /obj/effect/anomaly/grav/Destroy()
 	vis_contents -= warp
+	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(warp)
 	return ..()
+
+/obj/effect/anomaly/grav/process() // Спасибо ДаркВотеру
+	anomalyEffect()
 
 /obj/effect/anomaly/grav/anomalyEffect()
 	..()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -94,7 +94,7 @@
 	QDEL_NULL(warp)
 	return ..()
 
-/obj/effect/anomaly/grav/process() // Спасибо ДаркВотеру
+/obj/effect/anomaly/grav/process() // Thanks to DarkWater
 	anomalyEffect()
 
 /obj/effect/anomaly/grav/anomalyEffect()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -182,12 +182,17 @@
 /obj/effect/anomaly/bhole/atom_init()
 	. = ..()
 	aSignal.origin_tech = "materials=8;combat=4;engineering=4"
-	
+
 	START_PROCESSING(SSobj, src)
 	anomalyEffect()
 
 /obj/effect/anomaly/bhole/process() // Thanks to DarkWater
 	anomalyEffect()
+	
+/obj/effect/anomaly/bhole/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	anomalyNeutralize()
+	return ..()
 
 /obj/effect/anomaly/bhole/anomalyEffect()
 	..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -71,8 +71,7 @@
 	. = ..()
 	if(W == src)
 		Destroy() // каким-то образом удаляет экшен меню при попытке воспроизвести баг и фиксит его
-		to_chat(usr, "<span class='red'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
-		Make_Anomaly(60 SECONDS, /obj/effect/anomaly/grav)
+		to_chat(usr, "<span class='red'>Рюкзак засасывается сам в себя и исчезает.</span>")
 
 		return
 	if(istype(W, /obj/item/weapon/storage/backpack/holding/) && !IsHoldingMalfunction && !(W == src))

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -78,7 +78,7 @@
 	var/obj/effect/anomaly/anomaly = new current_anomaly(targloc)
 	anomaly.anomalyEffect()
 	sleep(delay_time)
-	qdel(anomaly)
+	qdel(current_anomaly)
 
 /obj/item/weapon/storage/backpack/holding/proc/failcheck(mob/user)
 	if (prob(src.reliability))

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -58,9 +58,43 @@
 	if(istype(I, /obj/item/weapon/storage/backpack/holding) && !I.crit_fail)
 		to_chat(user, "<span class='red'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
 		qdel(I)
+		var/obj/effect/anomaly/grav/grav_anomaly = new /obj/effect/anomaly/grav(src.loc)
+
+		to_chat(user, "<span class='red'>A gravitational anomaly appears as the Bluespace interfaces destabilize!</span>")
+
+		grav_anomaly.anomalyEffect()
+
+		START_PROCESSING(SSobj, grav_anomaly)
+
 		return
 
 	return ..()
+
+//Дальше костыли для движения аномалии, притягивания и отталкивания, если есть идеи как оптимизировать или это все вообще фигня по другому надо было сообщите
+
+/obj/effect/anomaly/grav/anomalyEffect()
+	boing = 1
+	for(var/obj/O in orange(4, src))
+		if(!O.anchored)
+			step_towards(O, src)
+
+	for(var/mob/living/M in orange(4, src))
+		step_towards(M, src)
+
+	move_anomaly()
+
+	while(TRUE)	
+		sleep(20)
+		boing = 1
+		for(var/obj/O in orange(4, src))
+			if(!O.anchored)
+				step_towards(O, src)
+		for(var/mob/living/M in orange(4, src))
+			step_towards(M, src)
+		sleep(50)
+		move_anomaly()
+
+	return
 
 /obj/item/weapon/storage/backpack/holding/proc/failcheck(mob/user)
 	if (prob(src.reliability))

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -57,7 +57,7 @@
 	if(istype(I, /obj/item/weapon/storage/backpack/holding) && !I.crit_fail && !(I == src))
 		to_chat(user, "<span class='red'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
 		qdel(I)
-		Make_Anomaly(150 SECONDS, /obj/effect/anomaly/bhole)
+		Make_Anomaly(50 SECONDS, /obj/effect/anomaly/bhole)
 
 	return ..()
 
@@ -69,7 +69,6 @@
 		return FALSE
 	if(istype(W, /obj/item/weapon/storage/backpack/holding))
 		to_chat(usr, "<span class='red'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
-		Make_Anomaly(150 SECONDS, /obj/effect/anomaly/bhole)
 		return FALSE
 	return TRUE
 
@@ -78,8 +77,8 @@
 	var/obj/effect/anomaly/anomaly = new current_anomaly(targloc)
 	anomaly.anomalyEffect()
 	sleep(delay_time)
-	qdel(current_anomaly)
-
+	anomaly.Destroy()
+	
 /obj/item/weapon/storage/backpack/holding/proc/failcheck(mob/user)
 	if (prob(src.reliability))
 		return 1 //No failure

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -46,7 +46,8 @@
 	desc = "A backpack that opens into a localized pocket of Blue Space."
 	origin_tech = "bluespace=4"
 	icon_state = "holdingpack"
-	max_w_class = SIZE_NORMAL
+	w_class = SIZE_HUMAN
+	max_w_class = SIZE_HUMAN
 	max_storage_space = 56
 
 /obj/item/weapon/storage/backpack/holding/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -64,7 +64,7 @@
 		to_chat(user, "<span class='red'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
 		qdel(I)
 		if(!IsHoldingMalfunction)
-			Make_Anomaly(60 SECONDS, /obj/effect/anomaly/grav)
+			Make_Anomaly(150 SECONDS, /obj/effect/anomaly/grav)
 	return .	
 
 /obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning = FALSE, NoUpdate = FALSE)
@@ -72,11 +72,10 @@
 	if(W == src)
 		Destroy() // каким-то образом удаляет экшен меню при попытке воспроизвести баг и фиксит его
 		to_chat(usr, "<span class='red'>Рюкзак засасывается сам в себя и исчезает.</span>")
-
 		return
 	if(istype(W, /obj/item/weapon/storage/backpack/holding/) && !IsHoldingMalfunction && !(W == src))
 		to_chat(usr, "<span class='red'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
-		Make_Anomaly(60 SECONDS, /obj/effect/anomaly/grav)
+		Make_Anomaly(150 SECONDS, /obj/effect/anomaly/grav)
 		return
 
 /obj/item/weapon/storage/backpack/holding/proc/Make_Anomaly(delay_time, current_anomaly)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fix #13547 Помимо простого и неочевидного фикса бага с невидимым блюспейс рюкзаком теперь создает аномалию при засовывании блюспейс рюкзака в рюкзак. Также во время попыток создать рабочую аномалию пофикшен баг при котором свойства аномалии проявляются лишь раз при спавне, а не каждый тик
## Почему и что этот ПР улучшит
Исправляет баги и возвращает старую механику в менее грифозном виде
## Авторство
hyda, danistans
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: HyDa, Danistans
- bugfix: Рюкзак корректно исчезает при засовывании сам в себя.
- bugfix: Аномалии созданные не ивентом теряли свои свойства.
- rscadd: Блюспейс рюкзак теперь при засовывании в другой блюспейс рюкзак создает аномалию.
