### PR TITLE
Смятые стикеры можно выбросить в мусорку

### DIFF
--- a/code/modules/paperwork/stickers.dm
+++ b/code/modules/paperwork/stickers.dm
@@ -37,6 +37,9 @@
 		return
 	if(!istype(target, /obj/structure) && !ismachinery(target))
 		return
+	if (crumpled)
+		..()
+		return
 
 	var/list/click_params = params2list(params)
 	var/matrix/M = matrix()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -127,8 +127,14 @@
 		for(var/mob/living/holdermob in I.contents)
 			holdermob.log_combat(usr, "placed in disposals")
 
+	if(istype(I, /obj/item/weapon/paper/sticker))
+		var/obj/item/weapon/paper/sticker/S = I
+		if (!S.crumpled)
+			return
+
 	if(!I || !I.canremove || I.flags & NODROP)
 		return
+
 	user.drop_from_inventory(I, src)
 
 	user.visible_message("<span class='notice'>[user.name] places \the [I] into the [src].</span>", self_message = "<span class='notice'>You place \the [I] into the [src].</span>")


### PR DESCRIPTION
## Описание изменений
Fixes TauCetiStation/TauCetiClassic#13708

Теперь при попытке выкинуть стикер в мусорку проверяется смят ли он:
- если смят - помещается в контейнер мусорки, отображается сообщение о помещении стикера в мусорку
- если не смят - наклеивается (старое поведение), сообщения о перемещении нет

## Почему и что этот ПР улучшит
Станет возможным выкинуть мятый стикер, сохранив его название.

## Авторство

## Чеинжлог
:cl:
 - bugfix: Теперь смятые стикеры можно выбросить в мусор
