### PR TITLE
закрываем пачку абузов

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -163,7 +163,7 @@
 	if(A && non_native_bump)
 		A.Bumped(src)
 
-/atom/movable/proc/forceMove(atom/destination, keep_pulling = FALSE, keep_buckled = FALSE, keep_moving_diagonally = FALSE)
+/atom/movable/proc/forceMove(atom/destination, keep_pulling = FALSE, keep_buckled = FALSE, keep_moving_diagonally = FALSE, keep_grabs = TRUE)
 	if(!destination)
 		return
 	if(pulledby && !keep_pulling)
@@ -192,9 +192,11 @@
 			AM.Crossed(src, oldloc)
 	Moved(oldloc, 0)
 
-/mob/forceMove(atom/destination, keep_pulling = FALSE, keep_buckled = FALSE)
+/mob/forceMove(atom/destination, keep_pulling = FALSE, keep_buckled = FALSE, keep_moving_diagonally = FALSE, keep_grabs = TRUE)
 	if(!keep_pulling)
 		stop_pulling()
+	if(!keep_grabs)
+		StopGrabs()
 	if(buckled && !keep_buckled)
 		buckled.unbuckle_mob()
 	. = ..()
@@ -203,7 +205,7 @@
 		buckled.set_dir(dir)
 	update_canmove()
 
-/mob/dead/observer/forceMove(atom/destination, keep_pulling, keep_buckled)
+/mob/dead/observer/forceMove(atom/destination, keep_pulling, keep_buckled, keep_moving_diagonally, keep_grabs)
 	if(destination)
 		if(loc)
 			loc.Exited(src)

--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -545,7 +545,7 @@
 	if(!istype(C))
 		return
 	C.SetNextMove(CLICK_CD_MELEE)
-	C.StopGrabs()
+	victim.StopGrabs()
 
 	holding = !holding
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -73,7 +73,6 @@
 	add_fingerprint(user)
 	close_machine(G.affecting)
 	playsound(src, 'sound/machines/analysis.ogg', VOL_EFFECTS_MASTER, null, FALSE)
-	qdel(G)
 
 /obj/machinery/bodyscanner/update_icon()
 	icon_state = "body_scanner_[occupant ? "1" : "0"]"

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -335,6 +335,7 @@ var/global/list/frozen_items = list()
 		icon_state = "cryosleeper_[orient_right ? "right" : "left"]"
 
 /obj/machinery/cryopod/open_machine()
+	occupant = null
 	dropContents()
 	update_icon()
 
@@ -425,9 +426,7 @@ var/global/list/frozen_items = list()
 		add_fingerprint(user)
 
 /obj/machinery/cryopod/proc/go_out()
-	occupant.forceMove(get_turf(src))
 	set_med_status("Active")
-	occupant = null
 	open_machine()
 
 //Attacks/effects.

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -340,8 +340,7 @@ var/global/list/frozen_items = list()
 	update_icon()
 
 /obj/machinery/cryopod/proc/insert(mob/M)
-	M.StopGrabs()
-	M.forceMove(src)
+	M.forceMove(src, keep_grabs = FALSE)
 	to_chat(M, "<span class='notice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
 	to_chat(M, "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>")
 	occupant = M

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -159,12 +159,7 @@ var/global/list/frozen_items = list()
 
 /obj/machinery/cryopod/atom_init()
 
-	announce = new /obj/item/device/radio/intercom(src)
-
-	if(orient_right)
-		icon_state = "cryosleeper_right"
-	else
-		icon_state = "cryosleeper_left"
+	announce = new /obj/item/device/radio/intercom(null)
 	. = ..()
 
 /obj/machinery/cryopod/Destroy()
@@ -258,11 +253,6 @@ var/global/list/frozen_items = list()
 				if ((G.fields["name"] == occupant.real_name))
 					qdel(G)
 
-			if(orient_right)
-				icon_state = "cryosleeper_right"
-			else
-				icon_state = "cryosleeper_left"
-
 			//This should guarantee that ghosts don't spawn.
 			occupant.ckey = null
 
@@ -277,6 +267,7 @@ var/global/list/frozen_items = list()
 			qdel(occupant)
 			occupant = null
 
+			open_machine()
 
 /obj/machinery/cryopod/attackby(obj/item/weapon/G, mob/user)
 
@@ -337,15 +328,25 @@ var/global/list/frozen_items = list()
 				preserve_item(object)
 		qdel(O)
 
+/obj/machinery/cryopod/update_icon()
+	if(occupant)
+		icon_state = "cryosleeper_[orient_right ? "right" : "left"]_cl"
+	else
+		icon_state = "cryosleeper_[orient_right ? "right" : "left"]"
+
+/obj/machinery/cryopod/open_machine()
+	dropContents()
+	update_icon()
 
 /obj/machinery/cryopod/proc/insert(mob/M)
+	M.StopGrabs()
 	M.forceMove(src)
-	icon_state = "cryosleeper_[orient_right ? "right" : "left"]_cl"
 	to_chat(M, "<span class='notice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
 	to_chat(M, "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>")
 	occupant = M
 	time_entered = world.time
 	set_med_status("*SSD*")
+	update_icon()
 
 /obj/machinery/cryopod/proc/set_med_status(mes)
 	for(var/datum/data/record/R in data_core.general)
@@ -356,7 +357,10 @@ var/global/list/frozen_items = list()
 
 /obj/machinery/cryopod/AltClick(mob/user)
 	. = ..()
-	enter_pod(user)
+	if(occupant)
+		eject()
+	else
+		enter_pod(user)
 
 /obj/machinery/cryopod/relaymove(mob/user)
 	..()
@@ -364,7 +368,8 @@ var/global/list/frozen_items = list()
 
 /obj/machinery/cryopod/MouseDrop_T(mob/target, mob/user)
 	. = ..()
-	enter_pod(user)
+	if(user == target)
+		enter_pod(user)
 
 /obj/machinery/cryopod/verb/eject()
 	set name = "Eject Pod"
@@ -394,6 +399,9 @@ var/global/list/frozen_items = list()
 	if(user.incapacitated() || !(ishuman(user)))
 		return
 
+	if(!Adjacent(user))
+		return
+
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='notice'>You have no idea how to do that.</span>")
 		return
@@ -420,8 +428,7 @@ var/global/list/frozen_items = list()
 	occupant.forceMove(get_turf(src))
 	set_med_status("Active")
 	occupant = null
-	icon_state = "cryosleeper_[orient_right ? "right" : "left"]"
-
+	open_machine()
 
 //Attacks/effects.
 /obj/machinery/cryopod/blob_act()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -237,8 +237,7 @@ Class Procs:
 			target.client.perspective = EYE_PERSPECTIVE
 			target.client.eye = src
 		occupant = target
-		target.forceMove(src)
-		target.StopGrabs()
+		target.forceMove(src, keep_grabs = FALSE)
 	updateUsrDialog()
 	update_icon()
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -232,15 +232,12 @@ Class Procs:
 				continue
 			else
 				target = C
-	if(target && !target.buckled)
+	if(target && !target.buckled && Adjacent(target))
 		if(target.client)
 			target.client.perspective = EYE_PERSPECTIVE
 			target.client.eye = src
 		occupant = target
-		target.loc = src
-		target.stop_pulling()
-		if(target.pulledby)
-			target.pulledby.stop_pulling()
+		target.forceMove(src)
 		target.StopGrabs()
 	updateUsrDialog()
 	update_icon()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -241,6 +241,7 @@ Class Procs:
 		target.stop_pulling()
 		if(target.pulledby)
 			target.pulledby.stop_pulling()
+		target.StopGrabs()
 	updateUsrDialog()
 	update_icon()
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -151,6 +151,7 @@
 /obj/machinery/recharge_station/close_machine()
 	if(!panel_open)
 		for(var/mob/living/silicon/robot/R in loc)
+			R.StopGrabs()
 			if(R.client)
 				R.client.eye = src
 				R.client.perspective = EYE_PERSPECTIVE

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -151,11 +151,10 @@
 /obj/machinery/recharge_station/close_machine()
 	if(!panel_open)
 		for(var/mob/living/silicon/robot/R in loc)
-			R.StopGrabs()
 			if(R.client)
 				R.client.eye = src
 				R.client.perspective = EYE_PERSPECTIVE
-			R.forceMove(src)
+			R.forceMove(src, keep_grabs = FALSE)
 			occupant = R
 			set_power_use(ACTIVE_POWER_USE)
 			add_fingerprint(R)

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -145,7 +145,7 @@
 /atom/movable/lighting_object/Move()
 	return
 
-/atom/movable/lighting_object/forceMove(atom/destination, keep_pulling)
+/atom/movable/lighting_object/forceMove(atom/destination, keep_pulling, keep_buckled, keep_moving_diagonally, keep_grabs)
 	return
 
 /atom/movable/lighting_object/shake_act(severity, recursive = TRUE)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -166,6 +166,8 @@
 /mob/proc/StopGrabs()
 	for(var/obj/item/weapon/grab/G in get_hand_slots())
 		qdel(G)
+	for(var/obj/item/weapon/grab/G in grabbed_by)
+		qdel(G)
 
 /mob/proc/GetGrabs()
 	. = list()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
- космонавты разучились в телепортацию: альт-клик по крио (для лива) более невозможен на дистанции
closes #14049

- космонавты разучились в суперпозицию: крио(и медицинское, и для лива)/слипер/медсканнер стал разрывать граб, не позволяя оказаться в двух местах одновременно (внутри и вне машинерии одновременно)
closes #13653

- попытки сбежать от крио (медицинского) теперь не такие тщетные: если персонаж попробует отойти от крио во время прогресс бара врача, запихивающего человека в крио, то его не телепортирует
closes #10028 (там очень жесткое описание)

- потайное хранилище крио (для лива) ликвидировано: находясь внутри крио, можно что-то выбросить, и это что-то будет теперь выпадать при открытии крио
(такая проблема еще у мехов есть, но тут и так солянка неатомарная, поэтому пока не трогал)

- другие мелочи: попытка перетянуть что угодно на крио (для лива) отправляла перетягивающего в капсулу: теперь не отправляет; 
альт клик по занятому крио (для лива) попытается сперва вытолкнуть спящего, избавляя от нужды лезть за вербом в пкм-меню (вот бы избавиться от вербов)

(боже почему крио меда и дорм одинаково именуются)
## Почему и что этот ПР улучшит
простите, веселые баги стали унылыми абузами, пришло время их смерти
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
