### PR TITLE
Фиксит пару багов на научке.

### DIFF
--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -26,7 +26,7 @@
 	//connect to a nearby scanner pad
 	owned_scanner = locate(/obj/machinery/artifact_scanpad) in get_step(src, dir)
 	if(!owned_scanner)
-		owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(1, src)
+		owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(4, src)
 
 /obj/machinery/artifact_analyser/ui_interact(mob/user)
 	if(stat & (NOPOWER|BROKEN) || !Adjacent(user) && !issilicon(user) && !isobserver(user))
@@ -35,7 +35,7 @@
 	var/dat = "<B>Anomalous material analyser</B><BR>"
 	dat += "<HR>"
 	if(!owned_scanner)
-		owned_scanner = locate() in orange(1, src)
+		owned_scanner = locate() in orange(4, src)
 
 	if(!owned_scanner)
 		dat += "<b><font color=red>Unable to locate analysis pad.</font></b><br>"

--- a/maps/asteroid/asteroid_classic.dmm
+++ b/maps/asteroid/asteroid_classic.dmm
@@ -1596,12 +1596,7 @@
 /area/asteroid/research_outpost/anomaly)
 "du" = (
 /obj/machinery/artifact_harvester,
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/bluegrid,
 /area/asteroid/research_outpost/harvesting)
 "dv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2057,6 +2052,16 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/xenoarch_utilizer,
+/obj/item/weapon/particles_battery{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/particles_battery{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/particles_battery,
+/obj/item/weapon/particles_battery,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -2596,17 +2601,9 @@
 	},
 /area/asteroid/research_outpost/hallway)
 "fi" = (
-/obj/structure/table,
-/obj/item/weapon/particles_battery{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
 	},
-/obj/item/weapon/particles_battery{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/particles_battery,
-/obj/item/weapon/particles_battery,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -3713,11 +3710,6 @@
 /turf/simulated/floor,
 /area/asteroid/research_outpost/entry)
 "hM" = (
-/obj/machinery/driver_button{
-	id = "research";
-	pixel_x = 6;
-	pixel_y = -26
-	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "archgunc"
@@ -4768,8 +4760,15 @@
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/maint)
 "jF" = (
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/bluegrid,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/obj/structure/stool/bed/chair/metal{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/asteroid/research_outpost/harvesting)
 "jG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -5653,18 +5652,7 @@
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso1)
 "lo" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "riso3";
-	name = "Door Bolt Control";
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/obj/item/weapon/folder/purple,
-/obj/item/device/analyzer,
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "lp" = (
@@ -5674,18 +5662,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "lq" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -5920,9 +5908,6 @@
 	},
 /area/asteroid/research_outpost/outpost_misc_lab)
 "lT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the isolation room cameras.";
 	dir = 4;
@@ -5930,6 +5915,10 @@
 	name = "Isolation Room Telescreen";
 	network = list("Anomaly Isolation");
 	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -5941,7 +5930,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -5969,9 +5958,8 @@
 	locked = 0;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -6300,29 +6288,42 @@
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
 "mP" = (
-/obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/weapon/folder/purple,
+/obj/item/device/analyzer,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "mQ" = (
-/obj/structure/table,
-/turf/simulated/floor,
-/area/asteroid/research_outpost/iso2)
-"mR" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/power/apc{
 	custom_smartlight_preset = "RnD";
-	dir = 4;
-	name = "RnD right APC";
-	pixel_x = 27
+	dir = 8;
+	name = "RnD left APC";
+	pixel_x = -27
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/asteroid/research_outpost/iso2)
+"mR" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the isolation room cameras.";
+	dir = 8;
+	layer = 4;
+	name = "Isolation Room Telescreen";
+	network = list("Anomaly Isolation");
+	pixel_x = 32
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -6471,11 +6472,11 @@
 	locked = 0;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
@@ -6493,6 +6494,9 @@
 	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
@@ -6884,7 +6888,6 @@
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "oh" = (
-/obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/ignition_switch{
 	id = "isolationsparker";
 	pixel_x = 22;
@@ -6892,6 +6895,12 @@
 	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/structure/stool/bed/chair/metal{
+	dir = 1
+	},
+/obj/machinery/artifact_analyser{
+	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -7138,6 +7147,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
 "oM" = (
@@ -7157,22 +7169,15 @@
 	},
 /area/asteroid/mine/maintenance)
 "oO" = (
-/obj/machinery/artifact_analyser{
-	pixel_y = 32
-	},
-/obj/structure/stool/bed/chair/metal{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the isolation room cameras.";
-	dir = 4;
-	layer = 4;
-	name = "Isolation Room Telescreen";
-	network = list("Anomaly Isolation");
-	pixel_x = -32
-	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/door_control{
+	id = "riso3";
+	name = "Door Bolt Control";
+	pixel_x = -25;
+	specialfunctions = 4
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -7450,21 +7455,14 @@
 /turf/simulated/floor/carpet,
 /area/asteroid/mine/living_quarters)
 "ps" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
-/obj/structure/stool/bed/chair/metal{
-	dir = 4
-	},
 /obj/machinery/light/smart{
 	dir = 8
 	},
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/bluegrid,
 /area/asteroid/research_outpost/harvesting)
 "pt" = (
 /obj/structure/cable{
@@ -12339,11 +12337,11 @@
 /area/asteroid/mine/production)
 "Cg" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/iso2)
 "Ch" = (
@@ -59437,8 +59435,8 @@ lT
 lo
 mQ
 oO
-Sb
-Hg
+Cg
+Jg
 Mg
 pl
 lj
@@ -59951,8 +59949,8 @@ lX
 mP
 mR
 oh
-Cg
-Jg
+Sb
+Hg
 Og
 pl
 lj

--- a/maps/asteroid/asteroid_rich.dmm
+++ b/maps/asteroid/asteroid_rich.dmm
@@ -981,8 +981,15 @@
 	},
 /area/asteroid/research_outpost/hallway)
 "ca" = (
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/bluegrid,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/obj/structure/stool/bed/chair/metal{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/asteroid/research_outpost/harvesting)
 "cb" = (
 /obj/structure/cable,
@@ -1873,7 +1880,19 @@
 	},
 /area/asteroid/mine/explored)
 "dU" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	custom_smartlight_preset = "RnD";
+	dir = 8;
+	name = "RnD left APC";
+	pixel_x = -27
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "dV" = (
@@ -3605,18 +3624,14 @@
 	},
 /area/asteroid/mine/explored)
 "js" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	custom_smartlight_preset = "RnD";
-	dir = 4;
-	name = "RnD right APC";
-	pixel_x = 27
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the isolation room cameras.";
+	dir = 8;
+	layer = 4;
+	name = "Isolation Room Telescreen";
+	network = list("Anomaly Isolation");
+	pixel_x = 32
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -3985,6 +4000,16 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/xenoarch_utilizer,
+/obj/item/weapon/particles_battery{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/particles_battery{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/particles_battery,
+/obj/item/weapon/particles_battery,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -4357,6 +4382,9 @@
 	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
@@ -5427,17 +5455,9 @@
 	},
 /area/asteroid/mine/living_quarters)
 "pf" = (
-/obj/structure/table,
-/obj/item/weapon/particles_battery{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
 	},
-/obj/item/weapon/particles_battery{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/particles_battery,
-/obj/item/weapon/particles_battery,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -5469,7 +5489,6 @@
 	},
 /area/asteroid/research_outpost/hallway)
 "pn" = (
-/obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/ignition_switch{
 	id = "isolationsparker";
 	pixel_x = 22;
@@ -5477,6 +5496,12 @@
 	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/structure/stool/bed/chair/metal{
+	dir = 1
+	},
+/obj/machinery/artifact_analyser{
+	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -7340,12 +7365,7 @@
 /area/asteroid/research_outpost/hallway)
 "uC" = (
 /obj/machinery/artifact_harvester,
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/bluegrid,
 /area/asteroid/research_outpost/harvesting)
 "uD" = (
 /obj/machinery/camera{
@@ -7902,11 +7922,6 @@
 /turf/simulated/floor/plating/airless,
 /area/asteroid/mine/abandoned)
 "wj" = (
-/obj/machinery/driver_button{
-	id = "research";
-	pixel_x = 6;
-	pixel_y = -26
-	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "archgunc"
@@ -9103,6 +9118,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
 "Ak" = (
@@ -10197,11 +10215,11 @@
 /area/asteroid/research_outpost/outpost_misc_lab)
 "Fb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/iso2)
 "Fd" = (
@@ -10554,11 +10572,11 @@
 	locked = 0;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/harvesting)
@@ -10966,10 +10984,15 @@
 /turf/simulated/wall/r_wall/purple,
 /area/asteroid/research_outpost/tempstorage)
 "Ip" = (
-/obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/weapon/folder/purple,
+/obj/item/device/analyzer,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "Ir" = (
@@ -11350,18 +11373,7 @@
 	},
 /area/asteroid/research_outpost/outpost_misc_lab)
 "JU" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "riso3";
-	name = "Door Bolt Control";
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/obj/item/weapon/folder/purple,
-/obj/item/device/analyzer,
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
 "JW" = (
@@ -11429,22 +11441,15 @@
 	},
 /area/asteroid/research_outpost/hallway)
 "Kl" = (
-/obj/machinery/artifact_analyser{
-	pixel_y = 32
-	},
-/obj/structure/stool/bed/chair/metal{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the isolation room cameras.";
-	dir = 4;
-	layer = 4;
-	name = "Isolation Room Telescreen";
-	network = list("Anomaly Isolation");
-	pixel_x = -32
-	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
+	},
+/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/door_control{
+	id = "riso3";
+	name = "Door Bolt Control";
+	pixel_x = -25;
+	specialfunctions = 4
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -12818,21 +12823,14 @@
 	},
 /area/asteroid/mine/abandoned)
 "QJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
-/obj/structure/stool/bed/chair/metal{
-	dir = 4
-	},
 /obj/machinery/light/smart{
 	dir = 8
 	},
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/bluegrid,
 /area/asteroid/research_outpost/harvesting)
 "QK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -13128,9 +13126,6 @@
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/maint)
 "RG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the isolation room cameras.";
 	dir = 4;
@@ -13138,6 +13133,10 @@
 	name = "Isolation Room Telescreen";
 	network = list("Anomaly Isolation");
 	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -13902,13 +13901,13 @@
 	},
 /area/asteroid/mine/abandoned)
 "UI" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -13926,7 +13925,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -14333,9 +14332,8 @@
 	locked = 0;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -14865,7 +14863,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/asteroid/research_outpost/iso2)
@@ -65953,8 +65951,8 @@ RG
 JU
 dU
 Kl
-Db
-YZ
+Fb
+he
 gi
 Na
 iB
@@ -66467,8 +66465,8 @@ WF
 Ip
 js
 pn
-Fb
-he
+Db
+YZ
 xB
 Na
 iB


### PR DESCRIPTION
## Описание изменений
Пофиксил баг который сам же обнаружил - в изоляционной комнате номер 3 анализатор артефакта не подключался к сканеру, потому что проверка была на orange(1, src), а сканер поставили зачем-то намного дальше. Увеличил orange и сделал небольшую перестановку на карте, чтобы анализатор подтягивал правильный сканер, а не из другой комнаты.

Убрал лишнюю кнопку сброса в космос
Fixes #13780

Все тестил на локалке.

![image](https://github.com/user-attachments/assets/f19a78cc-658a-49a7-ac89-78a5226e2927)


## Почему и что этот ПР улучшит
Теперь можно нормально сканировать арты с эффектами на газы.

## Чеинжлог


:cl: Richard Jones
 - bugfix: Фикс сломанного сканера артефактов в изоляционной комнате 3.
 - map: Убрана лишняя кнопка сброса в космос на научке.
