### PR TITLE
Increased toxicity of space cleaner

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
@@ -192,7 +192,7 @@
 
 /datum/reagent/space_cleaner/on_general_digest(mob/living/M)
 	..()
-	M.adjustToxLoss(0.2)
+	M.adjustToxLoss(1.5)
 
 	if(prob(10))
 		M.emote("hiccup")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Теперь космо очиститель наносит больше токсичного урона при поглощении

## Почему и что этот ПР улучшит

Добавит чуть больше логики. Почему соединение аммиака практически не отравляет?

## Авторство

@L4rever 

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->

:cl:

- tweak: Спейс клинер теперь более токсичный при приёме внутрь
