### PR TITLE
escape_lose

### DIFF
--- a/code/game/gamemodes/objectives/escape.dm
+++ b/code/game/gamemodes/objectives/escape.dm
@@ -6,9 +6,9 @@
 		return OBJECTIVE_LOSS
 	if(isbrain(owner.current))
 		return OBJECTIVE_LOSS
-	if(SSshuttle.location<2)
+	if(SSshuttle.location < 2)
 		return OBJECTIVE_LOSS
-	if(!owner.current || owner.current.stat ==DEAD)
+	if(!owner.current || owner.current.stat == DEAD)
 		return OBJECTIVE_LOSS
 	var/turf/location = get_turf(owner.current.loc)
 	if(!location)
@@ -17,6 +17,8 @@
 	if(iscarbon(owner.current))
 		var/mob/living/carbon/C = owner.current
 		if(C.restrained())
+			return OBJECTIVE_LOSS
+		if(C.handcuffed)
 			return OBJECTIVE_LOSS
 
 	var/area/check_area = location.loc


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Закованые в наручники триторы теперь фелят задание Escape on the shuttle or an escape pod alive and free.
## Почему и что этот ПР улучшит
В целе четко указано свободными, теперь это проверяется
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: Закованые в наручники триторы теперь фелят задание Escape on the shuttle or an escape pod alive and free.