### PR TITLE
Три маленьких фикса.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -109,8 +109,8 @@
 	return
 
 /obj/machinery/sleeper/deconstruct(disassembled)
-	for(var/atom/movable/A as anything in src)
-		A.forceMove(loc)
+	for(var/atom/movable/A as anything in contents)
+		A.forceMove(get_turf(src))
 	..()
 
 /obj/machinery/sleeper/attack_animal(mob/living/simple_animal/M)//Stop putting hostile mobs in things guise
@@ -154,9 +154,9 @@
 		if(EXPLODE_LIGHT)
 			if(prob(75))
 				return
-	for(var/atom/movable/A as anything in src)
-		A.loc = src.loc
-		ex_act(severity)
+	for(var/atom/movable/A as anything in contents)
+		A.forceMove(get_turf(src))
+		A.ex_act(severity)
 	qdel(src)
 
 /obj/machinery/sleeper/emp_act(severity)
@@ -198,8 +198,8 @@
 	open_machine()
 
 /obj/machinery/sleeper/Destroy()
-	var/turf/T = loc
-	T.contents += contents
+	for(var/atom/movable/A as anything in contents)
+		A.forceMove(get_turf(src))
 	return ..()
 
 /obj/machinery/sleeper/verb/remove_beaker()

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -117,13 +117,13 @@
 			if(prob(75))
 				return
 	for(var/atom/movable/A in src)
-		A.forceMove(loc)
-		ex_act(severity)
+		A.forceMove(get_turf(src))
+		A.ex_act(severity)
 	qdel(src)
 
 /obj/machinery/bodyscanner/deconstruct(disassembled)
 	for(var/atom/movable/A in src)
-		A.forceMove(loc)
+		A.forceMove(get_turf(src))
 	..()
 
 /obj/machinery/body_scanconsole/power_change()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -171,6 +171,19 @@ var/global/list/frozen_items = list()
 	. = ..()
 	QDEL_NULL(announce)
 
+/obj/machinery/cryopod/ex_act(severity)
+	switch(severity)
+		if(EXPLODE_HEAVY)
+			if(prob(50))
+				return
+		if(EXPLODE_LIGHT)
+			if(prob(75))
+				return
+	for(var/atom/movable/A as anything in contents)
+		A.forceMove(get_turf(src))
+		A.ex_act(severity)
+	qdel(src)
+
 /obj/machinery/cryopod/proc/delete_objective(datum/objective/target/O)
 	if(!O)
 		return


### PR DESCRIPTION
## Описание изменений
Слипер раньше при взрыве или уничтожении перекидывал тело внутри в нуллспейс.
Сканер и криофризер раньше при взрыве полностью защищали тело внутри.

## Почему и что этот ПР улучшит
Взрывы нормально дамажат людей в слиперах, фризерах и сканерах.

## Авторство
AndreyGysev
Slegar - на форуме сообщил что слипер в нуллспейс перекидывает людей.

## Чеинжлог
:cl: AndreyGysev, Slegar
 - bugfix: Пофикшен баг с перекидыванием людей в нуллспейс при уничтожении слипера.
 - bugfix: Пофикшен баг с неуязвимостью к взрывам людей в сканере или криофризере.
