### PR TITLE
эмиттеры перестали убивать вплотную лежачих людей

### DIFF
--- a/code/__HELPERS/vector.dm
+++ b/code/__HELPERS/vector.dm
@@ -45,6 +45,7 @@ return_location()
 /datum/plot_vector
 	var/turf/source
 	var/turf/target
+	var/cardinal_dir // in case we don't have a specific target
 	var/angle = 0	// direction of travel in degrees
 	var/loc_x = 0	// in pixels from the left edge of the map
 	var/loc_y = 0	// in pixels from the bottom edge of the map
@@ -52,16 +53,23 @@ return_location()
 	var/offset_x = 0	// distance to increment each step
 	var/offset_y = 0
 
-/datum/plot_vector/proc/setup(turf/S, turf/T, xo = 0, yo = 0, angle_offset=0)
+/datum/plot_vector/proc/setup(turf/S, turf/T, xo = 0, yo = 0, angle_offset=0, dir)
 	source = S
 	target = T
+	cardinal_dir = dir
 
 	if(!istype(source))
 		source = get_turf(source)
-	if(!istype(target))
+
+	if(!istype(source))
+		return
+
+	if(!target && cardinal_dir)
+		target = get_step(source, cardinal_dir)
+	else if(!istype(target))
 		target = get_turf(target)
 
-	if(!istype(source) || !istype(target))
+	if(!istype(target))
 		return
 
 	// convert coordinates to pixel space (default is 32px/turf, 8160px across for a size 255 map)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -1,6 +1,6 @@
 /turf
 	icon = 'icons/turf/floors.dmi'
-	
+
 	// base turf luminosity, works against byond native darkness
 	// most likely you shouldn't touch it
 	// currently direcly used only by starlight/environment lighting
@@ -150,7 +150,7 @@
 	var/atom/priority_target = mover.original
 
 	// Then check priority target if it on the tile
-	if(!isturf(priority_target) && priority_target.loc == T)
+	if(priority_target && !isturf(priority_target) && priority_target.loc == T)
 		if(isliving(priority_target))
 			if(!mover.check_miss(priority_target))
 				alive_obstacle = priority_target

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -160,15 +160,6 @@
 			s.start()
 		A.set_dir(src.dir)
 		A.starting = get_turf(src)
-		switch(dir)
-			if(NORTH)
-				A.original = locate(x, y+1, z)
-			if(EAST)
-				A.original = locate(x+1, y, z)
-			if(WEST)
-				A.original = locate(x-1, y, z)
-			else // Any other
-				A.original = locate(x, y-1, z)
 		A.process()
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -19,7 +19,7 @@
 	var/xo = null
 	var/current = null
 	var/obj/shot_from = null // the object which shot us
-	var/atom/original = null // the original target clicked
+	var/atom/original = null // the original target clicked, may not exist
 	var/turf/starting = null // the projectile's starting turf
 	var/list/permutated = list() // we've passed through these atoms, don't try to hit them again
 
@@ -255,7 +255,7 @@
 
 	// plot the initial trajectory
 	trajectory = new()
-	trajectory.setup(starting, original, pixel_x, pixel_y, angle_offset=offset)
+	trajectory.setup(starting, original, pixel_x, pixel_y, offset, dir)
 
 	// generate this now since all visual effects the projectile makes can use it
 	effect_transform = new()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
конечная цель у прожектайлов теперь может и не существовать
тогда прожектайлы будут просто лететь по своему направлению пока не врежутся во что-нибудь

нужно это для случаев когда мы просто хотим запустить прожектайл по прямой/диагонали как например с эмиттерами
ибо эмиттерам приходится выбирать за цель тайл перед собой
а после всяческих ребалансов лежачих стрелков - выстрел в тайл с лежачим мобом переадресует попадание в самого моба
теперь можно будет спокойно ползать под эмиттерами как раньше
## Почему и что этот ПР улучшит
![image](https://github.com/user-attachments/assets/feb7e199-8f19-478a-9997-15284d13bef6)

на моих глазах от этого бага пострадало несколько новых (и не совсем) игроков 😢
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Эмиттер не будет попадать в лежачих.
