### PR TITLE
фикс оверлея меча у синдиборга

### DIFF
--- a/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
@@ -26,7 +26,7 @@
 	laws = new /datum/ai_laws/syndicate_override()
 	if(!sword_overlay)
 		sword_overlay = image(icon, "syndie_android_sword", "layer" = 4.5)
-		sword_overlay.plane = sword_overlay.layer
+		sword_overlay.plane = GAME_PLANE
 
 /mob/living/silicon/robot/syndicate/updateicon()
 	..()
@@ -45,6 +45,7 @@
 	INVOKE_ASYNC(src, PROC_REF(recalculateChannels))
 
 /obj/item/weapon/melee/energy/sword/cyborg
+	blade_color = "blue"
 	var/hitcost = 500
 
 /obj/item/weapon/melee/energy/sword/cyborg/attack_self(mob/living/user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
опустил плейн у оверлея меча синдиборга, потому что из-за слишком высокого плейна он не был виден
а ещё меч всегда светится синим цветом, потому что на спрайте-оверлее он синий
## Почему и что этот ПР улучшит
фикс бага
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: У синдиборга не показывался оверлей включённого энергомеча.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
