### PR TITLE
516 relay loc

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -26,7 +26,7 @@
 #error You need version 514 or higher
 #endif
 
-#define RECOMMENDED_VERSION 514
+#define RECOMMENDED_VERSION 516
 
 
 // 515 split call for external libraries into call_ext

--- a/code/_onclick/hud/rendering/map_view.dm
+++ b/code/_onclick/hud/rendering/map_view.dm
@@ -65,7 +65,7 @@
 		PM.update_effects(client)
 
 		client.screen += PM
-		client.screen += PM.generate_relays()
+		client.screen += PM.generate_relays(assigned_map)
 
 /atom/movable/screen/map_view/proc/hide_from(client/client)
 	client.screen -= background

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -33,14 +33,14 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 		// don't use fixed size, it can break map_view scaling
 		screen_loc = "[map_view]:1,1"
 
-/atom/movable/screen/plane_master/proc/generate_relays()
+/atom/movable/screen/plane_master/proc/generate_relays(map_view)
 	. = list()
 	if(!isnull(render_relay_planes))
 		for(var/relay_plane in render_relay_planes)
 			// here I assume that plane always exists with client and we don't need to destroy it,
 			// so there is no need to keep render_plane_relay referenced anywhere except for client.screen
 			// for outer maps we just cleanup it all at once based on assigned_map value
-			var/atom/movable/screen/render_plane_relay/relay = new(null, src, relay_plane)
+			var/atom/movable/screen/render_plane_relay/relay = new(null, src, relay_plane, map_view)
 
 			. += relay
 

--- a/code/_onclick/hud/rendering/render_plane_relay.dm
+++ b/code/_onclick/hud/rendering/render_plane_relay.dm
@@ -4,12 +4,12 @@
 
 INITIALIZE_IMMEDIATE(/atom/movable/screen/render_plane_relay)
 /atom/movable/screen/render_plane_relay
-	screen_loc = "CENTER"
+	screen_loc = "SCREEN_SOUTHWEST"
 	layer = -1
 	plane = 0
 	appearance_flags = PASS_MOUSE | NO_CLIENT_COLOR | KEEP_TOGETHER
 
-/atom/movable/screen/render_plane_relay/atom_init(mapload, atom/movable/screen/plane_master/source_plane, render_plane)
+/atom/movable/screen/render_plane_relay/atom_init(mapload, atom/movable/screen/plane_master/source_plane, render_plane, map_view)
 	. = ..()
 
 	name = source_plane.render_target
@@ -17,7 +17,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/render_plane_relay)
 	render_source = source_plane.render_target
 
 	assigned_map = source_plane.assigned_map // for cleaning external maps
-	screen_loc = source_plane.screen_loc
+
+	if(map_view)
+		screen_loc = "[map_view]:SCREEN_SOUTHWEST"
 
 	plane = render_plane
 	layer = (source_plane.plane + abs(LOWEST_EVER_PLANE)) * 0.5 //layer must be positive but can be a decimal


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
по сути тож самое, что и #13713

только реле теперь крепляется всегда в левый нижний угол, а не в фиксированную точку (1,1), которая совпадала с левым нижним углом
проблем не возникало, потому что эта точка у нас не двигалась, а в 516 оказывается она теперь может убежать (если вытащить элемент худа за пределы обзора, к примеру)

а еще не позволяет зайти с 515 (если в конфиге это отдельно не дергалось)
## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
