### PR TITLE
ре♂fuck♂тор ♂gay♂вспышки

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -407,7 +407,7 @@
 	id = "flash_powder"
 	result = null
 	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1 )
-	result_amount = null
+	result_amount = 3
 
 /datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -415,22 +415,19 @@
 	s.set_up(2, 1, location)
 	s.start()
 
-	var/range = created_volume / 3
 	if(isatom(holder.my_atom))
 		var/atom/A = holder.my_atom
-		A.flash_lighting_fx(_range = (range + 2), _reset_lighting = FALSE)
+		A.flash_lighting_fx(_range = (created_volume / 3 + 2), _reset_lighting = FALSE)
 
 	for(var/mob/living/carbon/M in viewers(world.view, location))
-		if(M.eyecheck() > 0)
+		var/dist = get_dist(M, location)
+		if(M.eyecheck() > 0 && dist > 0)
 			continue
 		M.flash_eyes()
-		switch(get_dist(M, location))
-			if(0 to 3)
-				M.Stun(7)
-				M.Weaken(15)
-
-			if(4 to 5)
-				M.Stun(5)
+		if(dist <= 6)
+			var/duration = floor(sqrt(created_volume) / 2) / sqrt(dist + 1)
+			M.Stun(duration)
+			M.Weaken(duration * 1.2)
 
 /datum/chemical_reaction/napalm
 	name = "Napalm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
хим вспышка теперь скейлится от расстояния до цели и количества реагентов

T = [ (√V / 2) / √(S + 1) ]

таблица времени стана для возможных значений S и V
![image](https://github.com/user-attachments/assets/99924349-6cb8-47e4-8c3a-c7e5cd5dff09)

викен на 20% дольше стана.

нахождение в эпицентре взрыва игнорирует защиту глаз.

дальше 6 тайлов взрыв не распространяется (взрыв у края экрана вызовет лишь вспышку)

починил не скейлившийся ранее flash_lighting_fx

## Почему и что этот ПР улучшит
Убираем топорные 5 сек стана всем в радусе 5-ти клеток от литерали любого количества реагентов (ну это бред ебать, что 300 что 3 унции смешайте результат один)
Закрываем ебанутые числа стана за большими объёмами (гранаты, блюспейс бикеры). 
Наказываем за шахид взрывы в руках куда большей длительностью и игнором защиты глаз.

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: 
 - tweak: Эффект химической вспышки теперь зависит от количества реагентов и расстояния до цели.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
