### PR TITLE
Window structures reduce laser damage by half

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -197,7 +197,8 @@
 #define WORLD_ICON_SIZE 32
 #define PIXEL_MULTIPLIER WORLD_ICON_SIZE/32
 
-// (Bay12 = -2), but we don't have that projectile code, so...
+// bullet_act() return values
+#define PROJECTILE_WEAKENED -2
 #define PROJECTILE_FORCE_MISS -1
 #define PROJECTILE_ACTED 0
 #define PROJECTILE_ABSORBED 2

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -215,7 +215,7 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/door/window, windowdoor_list)
 
 /obj/machinery/door/window/bullet_act(obj/item/projectile/Proj, def_zone)
 	if(Proj.pass_flags & PASSGLASS)
-		return PROJECTILE_FORCE_MISS
+		return PROJECTILE_WEAKENED
 	return ..()
 
 /obj/machinery/door/window/play_attack_sound(damage_amount, damage_type, damage_flag)

--- a/code/game/objects/structures/windows/shuttle.dm
+++ b/code/game/objects/structures/windows/shuttle.dm
@@ -24,7 +24,7 @@
 
 /obj/structure/window/shuttle/bullet_act(obj/item/projectile/Proj, def_zone)
 	if(Proj.checkpass(PASSGLASS))
-		return PROJECTILE_FORCE_MISS
+		return PROJECTILE_WEAKENED
 
 	return ..()
 

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -103,7 +103,7 @@
 
 /obj/structure/window/fulltile/bullet_act(obj/item/projectile/Proj, def_zone)
 	if(Proj.checkpass(PASSGLASS) && (!grilled || Proj.checkpass(PASSGRILLE)))
-		return PROJECTILE_FORCE_MISS
+		return PROJECTILE_WEAKENED
 
 	if(grilled && Proj.checkpass(PASSGLASS)) // replics should be happy (im crying because of how awful this is)
 		if(prob((max_integrity - get_integrity()) * 100 / GRILLE_MAX_INTEGRITY))

--- a/code/game/objects/structures/windows/window_thin.dm
+++ b/code/game/objects/structures/windows/window_thin.dm
@@ -32,7 +32,7 @@
 
 /obj/structure/window/thin/bullet_act(obj/item/projectile/Proj, def_zone)
 	if(Proj.checkpass(PASSGLASS))
-		return PROJECTILE_FORCE_MISS
+		return PROJECTILE_WEAKENED
 
 	return ..()
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -184,6 +184,10 @@
 	bumped = TRUE
 	var/forcedodge = A.bullet_act(src, def_zone) // try to shot something
 
+	if(forcedodge == PROJECTILE_WEAKENED)
+		damage = damage / 2
+		forcedodge = PROJECTILE_FORCE_MISS
+
 	if(forcedodge == PROJECTILE_FORCE_MISS) // the bullet passes through a dense object!
 		forceMove(A_loc)
 		bumped = FALSE // reset bumped variable!


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Resolves https://github.com/TauCetiStation/TauCetiClassic/issues/6990

У нас уже даже окна в аварийные створки вернулись, и старые многоструктурные окна убрали, а таска так и висела.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->

:cl:
 - balance: Лазер (и другие подобные прожектайлы) теряют половину своей мощности, пролетая сквозь стеклянные структуры. Должно нивелировать абуз стеклянных баррикад против нюки.