### PR TITLE
фикс настенных сейфов

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -249,6 +249,15 @@
 	density = FALSE
 	cant_hold = list(/obj/item/weapon/storage/secure/briefcase)
 
+/obj/item/weapon/storage/secure/safe/try_open(mob/user)
+	if(locked)
+		if(user.in_interaction_vicinity(src))
+			to_chat(user, "<span class='warning'>[src] is locked and cannot be opened!</span>")
+		return FALSE
+	else
+		return ..()
+
+
 /obj/item/weapon/storage/secure/safe/atom_init()
 	. = ..()
 	new /obj/item/weapon/paper(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Заблокированные настенные сейфы нельзя открыть через альт-клик.
## Почему и что этот ПР улучшит
Фикс бага
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Заблокированные настенные сейфы можно было открыть альткликом.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
