### PR TITLE
При отключении света во время клонирования клон погибает

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -190,10 +190,9 @@
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/process()
 
-	if(stat & NOPOWER) //Autoeject if power is lost
-		if (src.occupant)
-			src.locked = 0
-			go_out()
+	if(stat & NOPOWER) //Kill if power is lost
+		if (occupant)
+			malfunction()
 		return
 
 	if((src.occupant) && (src.occupant.loc == src))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -191,9 +191,7 @@
 /obj/machinery/clonepod/process()
 
 	if(stat & NOPOWER) //Kill if power is lost
-		if (occupant)
-			malfunction()
-		return
+		malfunction()
 
 	if((src.occupant) && (src.occupant.loc == src))
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
см. название
## Почему и что этот ПР улучшит
Больше нельзя будет абузить отключение света для быстрого клонирования
И ещё больше прикольных способов для убийств
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- tweak: Если отключить свет в процессе клонирования, клон в капсуле умрёт.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
