### PR TITLE
небольшие твики электротерапевтического стула

### DIFF
--- a/code/game/objects/structures/deconverting_chair.dm
+++ b/code/game/objects/structures/deconverting_chair.dm
@@ -1,7 +1,7 @@
 
 /obj/structure/stool/bed/chair/electrotherapy
 	name = "electrotherapy chair"
-	desc = "Latest development in the field of brainwashing. This thing is almost guaranteed to bring back loyalty to your crew!"
+	desc = "Latest development in the field of brainwashing. This thing is almost guaranteed to bring back loyalty to your crew! Or... No?"
 	icon_state = "echair0"
 	var/list/roles_to_deconvert = list(SHADOW_THRALL, CULTIST)
 	var/on_cooldown = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
добавлен небольшой дуафтер для активации, нельзя активировать стул без человека на нём и когда сам активирующий сидит на нём.
теперь стул с 50 процентным шансом может удалить импланты лояльности и защиты разума у людей их имеющих
## Почему и что этот ПР улучшит
частично решает https://github.com/TauCetiStation/TauCetiClassic/issues/11273, прикольный ролеплей
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: maleyvich
- bugfix: Добавлен небольшой кулдаун для активации электротерапевтического стула.
- tweak: Теперь нельзя активировать электротерапевтический стул, если на нём нет человека, или вы сами на нём сидите.
- tweak: Электротерапевтический стул с большим шансом может отключить импланты лояльности и защиты разума.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
