### PR TITLE
Раундстарт ивент mess уничтожает вендоматы и вываливает вещи из них.

### DIFF
--- a/code/modules/events/roundstart_events/area/mess.dm
+++ b/code/modules/events/roundstart_events/area/mess.dm
@@ -6,6 +6,9 @@
 			new /obj/item/weapon/shard(B.loc)
 			qdel(B)
 
+		for(var/obj/machinery/vending/Vend in target_area)
+			Vend.take_damage(Vend.max_integrity * (1 - Vend.integrity_failure))
+
 		for(var/obj/structure/closet/C in target_area)
 			C.locked = FALSE
 			C.welded = FALSE


### PR DESCRIPTION
## Описание изменений
Теперь раундстарт ивент mess уничтожает вендоматы и вываливает из них вещи, медбей спасён!
![image](https://github.com/user-attachments/assets/e98e903d-0778-4124-afe1-c454cdbba62d)

## Почему и что этот ПР улучшит
Больше беспорядка богу беспорядка!
![image](https://github.com/user-attachments/assets/6ce931a4-bf91-42bf-99ce-52d8f7d69f6f)

## Авторство
AndreyGysev

## Чеинжлог
:cl: AndreyGysev
 - tweak: Раундстарт ивент mess теперь затрагивает и вендоматы.
