### PR TITLE
Debuffs Uppercut

### DIFF
--- a/code/modules/unarmed_combat/combos/harmful.dm
+++ b/code/modules/unarmed_combat/combos/harmful.dm
@@ -2,8 +2,8 @@
 	name = COMBO_UPPERCUT
 	desc = "A move where you lunge your fist from below into opponent's chin, knocking their helmet off."
 	combo_icon_state = "uppercut"
-	cost = 60
-	combo_elements = list(INTENT_HARM, INTENT_HARM, INTENT_HARM, INTENT_HARM)
+	cost = 65
+	combo_elements = list(INTENT_HARM, INTENT_HARM, INTENT_HARM, INTENT_PUSH)
 
 	ignore_size = TRUE
 


### PR DESCRIPTION
## Описание изменений
Апперкот сейчас слишком имба, используют в основном только его. (Уже много от кого слышал) Сейчас он представляет из себя просто закликивания хармом по голове. Чтобы сделать интереснее, чуть усложняем прием - добавляем пуш в конце и увеличиваем стоимость комбо очков с 60 до 65.

## Почему и что этот ПР улучшит
Больше мотивации использовать разные приемы в комбо боевке.

## Авторство
Добавить пуш (или граб) в конце предложил мне Людук.

## Чеинжлог

:cl:
 - tweak: Апперкот теперь требует пуша в конце и стоит 65 очков вместо 60.
 
