### PR TITLE
Fix Speech Modifications Breaking Runechat

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -211,7 +211,7 @@
 			if(5 to 9)
 				new_letter = uppertext(new_letter)
 			if(10)
-				new_letter += "'"
+				new_letter += html_decode("'")
 			if(11 to 15)
 				SWITCH_PASS
 
@@ -269,7 +269,7 @@
 				new_letter = ""
 
 			for(var/j = 1, j <= rand(0, 2), j++)
-				new_letter += pick("#","@","*","&","%","$","/", "<", ">", ";","*","*","*","*","*","*","*")
+				new_letter += html_decode(pick("#","@","*","&","%","$","/", "<", ">", ";","*","*","*","*","*","*","*"))
 
 		new_text += new_letter
 
@@ -288,7 +288,7 @@
 		new_letter = letter
 
 		for(var/j = 1, j <= rand(0, 2), j++)
-			new_letter += pick("#","@","*","&","%","$","/", "<", ">", ";","*","*","*","*","*","*","*")
+			new_letter += html_decode(pick("#","@","*","&","%","$","/", "<", ">", ";","*","*","*","*","*","*","*"))
 
 		new_text += new_letter
 


### PR DESCRIPTION
## Описание изменений

Мимопроходил.

Заметил что иногда сообщения в рунчате по-пьяни содержится что-то похожее на юникод-коды (`&#39`) (`'`).

Какое-то время пытался разобраться что происходит, в глаз попало что мы смешиваем эскейпнутые символы с не эскейпнутыми. Думаю должно решить проблему.

## Почему и что этот ПР улучшит

Меньше странностей над головой кукол.

:cl:
 - bugfix: Пьяные куклы порою пытались взломать матрицу и заколдовать всех вокруг странными символами над головой.
