### PR TITLE
Adds kitty ears to loadout menu

### DIFF
--- a/code/modules/client/character_menu/loadout/loadout_hats.dm
+++ b/code/modules/client/character_menu/loadout/loadout_hats.dm
@@ -95,6 +95,10 @@
 	berets["purple"] = /obj/item/clothing/head/beret/purple
 	gear_tweaks += new/datum/gear_tweak/path(berets)
 
+/datum/gear/head/kitty_ears
+	display_name = "Kitty ears"
+	path = /obj/item/clothing/head/kitty
+
 /datum/gear/head/chep
 	display_name = "Maid cap"
 	path = /obj/item/clothing/head/chep


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
в лодауте можно выбрать ушки с хвостиком
## Почему и что этот ПР улучшит
разнообразие это хорошо 
у нас уже есть борги-горничные и горничное платье в лодауте, так что атмосфере это не повредит
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - add: Теперь можно выбрать ушки котёнка в лодаут меню