### PR TITLE
auto guns fire delay fix

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -260,7 +260,7 @@
 // Gun procs.
 
 /obj/item/weapon/gun/proc/on_autofire_start(mob/living/shooter)
-	if(!ready_to_fire() || shooter.incapacitated())
+	if(shooter.incapacitated())
 		return FALSE
 	if(!can_fire())
 		shoot_with_empty_chamber(shooter)
@@ -275,11 +275,11 @@
 
 /obj/item/weapon/gun/proc/do_autofire(datum/source, atom/target, mob/living/shooter, params)
 	SIGNAL_HANDLER
-	if(!ready_to_fire() || shooter.incapacitated())
-		return NONE
+	if(shooter.incapacitated())
+		return FALSE
 	if(!can_fire())
 		shoot_with_empty_chamber(shooter)
-		return NONE
+		return FALSE
 	INVOKE_ASYNC(src, PROC_REF(do_autofire_shot), source, target, shooter, params)
 	return COMPONENT_AUTOFIRE_SHOT_SUCCESS //All is well, we can continue shooting.
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -680,7 +680,7 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 	damtype = BURN
 	hitsound = list('sound/weapons/sear.ogg')
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/cutter)
-	fire_delay = 0
+	fire_delay = 4
 	w_class = SIZE_SMALL //it is smaller than the pickaxe
 	origin_tech = "materials=4;phorontech=3;engineering=3"
 	desc = "The latest self-rechargeable low-power cutter using bursts of hot plasma. You could use it to cut limbs off of xenos! Or, you know, mine stuff."
@@ -713,7 +713,7 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 /obj/item/weapon/gun/energy/laser/cutter/atom_init()
 	. = ..()
 	power_supply.AddComponent(/datum/component/cell_selfrecharge, 50)
-	AddComponent(/datum/component/automatic_fire, 0.4 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/energy/laser/cutter/emag_act(mob/user)
 	if(emagged)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -65,12 +65,12 @@
 /obj/item/weapon/gun/proc/ready_to_fire()
 	if(world.time >= last_fired + fire_delay)
 		last_fired = world.time
-		return 1
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 /obj/item/weapon/gun/proc/process_chamber()
-	return 0
+	return FALSE
 
 /obj/item/weapon/gun/proc/special_check(mob/M, atom/target) //Placeholder for any special checks, like detective's revolver. or wizards
 	if(iswizard(M))

--- a/code/modules/projectiles/guns/plasma/plasma.dm
+++ b/code/modules/projectiles/guns/plasma/plasma.dm
@@ -16,7 +16,7 @@
 	desc = "Стандартный плазменный карабин типа булл-пап обладающий высокой скорострельностью."
 	icon_state = "plasma10_car"
 	item_state = "plasma10_car"
-	fire_delay = 0
+	fire_delay = 2
 	origin_tech = "combat=3;magnets=2"
 	fire_sound = 'sound/weapons/guns/plasma10_shot.ogg'
 	recoil = FALSE
@@ -58,7 +58,7 @@
 /obj/item/weapon/gun/plasma/atom_init()
 	. = ..()
 	if(fullauto)
-		AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
+		AddComponent(/datum/component/automatic_fire, fire_delay)
 	magazine = new initial_mag(src)
 	for(var/i in ammo_type)
 		var/path = ammo_type[i]

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -51,11 +51,11 @@
 	desc = "Легкий, скорострельный пистолет-пулемёт. Использует патроны калибра 9мм."
 	spread_increase = 0.5
 	spread_max = 1.5
-	fire_delay = 0
+	fire_delay = 2
 
 /obj/item/weapon/gun/projectile/automatic/saber/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/mini_uzi
 	name = "Mac-10"
@@ -67,13 +67,13 @@
 	origin_tech = "combat=5;materials=2;syndicate=8"
 	initial_mag = /obj/item/ammo_box/magazine/mac10
 	can_be_silenced = TRUE
-	fire_delay = 0
+	fire_delay = 1
 	spread_increase = 0.25
 	spread_max = 2
 
 /obj/item/weapon/gun/projectile/automatic/mini_uzi/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.1 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/c20r
 	name = "C-20r SMG"
@@ -88,13 +88,13 @@
 	should_alarm_when_empty = TRUE
 	can_be_silenced = TRUE
 	has_ammo_counter = TRUE
-	fire_delay = 0
+	fire_delay = 2
 	spread_increase = 0.25
 	spread_max = 1.5
 
 /obj/item/weapon/gun/projectile/automatic/c20r/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw
 	name = "L6 SAW"
@@ -108,13 +108,13 @@
 	has_cover = TRUE
 	two_hand_weapon = ONLY_TWOHAND
 	has_ammo_counter = TRUE
-	fire_delay = 0
+	fire_delay = 2.5
 	spread_increase = 0.5
 	spread_max = 2
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.25 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/update_icon()
 	icon_state = "l6[cover_open ? "open" : "closed"][magazine ? CEIL(get_ammo(0) / 25) * 25 : "-empty"]"
@@ -168,13 +168,13 @@
 	suitable_mags = list(/obj/item/ammo_box/magazine/l13, /obj/item/ammo_box/magazine/l13/lethal)
 	fire_sound = 'sound/weapons/guns/gunshot_l13.ogg'
 	can_be_silenced = TRUE
-	fire_delay = 0
+	fire_delay = 2
 	spread_increase = 0.25
 	spread_max = 1.5
 
 /obj/item/weapon/gun/projectile/automatic/l13/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/tommygun
 	name = "tommy gun"
@@ -188,13 +188,13 @@
 	initial_mag = /obj/item/ammo_box/magazine/tommygun
 	fire_sound = 'sound/weapons/guns/gunshot_light.ogg'
 	can_be_silenced = TRUE
-	fire_delay = 0
+	fire_delay = 1.5
 	spread_increase = 0.25
 	spread_max = 2
 
 /obj/item/weapon/gun/projectile/automatic/tommygun/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.15 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/bar
 	name = "Browning M1918"
@@ -206,13 +206,13 @@
 	origin_tech = "combat=5;materials=2"
 	initial_mag = /obj/item/ammo_box/magazine/bar
 	fire_sound = 'sound/weapons/guns/Gunshot2.ogg'
-	fire_delay = 0
+	fire_delay = 4
 	spread_increase = 0.5
 	spread_max = 1
 
 /obj/item/weapon/gun/projectile/automatic/bar/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.4 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/borg
 	name = "Robot SMG"
@@ -260,13 +260,13 @@
 	initial_mag = /obj/item/ammo_box/magazine/a28
 	suitable_mags = list(/obj/item/ammo_box/magazine/a28, /obj/item/ammo_box/magazine/a28/nonlethal, /obj/item/ammo_box/magazine/a28/incendiary)
 	fire_sound = 'sound/weapons/guns/gunshot_medium.ogg'
-	fire_delay = 0
+	fire_delay = 2.5
 	spread_increase = 0.5
 	spread_max = 1.5
 
 /obj/item/weapon/gun/projectile/automatic/a28/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.25 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/a28/nonlethal
 	name = "A28 assault rifle NL"
@@ -287,13 +287,13 @@
 	item_state = "a74"
 	origin_tech = "combat=5;materials=4;syndicate=6"
 	fire_sound = 'sound/weapons/guns/gunshot_ak74.ogg'
-	fire_delay = 0
+	fire_delay = 2.5
 	spread_increase = 0.5
 	spread_max = 1.5
 
 /obj/item/weapon/gun/projectile/automatic/a74/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.25 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/a74/krinkov
 	name = "Krinkov"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -70,13 +70,13 @@
 	initial_mag = /obj/item/ammo_box/magazine/stechkin
 	suitable_mags = list(/obj/item/ammo_box/magazine/stechkin, /obj/item/ammo_box/magazine/stechkin/extended)
 	can_be_silenced = TRUE
-	fire_delay = 0
+	fire_delay = 3
 	spread_increase = 0.5
 	spread_max = 1.5
 
 /obj/item/weapon/gun/projectile/automatic/pistol/stechkin/atom_init()
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
+	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 /obj/item/weapon/gun/projectile/automatic/pistol/colt1911
 	desc = "Дешевая марсианская подделка Colt M1911. Использует менее смертоносные патроны 45-го калибра."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
убрал лишнюю проверку ready_to_fire в компоненте автоматической стрельбы, потому что она уже есть в коде стрельбы оружия
прописал автоматам файрделей
## Почему и что этот ПР улучшит
когда я добавлял автоматическую стрельбу, я нормально не разобрался из-за чего автоматы с файрделеем выше нуля не могли стрелять (из-за лишнего ready_to_fire) , вот из-за этого я всем автоматам прописал файрделей 0
ну и это пофиксит то что автоматические пушки при заклике стреляли быстрее, чем с зажатием
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
никто не заметит изменений, так что думаю что чеинжлог не нужен
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
