### PR TITLE
скилл бафы на лоупопе

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -322,7 +322,7 @@ SUBSYSTEM_DEF(ticker)
 
 	if(totalPlayersReady <= 10)
 		is_lowpop = TRUE
-		to_chat(world, "<span class='notice'>Система штрафов и бонусов от умений персонажа отключена.</span>")
+		to_chat(world, "<span class='notice'>Система штрафов от умений персонажа отключена.</span>")
 
 	spawn(0)//Forking here so we dont have to wait for this to finish
 		mode.PostSetup()

--- a/code/modules/skills/helpers.dm
+++ b/code/modules/skills/helpers.dm
@@ -11,8 +11,6 @@
 
 /proc/apply_skill_bonus(mob/user, value, required_skills, multiplier)
 	var/result = value
-	if(SSticker.is_lowpop)
-		return result
 	for(var/datum/skill/required_skill as anything in required_skills)
 		var/value_with_helpers = get_skill_with_assistance(user, required_skill)
 		result += value * multiplier * (value_with_helpers - required_skills[required_skill])


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
#13644
я хочу вернуть баффы на лоупоп, потому что без них крайне грустно на строечке. Мне в падлу как-то ковырять джсон чтобы через конфиг это пропихивать на конкретную карту. Да и в целом мне кажется для всех карт будет норм.

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - tweak: Баффы от скиллов вернулись на лоупоп.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
