### PR TITLE
Фикс бага с удалением спрайта ящика мимика

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -315,6 +315,12 @@
 	icon_opened = "crateopen"
 	icon_closed = "crate"
 
+/obj/structure/closet/crate/loot
+	desc = "Что же может оказаться внутри?"
+	name = "Abandoned crate"
+	icon_closed = "treasure"
+	icon_opened = "treasureopen"
+
 /obj/structure/closet/crate/rcd/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/rcd_ammo(src)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -50,7 +50,8 @@
 //
 // Crate Mimic
 //
-
+/mob/living/simple_animal/hostile/mimic/crate/proc/create_crate()
+	return new /obj/structure/closet/crate(get_turf(src))
 
 // Aggro when you try to open them. Will also pickup loot when spawns and drop it when dies.
 /mob/living/simple_animal/hostile/mimic/crate
@@ -107,13 +108,13 @@
 	icon_state = initial(icon_state)
 
 /mob/living/simple_animal/hostile/mimic/crate/death()
+	var/obj/structure/closet/crate/C = create_crate()
 
-	var/obj/structure/closet/crate/C = new(get_turf(src))
-	// Put loot in crate
 	for(var/obj/O in src)
 		O.loc = C
 
 	visible_message("<span class='warning'><b>[src]</b> stops moving!</span>")
+
 	qdel(src)
 	..()
 
@@ -358,3 +359,6 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "treasure"
 	icon_living = "treasure"
+
+/mob/living/simple_animal/hostile/mimic/crate/loot/create_crate()
+	return new /obj/structure/closet/crate/loot(get_turf(src))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь при уничтожении мимика спрайт ящика не меняется на стандартный.
Если вкратце добавил новый метод для упрощения и понятности кода
## Почему и что этот ПР улучшит
Минус баг, проще код
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:
 - bugfix: Теперь при убийстве мимика спрайт не перключается на стандартный