### PR TITLE
убирает упоминания пола Дасти

### DIFF
--- a/code/game/gamemodes/objectives/traders_objectives.dm
+++ b/code/game/gamemodes/objectives/traders_objectives.dm
@@ -42,7 +42,7 @@
 		"факс" = /obj/machinery/faxmachine,
 		"ядерную боеголовку" = /obj/machinery/nuclearbomb,
 		"раздатчик атмосферных труб" = /obj/machinery/pipedispenser,
-		"питомец главврача Дасти" = /mob/living/simple_animal/cat/dusty,
+		"питомца главврача Дасти" = /mob/living/simple_animal/cat/dusty,
 		"плазменный дробовик" = /obj/item/weapon/gun/plasma/p104sass,
 		"ручной телепортер" = /obj/item/weapon/hand_tele,
 		"тыквяк" = /obj/item/weapon/reagent_containers/food/snacks/grown/gourd,

--- a/code/game/gamemodes/objectives/traders_objectives.dm
+++ b/code/game/gamemodes/objectives/traders_objectives.dm
@@ -42,7 +42,7 @@
 		"факс" = /obj/machinery/faxmachine,
 		"ядерную боеголовку" = /obj/machinery/nuclearbomb,
 		"раздатчик атмосферных труб" = /obj/machinery/pipedispenser,
-		"кота главврача Дасти" = /mob/living/simple_animal/cat/dusty,
+		"питомец главврача Дасти" = /mob/living/simple_animal/cat/dusty,
 		"плазменный дробовик" = /obj/item/weapon/gun/plasma/p104sass,
 		"ручной телепортер" = /obj/item/weapon/hand_tele,
 		"тыквяк" = /obj/item/weapon/reagent_containers/food/snacks/grown/gourd,

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -140,7 +140,7 @@
 ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/cat/dusty, chief_animal_list)
 /mob/living/simple_animal/cat/dusty
 	name = "Dusty"
-	desc = "Его шерсть на вид и ощупь напоминает бархат."
+	desc = "Шерсть этого зверька на вид и ощупь напоминает бархат."
 
 /mob/living/simple_animal/cat/Syndi
 	name = "SyndiCat"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В описании и в цельке торговца теперь не указано, какого пола Дасти
## Почему и что этот ПР улучшит
всем привет, я считаю что указание пола у Дасти это ненужная отсебятина переводчиков, добавленная в этом вот ПРе #11440
 потому считаю что указания пола не должно быть, как в оригинальном описании.

до перевода, если что, было такое описание
``Its fur has the look and feel of velvet, and its tail quivers occasionally``
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- spellcheck: Корректировка перевода Дасти.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
