### PR TITLE
Cucumber fix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -237,6 +237,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cucumber/atom_init()
 	. = ..()
+	reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
 	reagents.add_reagent("ethylredoxrazine", 1+round((potency / 10), 1))
 	bitesize = reagents.total_volume
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
из-за того, что внутри огурца не было нутриментов, он не насыщал, и не было возможным компостить его в трей. получался такой болванчик с одним реагентом. исправляем.
## Почему и что этот ПР улучшит

## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TheBadDay4
 - bugfix: огурец насыщает
