### PR TITLE
signaler random

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -24,8 +24,14 @@
 
 /obj/item/device/assembly/signaler/atom_init(mapload, my_new_frequency)
 	. = ..()
-	if(my_new_frequency)
+
+	code = rand(1, 100)
+
+	if(!my_new_frequency)
+		frequency = rand(1200, 1600)
+	else
 		frequency = my_new_frequency
+
 	addtimer(CALLBACK(src, PROC_REF(set_frequency), frequency), 40)
 
 /obj/item/device/assembly/signaler/Destroy()
@@ -61,9 +67,9 @@
 <B>Frequency/Code</B> for signaler:<BR>
 Frequency:
 <A href='byond://?src=\ref[src];freq=-10'>-</A>
-<A href='byond://?src=\ref[src];freq=-2'>-</A>
+<A href='byond://?src=\ref[src];freq=-1'>-</A>
 [format_frequency(src.frequency)]
-<A href='byond://?src=\ref[src];freq=2'>+</A>
+<A href='byond://?src=\ref[src];freq=1'>+</A>
 <A href='byond://?src=\ref[src];freq=10'>+</A><BR>
 
 Code:
@@ -141,7 +147,6 @@ Code:
 				spawn(0)
 					if(S)	S.pulse(0)
 		return 0*/
-
 
 /obj/item/device/assembly/signaler/pulse(radio = 0)
 	if(connected && wires)

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -476,9 +476,9 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <br>
                 &nbsp;
                 {{:helper.link('-1', null, {'cartmenu' : "1", 'choice' : "Signal Frequency", 'sfreq' : "-10"}, null, null)}}&nbsp;
-                {{:helper.link('-.2', null, {'cartmenu' : "1", 'choice' : "Signal Frequency", 'sfreq' : "-2"}, null, null)}}&nbsp;
+                {{:helper.link('-.1', null, {'cartmenu' : "1", 'choice' : "Signal Frequency", 'sfreq' : "-1"}, null, null)}}&nbsp;
 
-                {{:helper.link('+.2', null, {'cartmenu' : "1", 'choice' : "Signal Frequency", 'sfreq' : "2"}, null, null)}}&nbsp;
+                {{:helper.link('+.1', null, {'cartmenu' : "1", 'choice' : "Signal Frequency", 'sfreq' : "1"}, null, null)}}&nbsp;
                 {{:helper.link('+1', null, {'cartmenu' : "1", 'choice' : "Signal Frequency", 'sfreq' : "10"}, null, null)}}
             </div>
         </div>


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Сигналер спаунится с рандомными частотами
Также поменял тип передачи сигналера вместо 0.2 на 0.1
## Почему и что этот ПР улучшит
Меньше самоподрывов случайным прокликиванием базовой частоты
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: Теперь сигналеры спаунятся с рандомной частотой, а не одинаковой.