### PR TITLE
Магбутсы защищают от репульса

### DIFF
--- a/code/datums/spells/repulse.dm
+++ b/code/datums/spells/repulse.dm
@@ -23,6 +23,13 @@
 		if(AM == user || AM.anchored)
 			continue
 
+		if(ishuman(AM)) // AIR_FLOW_PROTECT defend a human from repulse
+			var/mob/living/carbon/human/H = AM
+			if(H.shoes && (H.shoes.flags & AIR_FLOW_PROTECT))
+				continue
+			if(H.wear_suit && (H.wear_suit.flags & AIR_FLOW_PROTECT))
+				continue
+
 		throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(AM, user)))
 		distfromcaster = get_dist(user, AM)
 		if(distfromcaster == 0)

--- a/code/datums/spells/repulse.dm
+++ b/code/datums/spells/repulse.dm
@@ -23,7 +23,7 @@
 		if(AM == user || AM.anchored)
 			continue
 
-		if(ishuman(AM)) // AIR_FLOW_PROTECT defend a human from repulse
+		if(ishuman(AM)) // AIR_FLOW_PROTECT defends a human from repulse
 			var/mob/living/carbon/human/H = AM
 			if(H.shoes && (H.shoes.flags & AIR_FLOW_PROTECT))
 				continue

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,7 +14,7 @@
 	name = "Toggle Magboots"
 
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
-	if(!do_after(user, 0.8 SECONDS, target = src))
+	if(user.is_busy() || !do_after(user, 0.8 SECONDS, target = src))
 		return
 	if(magpulse)
 		flags &= ~(NOSLIP | AIR_FLOW_PROTECT)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,6 +14,8 @@
 	name = "Toggle Magboots"
 
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
+	if(!do_after(user, 0.8 SECONDS, target = src))
+		return
 	if(magpulse)
 		flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
 		slowdown = SHOES_SLOWDOWN


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
флаг AIR_FLOW_PROTECT теперь защищает от репульса мага, а это:
включенные магбутсы, големы, тапки ниндзя.

накинул магбутсам вне рига секундный дуафтер типо надо дотянуться там кнопку нащупать, ну и чтобы не абузили суки.
если магбутсы внутри рига, то переключение всё также моментальное.

## Почему и что этот ПР улучшит
мне кажется что это прикольно

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - balance: Репульс мага не действует на големов и людей с включенными магбутсами.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
