### PR TITLE
Glowshrooms tweak

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1108,6 +1108,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/atom_init()
 	. = ..()
+	reagents.add_reagent("radium", 1+round((potency / 5), 1))
 	set_light(round(potency/10,1))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user)


### PR DESCRIPTION
## Описание изменений

в глоушрумах теперь содержится радий.

## Почему и что этот ПР улучшит

делает ботанику автономнее

## Авторство

код nasend_

## Чеинжлог

:cl: nasend_
 - tweak: Светящиеся грибы содержат радий.
 