### PR TITLE
Добавляем капитану магбутсы

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -37238,6 +37238,7 @@
 /obj/item/weapon/tank/jetpack/oxygen,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/clothing/suit/armor/captain,
+/obj/item/clothing/shoes/magboots/ert,
 /obj/item/clothing/head/helmet/space/capspace,
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -29221,6 +29221,7 @@
 /obj/item/weapon/tank/jetpack/oxygen,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/clothing/suit/armor/captain,
+/obj/item/clothing/shoes/magboots/ert,
 /obj/item/clothing/head/helmet/space/capspace,
 /obj/effect/decal/turf_decal{
 	dir = 10;

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -27675,6 +27675,7 @@
 /obj/item/weapon/tank/jetpack/oxygen,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/clothing/suit/armor/captain,
+/obj/item/clothing/shoes/magboots/ert,
 /obj/item/clothing/head/helmet/space/capspace,
 /obj/structure/bobross{
 	pixel_x = 32

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -65406,6 +65406,7 @@
 /obj/item/weapon/tank/jetpack/oxygen,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/clothing/suit/armor/captain,
+/obj/item/clothing/shoes/magboots/ert,
 /obj/item/clothing/head/helmet/space/capspace,
 /obj/machinery/door/window{
 	base_state = "right";

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -73090,6 +73090,7 @@
 	},
 /obj/item/weapon/tank/jetpack/oxygen,
 /obj/item/clothing/suit/armor/captain,
+/obj/item/clothing/shoes/magboots/ert,
 /obj/item/clothing/head/helmet/space/capspace,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/weapon/hand_tele,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
У кэпа появились магбутсы
## Почему и что этот ПР улучшит
На стенде с космо броней у кэпа нет магбустов, что странно учитывая что это космо броня.
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: На стенд с космо броней капитана добавлены магбутсы