### PR TITLE
cardiopulmonary resuscitation (CPR) update 

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1922,7 +1922,9 @@
 	var/obj/item/organ/internal/heart/Heart = organs_by_name[O_HEART]
 	var/obj/item/organ/internal/heart/Lungs = organs_by_name[O_LUNGS]
 
+	var/fail_damage = apply_skill_bonus(user, 20, list(/datum/skill/medical = SKILL_LEVEL_NONE),  multiplier = -0.20)
 	var/needed_massages = 12
+	var/obj/item/organ/external/BP = get_bodypart(Heart.parent_bodypart)
 	if(HAS_TRAIT(src, TRAIT_FAT))
 		needed_massages = 20
 	if(Lungs && !Lungs.is_bruised())
@@ -1972,16 +1974,13 @@
 		else
 			massages_done_right--
 			to_chat(user, "<span class='warning'>You've skipped a beat.</span>")
+			if ((BP.body_zone == BP_CHEST && op_stage.ribcage != 2) || BP.open < 2)
+				apply_damage(fail_damage, BRUTE, BP.body_zone)
 
 	else
 		to_chat(user, "<span class='warning'>It seems [src]'s [Heart] is too squishy... It doesn't beat at all!</span>")
 
 	last_massage = world.time
-
-	var/obj/item/organ/external/BP = get_bodypart(Heart.parent_bodypart)
-	if (((BP.body_zone == BP_CHEST && op_stage.ribcage != 2) || BP.open < 2) && prob(5))
-		BP.fracture()
-		to_chat(user, "<span class='warning'>You hear cracking in [src]'s [BP]!.</span>")
 
 /mob/living/carbon/human/proc/return_to_body_dialog()
 	// just give a sound notification if already in the body


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
При "пропуске" удара во время CPR торсу реанимируемого наносится урон, который зависит от навыка медицины (20 брута при нулевом уровне навыка, каждый уровень навыка уменьшает урон на 20%). Вскрытие грудной клетки убирает урон от неправильных ударов.
Убран шанс случайно сломать грудь во время CPR.
## Почему и что этот ПР улучшит
resolves #13738
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: Simbaka
- tweak: Убрана вероятность случайно сломать рёбра во время массажа сердца. Вместо этого, при неправильных ударах, торсу реанимируемого наносится урон, который зависит от навыка медицины.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
