### PR TITLE
Возможность выбора нескольких ролей в спавнер меню

### DIFF
--- a/code/datums/spawners_menu/maps/forts.dm
+++ b/code/datums/spawners_menu/maps/forts.dm
@@ -1,4 +1,4 @@
-/datum/spawner/multiple/fort_teams
+/datum/spawner/multiple_landmark/fort_teams
 	name = "Fort Team"
 	desc = "Отстраивайте и защищайте форт своей команды, уничтожьте форт команды противников!"
 	wiki_ref = "Forst"
@@ -14,13 +14,13 @@
 	var/list/team_outfits = list(TEAM_NAME_BLUE = /datum/outfit/forts_team/blue, TEAM_NAME_RED = /datum/outfit/forts_team/red)
 	var/list/factions = list()
 
-/datum/spawner/multiple/fort_teams/New(datum/map_module/forts/MM)
+/datum/spawner/multiple_landmark/fort_teams/New(datum/map_module/forts/MM)
 	. = ..()
 	map_module = MM
 	factions[TEAM_NAME_BLUE] = map_module.factions[TEAM_NAME_BLUE]
 	factions[TEAM_NAME_RED]  = map_module.factions[TEAM_NAME_RED]
 
-/datum/spawner/multiple/fort_teams/spawn_body(mob/dead/spectator)
+/datum/spawner/multiple_landmark/fort_teams/spawn_body(mob/dead/spectator)
 	var/team_name = pick_landmark_name()
 
 	var/client/C = spectator.client

--- a/code/datums/spawners_menu/maps/forts.dm
+++ b/code/datums/spawners_menu/maps/forts.dm
@@ -1,4 +1,4 @@
-/datum/spawner/fort_team
+/datum/spawner/multiple/fort_teams
 	name = "Fort Team"
 	desc = "Отстраивайте и защищайте форт своей команды, уничтожьте форт команды противников!"
 	wiki_ref = "Forst"
@@ -6,43 +6,30 @@
 	lobby_spawner = TRUE
 	positions = INFINITY
 
-	cooldown_type = /datum/spawner/fort_team // will be shared between both teams
 	cooldown = 5 MINUTES
+	spawn_landmarks_names = list(TEAM_NAME_BLUE, TEAM_NAME_RED)
 
 	var/datum/map_module/forts/map_module
 
-	var/team_name
-	var/team_outfit
+	var/list/team_outfits = list(TEAM_NAME_BLUE = /datum/outfit/forts_team/blue, TEAM_NAME_RED = /datum/outfit/forts_team/red)
+	var/list/factions = list()
 
-/datum/spawner/fort_team/New(datum/map_module/forts/MM)
+/datum/spawner/multiple/fort_teams/New(datum/map_module/forts/MM)
 	. = ..()
 	map_module = MM
-	faction = MM.factions[team_name]
+	factions[TEAM_NAME_BLUE] = map_module.factions[TEAM_NAME_BLUE]
+	factions[TEAM_NAME_RED]  = map_module.factions[TEAM_NAME_RED]
 
-/datum/spawner/fort_team/spawn_body(mob/dead/spectator)
-	var/spawnloc = pick_spawn_location()
+/datum/spawner/multiple/fort_teams/spawn_body(mob/dead/spectator)
+	var/team_name = pick_landmark_name()
 
 	var/client/C = spectator.client
 
-	var/mob/living/carbon/human/H = new(spawnloc)
+	var/mob/living/carbon/human/H = new(pick_landmarked_location(team_name))
 	H.key = C.key
 
-	map_module.assign_to_team(H, faction)
-	H.equipOutfit(team_outfit)
+	H.equipOutfit(team_outfits[team_name])
+	map_module.assign_to_team(H, factions[team_name])
 
 	var/new_name = spectator.name
 	INVOKE_ASYNC(C, TYPE_PROC_REF(/client, create_human_apperance), H, new_name, TRUE)
-
-/datum/spawner/fort_team/red
-	name = TEAM_NAME_RED
-	team_name = TEAM_NAME_RED
-	spawn_landmark_name = TEAM_NAME_RED // /obj/effect/landmark/red_team
-
-	team_outfit = /datum/outfit/forts_team/red
-
-/datum/spawner/fort_team/blue
-	name = TEAM_NAME_BLUE
-	team_name = TEAM_NAME_BLUE
-	spawn_landmark_name = TEAM_NAME_BLUE // /obj/effect/landmark/blue_team
-
-	team_outfit = /datum/outfit/forts_team/blue

--- a/code/datums/spawners_menu/maps/forts.dm
+++ b/code/datums/spawners_menu/maps/forts.dm
@@ -1,4 +1,4 @@
-/datum/spawner/multiple_landmark/fort_teams
+/datum/spawner/fort_team
 	name = "Fort Team"
 	desc = "Отстраивайте и защищайте форт своей команды, уничтожьте форт команды противников!"
 	wiki_ref = "Forst"
@@ -6,30 +6,43 @@
 	lobby_spawner = TRUE
 	positions = INFINITY
 
+	cooldown_type = /datum/spawner/fort_team // will be shared between both teams
 	cooldown = 5 MINUTES
-	spawn_landmarks_names = list(TEAM_NAME_BLUE, TEAM_NAME_RED)
 
 	var/datum/map_module/forts/map_module
 
-	var/list/team_outfits = list(TEAM_NAME_BLUE = /datum/outfit/forts_team/blue, TEAM_NAME_RED = /datum/outfit/forts_team/red)
-	var/list/factions = list()
+	var/team_name
+	var/team_outfit
 
-/datum/spawner/multiple_landmark/fort_teams/New(datum/map_module/forts/MM)
+/datum/spawner/fort_team/New(datum/map_module/forts/MM)
 	. = ..()
 	map_module = MM
-	factions[TEAM_NAME_BLUE] = map_module.factions[TEAM_NAME_BLUE]
-	factions[TEAM_NAME_RED]  = map_module.factions[TEAM_NAME_RED]
+	faction = MM.factions[team_name]
 
-/datum/spawner/multiple_landmark/fort_teams/spawn_body(mob/dead/spectator)
-	var/team_name = pick_landmark_name()
+/datum/spawner/fort_team/spawn_body(mob/dead/spectator)
+	var/spawnloc = pick_spawn_location()
 
 	var/client/C = spectator.client
 
-	var/mob/living/carbon/human/H = new(pick_landmarked_location(team_name))
+	var/mob/living/carbon/human/H = new(spawnloc)
 	H.key = C.key
 
-	H.equipOutfit(team_outfits[team_name])
-	map_module.assign_to_team(H, factions[team_name])
+	map_module.assign_to_team(H, faction)
+	H.equipOutfit(team_outfit)
 
 	var/new_name = spectator.name
 	INVOKE_ASYNC(C, TYPE_PROC_REF(/client, create_human_apperance), H, new_name, TRUE)
+
+/datum/spawner/fort_team/red
+	name = TEAM_NAME_RED
+	team_name = TEAM_NAME_RED
+	spawn_landmark_name = TEAM_NAME_RED // /obj/effect/landmark/red_team
+
+	team_outfit = /datum/outfit/forts_team/red
+
+/datum/spawner/fort_team/blue
+	name = TEAM_NAME_BLUE
+	team_name = TEAM_NAME_BLUE
+	spawn_landmark_name = TEAM_NAME_BLUE // /obj/effect/landmark/blue_team
+
+	team_outfit = /datum/outfit/forts_team/blue

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -204,7 +204,7 @@
 	shuffle(filtered_candidates)
 
 	for(var/mob/dead/M in filtered_candidates)
-		if(positions > 0 && can_spawn(spectator))
+		if(positions > 0 && can_spawn(M))
 			positions--
 			to_chat(M, "<span class='notice'>Вы получили роль \"[name]\"!</span>")
 			INVOKE_ASYNC(src, PROC_REF(do_spawn), M)

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -289,8 +289,8 @@
 	return pick_landmarked_location(landmark_name)
 
 /datum/spawner/multiple/proc/pick_landmark_name()
-	var landmark_name = ""
-	var n = INFINITY
+	var/landmark_name = ""
+	var/n = INFINITY
 
 	for(name in spawn_landmarks_names)
 		if(spawn_landmarks_names[name] < n)

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -270,6 +270,52 @@
 	spectator.forceMove(get_turf(jump_to))
 
 /*
+ * Равномерно распределяет желающих по лэндмаркам из списка
+*/
+/datum/spawner/multiple
+	var/list/spawn_landmarks_names = list()
+
+/datum/spawner/multiple/New()
+	. = ..()
+	for(name in spawn_landmarks_names)
+		spawn_landmarks_names[name] = 0
+
+/datum/spawner/multiple/pick_spawn_location()
+	var/landmark_name = pick_landmark_name()
+
+	if(!length(landmarks_list[landmark_name]))
+		CRASH("[src.type] attempts to pick spawn location \"[landmark_name]\", but can't find one!")
+
+	return pick_landmarked_location(landmark_name)
+
+/datum/spawner/multiple/proc/pick_landmark_name()
+	var landmark_name = ""
+	var n = INFINITY
+
+	for(name in spawn_landmarks_names)
+		if(spawn_landmarks_names[name] < n)
+			n = spawn_landmarks_names[name]
+			landmark_name = name
+
+	spawn_landmarks_names[landmark_name] += 1
+
+	return landmark_name
+
+/datum/spawner/multiple/jump(mob/dead/spectator)
+	var/list/avaible_landmarks = list()
+
+	for(name in spawn_landmarks_names)
+		if(length(landmarks_list[name]))
+			avaible_landmarks += name
+
+	if(!length(avaible_landmarks))
+		to_chat(spectator, "<span class='notice'>У этой роли нет предустановленных локаций для спавна.</span>")
+		return
+
+	var/jump_to = pick(landmarks_list[pick(avaible_landmarks)])
+	spectator.forceMove(get_turf(jump_to))
+
+/*
  * Families
 */
 /datum/spawner/dealer

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -270,17 +270,17 @@
 	spectator.forceMove(get_turf(jump_to))
 
 /*
- * Равномерно распределяет желающих по лэндмаркам из списка
+ * Evenly distributes to the landing marks from the list
 */
-/datum/spawner/multiple
+/datum/spawner/multiple_landmark
 	var/list/spawn_landmarks_names = list()
 
-/datum/spawner/multiple/New()
+/datum/spawner/multiple_landmark/New()
 	. = ..()
 	for(var/name in spawn_landmarks_names)
 		spawn_landmarks_names[name] = 0
 
-/datum/spawner/multiple/pick_spawn_location()
+/datum/spawner/multiple_landmark/pick_spawn_location()
 	var/landmark_name = pick_landmark_name()
 
 	if(!length(landmarks_list[landmark_name]))
@@ -288,7 +288,7 @@
 
 	return pick_landmarked_location(landmark_name)
 
-/datum/spawner/multiple/proc/pick_landmark_name()
+/datum/spawner/multiple_landmark/proc/pick_landmark_name()
 	var/landmark_name = ""
 	var/n = INFINITY
 
@@ -301,7 +301,7 @@
 
 	return landmark_name
 
-/datum/spawner/multiple/jump(mob/dead/spectator)
+/datum/spawner/multiple_landmark/jump(mob/dead/spectator)
 	var/list/avaible_landmarks = list()
 
 	for(var/name in spawn_landmarks_names)

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -180,9 +180,9 @@
 	if(!multiple)
 		spectator.clear_spawner_registration()
 	else if(spectator.registered_spawners.len)
-		var/datum/spawner/S = spectator.registered_spawners[0]
-		if(!S.multiple)
-			spectator.clear_spawner_registration()
+		for(var/datum/spawner/S as anything in spectator.registered_spawners)
+			if(!S.multiple)
+				S.cancel_registration(spectator)
 
 	registered_candidates += spectator
 	spectator.registered_spawners += src

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -277,7 +277,7 @@
 
 /datum/spawner/multiple/New()
 	. = ..()
-	for(name in spawn_landmarks_names)
+	for(var/name in spawn_landmarks_names)
 		spawn_landmarks_names[name] = 0
 
 /datum/spawner/multiple/pick_spawn_location()
@@ -292,7 +292,7 @@
 	var/landmark_name = ""
 	var/n = INFINITY
 
-	for(name in spawn_landmarks_names)
+	for(var/name in spawn_landmarks_names)
 		if(spawn_landmarks_names[name] < n)
 			n = spawn_landmarks_names[name]
 			landmark_name = name
@@ -304,7 +304,7 @@
 /datum/spawner/multiple/jump(mob/dead/spectator)
 	var/list/avaible_landmarks = list()
 
-	for(name in spawn_landmarks_names)
+	for(var/name in spawn_landmarks_names)
 		if(length(landmarks_list[name]))
 			avaible_landmarks += name
 

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -177,8 +177,12 @@
 		return
 
 	// multiple and non-multiple spawners cannot be together
-	if(!multiple || (spectator.registered_spawners.len && !spectator.registered_spawners[0].multiple))
+	if(!multiple)
 		spectator.clear_spawner_registration()
+	else if(spectator.registered_spawners.len)
+		var/datum/spawner/S = spectator.registered_spawners[0]
+		if(!S.multiple)
+			spectator.clear_spawner_registration()
 
 	registered_candidates += spectator
 	spectator.registered_spawners += src

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -74,7 +74,7 @@
 	var/register_only = FALSE
 
 	// Flag if it's supports multiple selection
-	var/multiple = FALSE
+	var/multideclare = FALSE
 
 	// List of clients who checked for spawner
 	var/list/registered_candidates = list()
@@ -176,12 +176,11 @@
 		to_chat(spectator, "<span class='notice'>Вы отменили заявку на роль \"[name]\".</span>")
 		return
 
-	// multiple and non-multiple spawners cannot be together
-	if(!multiple)
+	if(!multideclare)
 		spectator.clear_spawner_registration()
 	else if(spectator.registered_spawners.len)
 		for(var/datum/spawner/S as anything in spectator.registered_spawners)
-			if(!S.multiple)
+			if(!S.multideclare)
 				S.cancel_registration(spectator)
 
 	registered_candidates += spectator
@@ -760,7 +759,7 @@
 	ranks = list(ROLE_GHOSTLY)
 
 	register_only = TRUE
-	multiple = TRUE
+	multideclare = TRUE
 	time_for_registration = 0.5 MINUTES
 
 	time_while_available = 4 MINUTES

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -160,9 +160,6 @@
 	if(!spectator.client || spectator.client.is_in_spawner)
 		return
 
-	if(!can_spawn(spectator))
-		return
-
 	if(!register_only)
 		if(positions < 1)
 			to_chat(spectator, "<span class='notice'>Нет свободных позиций для роли.</span>")
@@ -174,6 +171,9 @@
 	if(spectator in registered_candidates)
 		cancel_registration(spectator)
 		to_chat(spectator, "<span class='notice'>Вы отменили заявку на роль \"[name]\".</span>")
+		return
+
+	if(!can_spawn(spectator))
 		return
 
 	if(!multideclare)

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -760,6 +760,7 @@
 	ranks = list(ROLE_GHOSTLY)
 
 	register_only = TRUE
+	multiple = TRUE
 	time_for_registration = 0.5 MINUTES
 
 	time_while_available = 4 MINUTES

--- a/code/modules/map_module/forts.dm
+++ b/code/modules/map_module/forts.dm
@@ -21,7 +21,7 @@
 
 	// assoc lists (TEAMNAME = reference)
 	var/list/datum/faction/factions = list()
-	var/list/datum/spawner/fort_team/spawners = list()
+	var/list/datum/spawner/multiple/fort_teams/spawner
 	var/list/obj/machinery/computer/fort_console/consoles = list()
 
 /datum/map_module/forts/New()
@@ -31,8 +31,7 @@
 	factions[TEAM_NAME_RED] = create_custom_faction(TEAM_NAME_RED, TEAM_NAME_RED, "red", objective)
 	factions[TEAM_NAME_BLUE] = create_custom_faction(TEAM_NAME_BLUE, TEAM_NAME_BLUE, "blue", objective)
 
-	spawners[TEAM_NAME_RED] = create_spawner(/datum/spawner/fort_team/red, src)
-	spawners[TEAM_NAME_BLUE] = create_spawner(/datum/spawner/fort_team/blue, src)
+	spawner = create_spawner(/datum/spawner/multiple/fort_teams, src)
 
 /datum/map_module/forts/stat_entry(mob/M)
 	if(M.client.holder)
@@ -86,7 +85,7 @@
 	teammate.AssignToRole(M.mind, msg_admins = FALSE)
 
 	if(rank == FORTS_ROLE_COMMANDER)
-		var/obj/item/weapon/card/id/captains_spare/card = new 
+		var/obj/item/weapon/card/id/captains_spare/card = new
 		card.assignment = FORTS_ROLE_COMMANDER
 		card.assign(M.real_name)
 		M.equip_to_appropriate_slot(card)
@@ -207,5 +206,5 @@ var/global/forts_points_multiplier = 1
 		MM.announce("Скорость получения очков вернулась в норму!")
 	else
 		MM.announce("Скорость получения очков увеличина в [forts_points_multiplier] [pluralize_russian(forts_points_multiplier, "раз", "раза", "раз")]!")
- 
+
 	message_admins("[key_name(src)] changed points multiplier to [forts_points_multiplier].")

--- a/code/modules/map_module/forts.dm
+++ b/code/modules/map_module/forts.dm
@@ -21,7 +21,7 @@
 
 	// assoc lists (TEAMNAME = reference)
 	var/list/datum/faction/factions = list()
-	var/list/datum/spawner/multiple/fort_teams/spawner
+	var/list/datum/spawner/multiple_landmark/fort_teams/spawner
 	var/list/obj/machinery/computer/fort_console/consoles = list()
 
 /datum/map_module/forts/New()
@@ -31,7 +31,7 @@
 	factions[TEAM_NAME_RED] = create_custom_faction(TEAM_NAME_RED, TEAM_NAME_RED, "red", objective)
 	factions[TEAM_NAME_BLUE] = create_custom_faction(TEAM_NAME_BLUE, TEAM_NAME_BLUE, "blue", objective)
 
-	spawner = create_spawner(/datum/spawner/multiple/fort_teams, src)
+	spawner = create_spawner(/datum/spawner/multiple_landmark/fort_teams, src)
 
 /datum/map_module/forts/stat_entry(mob/M)
 	if(M.client.holder)

--- a/code/modules/map_module/forts.dm
+++ b/code/modules/map_module/forts.dm
@@ -21,7 +21,7 @@
 
 	// assoc lists (TEAMNAME = reference)
 	var/list/datum/faction/factions = list()
-	var/list/datum/spawner/multiple_landmark/fort_teams/spawner
+	var/list/datum/spawner/fort_team/spawners = list()
 	var/list/obj/machinery/computer/fort_console/consoles = list()
 
 /datum/map_module/forts/New()
@@ -31,7 +31,8 @@
 	factions[TEAM_NAME_RED] = create_custom_faction(TEAM_NAME_RED, TEAM_NAME_RED, "red", objective)
 	factions[TEAM_NAME_BLUE] = create_custom_faction(TEAM_NAME_BLUE, TEAM_NAME_BLUE, "blue", objective)
 
-	spawner = create_spawner(/datum/spawner/multiple_landmark/fort_teams, src)
+	spawners[TEAM_NAME_RED] = create_spawner(/datum/spawner/fort_team/red, src)
+	spawners[TEAM_NAME_BLUE] = create_spawner(/datum/spawner/fort_team/blue, src)
 
 /datum/map_module/forts/stat_entry(mob/M)
 	if(M.client.holder)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -11,7 +11,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 /mob/dead/Logout()
 	..()
 	for(var/datum/spawner/S in registred_spawners)
-		registred_spawner.cancel_registration(src)
+		S.cancel_registration(src)
 
 /mob/dead/Destroy()
 	QDEL_NULL(spawners_menu)
@@ -45,5 +45,5 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	to_chat(src, "<span class='notice'>You can not emote.</span>")
 
 /mob/dead/proc/remove_registration_for_spawners()
-	for(var/datum/spawner/S registred_spawners)
-		S.registered_candidates -= src
+	for(var/datum/spawner/S in registred_spawners)
+		S.cancel_registration(src)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -6,11 +6,11 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 
 	var/datum/spawners_menu/spawners_menu
-	var/list/registred_spawners = list()
+	var/list/registered_spawners = list()
 
 /mob/dead/Logout()
 	..()
-	remove_registration_for_spawners()
+	clear_spawner_registration()
 
 /mob/dead/Destroy()
 	QDEL_NULL(spawners_menu)
@@ -43,6 +43,6 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 /mob/dead/me_emote(message, message_type = SHOWMSG_VISUAL, intentional=FALSE)
 	to_chat(src, "<span class='notice'>You can not emote.</span>")
 
-/mob/dead/proc/remove_registration_for_spawners()
-	for(var/datum/spawner/S in registred_spawners)
+/mob/dead/proc/clear_spawner_registration()
+	for(var/datum/spawner/S in registered_spawners)
 		S.cancel_registration(src)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -44,5 +44,5 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	to_chat(src, "<span class='notice'>You can not emote.</span>")
 
 /mob/dead/proc/clear_spawner_registration()
-	for(var/datum/spawner/S in registered_spawners)
+	for(var/datum/spawner/S as anything in registered_spawners)
 		S.cancel_registration(src)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -6,7 +6,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 
 	var/datum/spawners_menu/spawners_menu
-	var/list/registered_spawners = list()
+	var/list/datum/spawner/registered_spawners = list()
 
 /mob/dead/Logout()
 	..()

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -10,8 +10,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead/Logout()
 	..()
-	for(var/datum/spawner/S in registred_spawners)
-		S.cancel_registration(src)
+	remove_registration_for_spawners()
 
 /mob/dead/Destroy()
 	QDEL_NULL(spawners_menu)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -6,13 +6,12 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 
 	var/datum/spawners_menu/spawners_menu
-	var/datum/spawner/registred_spawner
+	var/list/registred_spawners = list()
 
 /mob/dead/Logout()
 	..()
-	if(registred_spawner)
-		var/datum/spawner/S = registred_spawner
-		S.cancel_registration(src)
+	for(var/datum/spawner/S in registred_spawners)
+		registred_spawner.cancel_registration(src)
 
 /mob/dead/Destroy()
 	QDEL_NULL(spawners_menu)
@@ -44,3 +43,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead/me_emote(message, message_type = SHOWMSG_VISUAL, intentional=FALSE)
 	to_chat(src, "<span class='notice'>You can not emote.</span>")
+
+/mob/dead/proc/remove_registration_for_spawners()
+	for(var/datum/spawner/S registred_spawners)
+		S.registered_candidates -= src


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
было
![image](https://github.com/user-attachments/assets/5ea8658e-0619-4922-98af-a09da449756a)
будет
![image](https://github.com/user-attachments/assets/086b37f9-4d7b-4e7e-b75a-454235eb98ae)

проблема текущей моей реализации что по сути оно будет набивать их до фулла по порядку следования, поэтому если на фортах все выставят обе тимы, то в синей никого не окажется, но тут как будто напрашивается какой-то специальный спавнер с равномерным распределением по ролям

## Почему и что этот ПР улучшит
ностромо буде жить

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - tweak: Возможность множественного выбора ролей в спавнер меню.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
