### PR TITLE
небольшой фикс стрельбы из оружия мехов

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -25,9 +25,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/action(atom/target)
 	if(!action_checks(target))
 		return
-	var/turf/curloc = chassis.loc
 	var/turf/targloc = get_turf(target)
-	if(!curloc || !targloc)
+	if(!targloc)
 		return
 	chassis.use_power(energy_drain)
 	chassis.visible_message("<span class='warning'>[chassis] fires [src]!</span>")
@@ -36,9 +35,8 @@
 	set_ready_state(FALSE)
 	for(var/i = 1 to min(projectiles, projectiles_per_shot))
 		var/turf/aimloc = targloc
-		if(deviation)
-			aimloc = locate(targloc.x+GaussRandRound(deviation,1),targloc.y+GaussRandRound(deviation,1),targloc.z)
-		if(!aimloc || aimloc == curloc)
+		var/turf/curloc = chassis.loc
+		if(!curloc || !aimloc || aimloc == curloc)
 			break
 		playsound(chassis, fire_sound, VOL_EFFECTS_MASTER, fire_volume)
 		projectiles--
@@ -58,6 +56,7 @@
 	P.starting = P.loc
 	P.current = P.loc
 	P.firer = chassis.occupant
+	P.dispersion = deviation
 	if(isbrain(chassis.occupant))
 		P.def_zone = ran_zone()
 	else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
локация из которой происходит выстрел переопределяется после каждого выстрела в очереди, а не до начала стрельбы

https://github.com/user-attachments/assets/4cea3b51-2883-4ee7-9d01-9d9f9689e32c


ещё переменная deviation вместо непонятного изменения локации цели меняет dispersion снаряда
## Почему и что этот ПР улучшит
начав стрелять из пулемёта, локация из которой "стреляются" пули не менялась, даже если мех сдвинется
и ещё разброс у оружия мехов должен чуть лучше работать
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Начав стрелять из пулемёта меха, локация из которой "стреляются" пули не менялась, даже если мех сдвинется.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
