### PR TITLE
Удаление майндсвапа

### DIFF
--- a/code/game/gamemodes/modes_gameplays/wizard/spellbook.dm
+++ b/code/game/gamemodes/modes_gameplays/wizard/spellbook.dm
@@ -164,12 +164,6 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/trigger/blind
 	log_name = "BD"
 
-/datum/spellbook_entry/mindswap
-	name = "Обмен разумом"
-	spell_type = /obj/effect/proc_holder/spell/targeted/mind_transfer
-	log_name = "MT"
-	category = "Мобильность"
-
 /datum/spellbook_entry/forcewall
 	name = "Магическая стена"
 	spell_type = /obj/effect/proc_holder/spell/targeted/forcewall


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Майнд свап удалён из спелбука. Админы всё ещё могут выдать его, если посчитают нужным.
## Почему и что этот ПР улучшит
Данный спелл привносит веселье лишь для самого мага, портя игру ВСЕМ остальным игрокам, но при этом на него не распространяются правила о грифе.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- balance: Маг больше не может взять спелл "Обмен Разумом".
