### PR TITLE
Убираем спам из ss-13-talks в Дискорде 

### DIFF
--- a/code/controllers/subsystem/samosbor.dm
+++ b/code/controllers/subsystem/samosbor.dm
@@ -55,12 +55,10 @@ SUBSYSTEM_DEF(samosbor)
 	if(milestone >= bridge_announce_milestone)
 		bridge_type += BRIDGE_ANNOUNCE
 	world.send2bridge(
-		type = bridge_type
-		attachment_title = "Новый результат на сегодня: более [milestone] игроков онлайн!"
+		type = bridge_type,
+		attachment_title = "Новый результат на сегодня: более [milestone] игроков онлайн!",
 		attachment_msg = BRIDGE_JOIN_LINKS
 	)
-
-
 
 #undef SAMOSBOR_CACHE_FOLDER
 #undef SAMOSBOR_CACHE_PATH


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
После введения "Самосбор" прошло месяц, вроде все хорошо, но в #ss13-talks сейчас помойка в большей степени из-за анонсов там, чем разговоров. 
![Screenshot_20250213-225659](https://github.com/user-attachments/assets/17e6573a-929f-4970-b253-000e5cc4ba7d)
![Screenshot_20250213-225703](https://github.com/user-attachments/assets/b541303d-7cfe-436e-86e2-27d30be2ebb5)
![Screenshot_20250213-225709](https://github.com/user-attachments/assets/50a8e237-b578-4705-a829-726755cbecf1)
Хотя у нас есть уже целая роль и **канал**, чтобы отслеживать Самосбор.
![Screenshot_20250213-225745~2](https://github.com/user-attachments/assets/01acc12d-0680-4bd0-b377-73dd8a9dc9b4)


## Почему и что этот ПР улучшит
Не допускает больше помойку системными анонсами самосбора произошедшую в #ss13-talks 

## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

Изменения касаются только Дискорд сервера
