### PR TITLE
инвалиды могут нормально ползать

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1042,6 +1042,9 @@
 			if(C.traumatic_shock >= TRAUMATIC_SHOCK_CRITICAL)
 				to_chat(C, "<span class='danger'>I'm in so much pain! I can not get up!</span>")
 				return
+		if(!has_bodypart(BP_L_LEG) && !has_bodypart(BP_L_LEG))
+			to_chat(src, "<span class='danger'>WAIT, where are the legs?</span>")
+			return
 		crawl_getup = TRUE
 		if(do_after(src, 10, target = src))
 			crawl_getup = FALSE

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -209,7 +209,10 @@
 	if(!lying)
 		if(!HAS_TRAIT(src, TRAIT_NO_PAIN))
 			emote("scream")
-		Weaken(2)
+		if(crawl_can_use())
+			SetCrawling(TRUE)
+		else
+			Weaken(2)
 
 	if(iszombie(src)) // workaroud for zombie attack without stance
 		if(!crawling)
@@ -219,8 +222,6 @@
 				Stun(5)
 				Weaken(5)
 				return
-	else
-		Weaken(5) //can't emote while weakened, apparently.
 
 	if(lying)
 		var/has_arm = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
безногие и одноногие человечки вместо того чтобы попадать в вечный стан переходят на кравл
## Почему и что этот ПР улучшит
инвалиды смогут хоть чё-то сделать если у них украдут тросточку/инвалидное кресло
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Безногие и одноногие не могли поднимать предметы лёжа.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
