### PR TITLE
Раунд старт ивент выклчающий часть камер

### DIFF
--- a/code/modules/events/_event_container.dm
+++ b/code/modules/events/_event_container.dm
@@ -140,7 +140,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_FEATURE = "RoundStart", EV
 		// /datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = 0, event_enabled = 1, min_event_players = 0, min_event_weight = 0, max_event_weight = 0)
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Roundstart Nothing",      /datum/event/nothing, 1500),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Light",             /datum/event/feature/area/break_light,                        50, list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 40)),
-		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Cameras",             /datum/event/feature/area/break_camera,                     50, list(ASSIGNMENT_ENGINEER = 20)),
+		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Cameras",           /datum/event/feature/area/break_camera,                     50, list(ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Dirt Bay",                /datum/event/feature/area/dirt,                               10, list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Randomize Cargo Storage", /datum/event/feature/area/cargo_storage,                      10),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Armory Mess",             /datum/event/feature/area/mess/armory,                        10),

--- a/code/modules/events/_event_container.dm
+++ b/code/modules/events/_event_container.dm
@@ -140,6 +140,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_FEATURE = "RoundStart", EV
 		// /datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = 0, event_enabled = 1, min_event_players = 0, min_event_weight = 0, max_event_weight = 0)
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Roundstart Nothing",      /datum/event/nothing, 1500),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Light",             /datum/event/feature/area/break_light,                        50, list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 40)),
+		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Cameras",             /datum/event/feature/area/break_camera,                     50, list(ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Dirt Bay",                /datum/event/feature/area/dirt,                               10, list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Randomize Cargo Storage", /datum/event/feature/area/cargo_storage,                      10),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Armory Mess",             /datum/event/feature/area/mess/armory,                        10),

--- a/code/modules/events/_event_container.dm
+++ b/code/modules/events/_event_container.dm
@@ -140,7 +140,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_FEATURE = "RoundStart", EV
 		// /datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = 0, event_enabled = 1, min_event_players = 0, min_event_weight = 0, max_event_weight = 0)
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Roundstart Nothing",      /datum/event/nothing, 1500),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Light",             /datum/event/feature/area/break_light,                        50, list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 40)),
-		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Cameras",           /datum/event/feature/area/break_camera,                     50, list(ASSIGNMENT_ENGINEER = 20)),
+		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Break Cameras",           /datum/event/feature/area/break_camera,                       50, list(ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Dirt Bay",                /datum/event/feature/area/dirt,                               10, list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Randomize Cargo Storage", /datum/event/feature/area/cargo_storage,                      10),
 		new /datum/event_meta(EVENT_LEVEL_FEATURE, "Armory Mess",             /datum/event/feature/area/mess/armory,                        10),

--- a/code/modules/events/roundstart_events/area/break_camera.dm
+++ b/code/modules/events/roundstart_events/area/break_camera.dm
@@ -1,0 +1,10 @@
+/datum/event/feature/area/break_camera
+    percent_areas = 40
+
+/datum/event/feature/area/break_camera/start()
+    message_admins("RoundStart Event: [percent_areas]% of cameras have been disabled.")
+    for(var/area/target_area in targeted_areas)
+        for(var/obj/machinery/camera/C in target_area)
+            if(C.status)
+                C.status = 0
+                C.update_icon()

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -1702,6 +1702,7 @@
 #include "code\modules\events\roundstart_events\roundstart.dm"
 #include "code\modules\events\roundstart_events\area\area_event.dm"
 #include "code\modules\events\roundstart_events\area\break_light.dm"
+#include "code\modules\events\roundstart_events\area\break_camera.dm"
 #include "code\modules\events\roundstart_events\area\cargo_storage.dm"
 #include "code\modules\events\roundstart_events\area\dirt.dm"
 #include "code\modules\events\roundstart_events\area\lasertag_ed.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавлен раунд старт ивент по выключению части камер
## Почему и что этот ПР улучшит
Даем работку инжам, мешаем сб сидеть на камерах
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: Раунд старт ивент выклчающий часть камер