### PR TITLE
исправляем перегруженный прок

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -714,7 +714,7 @@
 	return TRUE
 
 /atom/proc/check_sprite()
-	if(icon_state in icon_states(icon))
+	if(icon_exists(icon, icon_state))
 		return TRUE
 	return FALSE
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -902,3 +902,26 @@ var/global/list/humanoid_icon_cache = list()
 		return out_icon
 	else
 		return humanoid_icon_cache[icon_id]
+
+///Checks if the given iconstate exists in the given file, caching the result. Setting scream to TRUE will print a stack trace ONCE.
+/proc/icon_exists(file, state, scream)
+	var/static/list/icon_states_cache = list()
+	if(icon_states_cache[file]?[state])
+		return TRUE
+
+	if(icon_states_cache[file]?[state] == FALSE)
+		return FALSE
+
+	var/list/states = icon_states(file)
+
+	if(!icon_states_cache[file])
+		icon_states_cache[file] = list()
+
+	if(state in states)
+		icon_states_cache[file][state] = TRUE
+		return TRUE
+	else
+		icon_states_cache[file][state] = FALSE
+		if(scream)
+			stack_trace("Icon Lookup for state: [state] in file [file] failed.")
+		return FALSE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -631,7 +631,7 @@ BLIND     // can't see anything
 
 	if(copytext(item_state,-2) != "_d")
 		basecolor = item_state
-	if((basecolor + "_d") in icon_states('icons/mob/uniform.dmi'))
+	if(icon_exists('icons/mob/uniform.dmi', "[basecolor]_d"))
 		item_state = item_state == "[basecolor]" ? "[basecolor]_d" : "[basecolor]"
 		update_inv_mob()
 	else

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -119,13 +119,13 @@ Please contact me on #coderbus IRC. ~Carn x
 	else if(S.sprite_sheets[sprite_sheet_slot])
 		icon_path = S.sprite_sheets[sprite_sheet_slot]
 
-	if(!("[t_state][icon_state_appendix]" in icon_states(icon_path)))
+	if(!icon_exists(icon_path, "[t_state][icon_state_appendix]"))
 		icon_path = def_icon_path
 
 	var/fem = ""
 	if(H.gender == FEMALE && S.gender_limb_icons)
 		if(t_state != null)
-			if("[t_state]_fem" in icon_states(def_icon_path))
+			if(icon_exists(def_icon_path, "[t_state]_fem"))
 				fem = "_fem"
 
 	var/mutable_appearance/I = mutable_appearance(icon = icon_path, icon_state = "[t_state][fem][icon_state_appendix]", layer = layer)
@@ -448,7 +448,7 @@ Please contact me on #coderbus IRC. ~Carn x
 				icon_path = A.icon_custom
 
 			if(gender == FEMALE && species.gender_limb_icons)
-				if("[t_state]_fem" in icon_states(icon_path))
+				if(icon_exists(icon_path, "[t_state]_fem"))
 					t_state += "_fem"
 
 			var/image/accessory

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -119,7 +119,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	else if(S.sprite_sheets[sprite_sheet_slot])
 		icon_path = S.sprite_sheets[sprite_sheet_slot]
 
-	if(!icon_exists(icon_path, "[t_state][icon_state_appendix]"))
+	if(icon_path != def_icon_path && !icon_exists(icon_path, "[t_state][icon_state_appendix]"))
 		icon_path = def_icon_path
 
 	var/fem = ""

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -125,7 +125,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	var/fem = ""
 	if(H.gender == FEMALE && S.gender_limb_icons)
 		if(t_state != null)
-			if(icon_exists(def_icon_path, "[t_state]_fem"))
+			if(icon_exists(icon_path, "[t_state]_fem"))
 				fem = "_fem"
 
 	var/mutable_appearance/I = mutable_appearance(icon = icon_path, icon_state = "[t_state][fem][icon_state_appendix]", layer = layer)

--- a/code/modules/mob/living/carbon/ian/update_icons.dm
+++ b/code/modules/mob/living/carbon/ian/update_icons.dm
@@ -119,7 +119,7 @@
 		t_state = mouth.icon_state
 
 	var/skip = FALSE
-	if(!(t_state in icon_states(mouth.lefthand_file))) //oh, god, no! plz NO! not those icon_custom, icon_override, icon_graytide, icon_whatever9000namedifferent_icons_with_million_ifs...
+	if(!icon_exists(mouth.lefthand_file, t_state)) //oh, god, no! plz NO! not those icon_custom, icon_override, icon_graytide, icon_whatever9000namedifferent_icons_with_million_ifs...
 		t_state = "uni_item"
 		skip = TRUE
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
``get_standing_overlay()`` (прок для отображения на мобе одежды/инхедов/всего этого) за раунд нагоняет неадекватные цифры из-за медленного ``icon_states()``, который нужен был для случаев, когда мы переопределяем ``icon_path``, что не очень частое явление
но ``icon_states()`` вызывался даже в тех случаях, когда путь до иконки был стандартный, из-за чего прок стал до ужаса медленным

теперь оно не будет лишний раз искать стейт, что примерно в 10 раз ускорит все это дело
![image](https://github.com/user-attachments/assets/55560e81-807c-4d00-9ae8-cf8cf7a0ff92)

вместе с этим подтянул ``icon_exists()`` с тг, который повторяет бьендовский ``icon_states()``, но кэширует результаты
впихнул в особо горячие места, в особенности для поиска фем-стейта одежды
в идеале кэшировать бы это как-то заранее, чтобы не приходилось ``icon_states()`` каждый раз вызывать, но я пока не уверен насколько это нужно и в каких файлах могут быть фем-стейты, это как-то обобщить надо
## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
