### PR TITLE
tooltip flickering fix

### DIFF
--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -44,7 +44,7 @@ Notes:
 		owner = C
 		var/datum/asset/stuff = get_asset_datum(/datum/asset/simple/jquery)
 		stuff.send(owner)
-		owner << browse(file2text(file), "window=[control]")
+		owner << browse(file2text(file), "window=[control];size=1x1")
 	..()
 
 #define GET_RATIO(C) ((C.window_pixelratio != 1) ? C.window_pixelratio : (C.dpi != 1 ? C.dpi : 1))

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -97,7 +97,7 @@
 				//alert(tooltip.params+' | '+tooltip.clientView+' | '+tooltip.text+' | '+tooltip.theme); //DEBUG
 
 				//Some reset stuff to avoid fringe issues with sizing
-				window.location = 'byond://winset?id='+tooltip.control+';anchor1=0,0;size=999x999';
+				window.location = 'byond://winset?id='+tooltip.control+';anchor1=0,0;size=1x1';
 
 				//Get the real icon size according to the client view
 				var mapWidth 		= map['view-size'].x,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

При быстром апдейте тултипа можно было заметить белое окно на пол экрана. Я поправил размер, но всё равно еще можно заметить белый фон. Надо фиксить порядок инициализации, но проще уже сразу переписать/портировать обновления с учетом нового браузера.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
