### PR TITLE
другой изначальный дир при постройке структур

### DIFF
--- a/code/datums/cob_highlight.dm
+++ b/code/datums/cob_highlight.dm
@@ -9,7 +9,7 @@
 	var/obj/item/stack/using_this = null
 	var/turf/over_this = null
 	var/busy = FALSE
-	var/build_direction = NORTH
+	var/build_direction = SOUTH
 	var/image/b_overlay = null
 	var/obj/effect/holo_build = null
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
структуры, имеющие 1 дир (кровати как пример), всегда представлены на спрайте именно в южном дире
но при постройке по-дефолту стоит северный, что оч путает игрока
теперь им будет южный
## Почему и что этот ПР улучшит
![image](https://github.com/user-attachments/assets/2184352c-0f43-49ac-885d-01662e141e5d)

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
