### PR TITLE
Исправлен индикатор статуса мусорки

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -408,7 +408,7 @@
 		set_light(1, 1, "#0c8801")
 
 	for(var/image/I in status_overlay)
-		I.plane = LIGHTING_LAMPS_PLANE
+		I.layer = DEFAULT_MACHINERY_LAYER + 0.01
 		add_overlay(I)
 
 // timed process


### PR DESCRIPTION
## Описание изменений
Fixes TauCetiStation/TauCetiClassic#13660

Индикаторы статуса мусорки перемещены на плоскость машинерии, слой +0.01

## Почему и что этот ПР улучшит
Индикаторы статуса мусорки перестанут перекрывать пришедшие по почте предметы

## Авторство

## Чеинжлог
:cl:
 - bugfix: Индикаторы статуса мусорки более не перекрывают пришедшие по почте предметы
