### PR TITLE
Добавляет печать ЦК на раунд старт сообщение от ЦК

### DIFF
--- a/code/game/gamemodes/misc_gamemode_procs.dm
+++ b/code/game/gamemodes/misc_gamemode_procs.dm
@@ -61,6 +61,8 @@
 			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper( comm.loc )
 			intercept.name = "Cent. Com. Status Summary"
 			intercept.info = intercepttext
+			var/obj/item/weapon/stamp/centcomm/S = new
+			S.stamp_paper(intercept)
 			intercept.update_icon()
 
 			comm.messagetitle.Add("Cent. Com. Status Summary")

--- a/code/game/gamemodes/misc_gamemode_procs.dm
+++ b/code/game/gamemodes/misc_gamemode_procs.dm
@@ -56,18 +56,20 @@
 			else
 				intercepttext += "<b>[M.name]</b>, the <b>[M.mind.assigned_role]</b> <br>"
 
+	var/obj/item/weapon/stamp/centcomm/stamp = new
+
 	for (var/obj/machinery/computer/communications/comm in communications_list)
 		if (!(comm.stat & (BROKEN | NOPOWER)) && comm.prints_intercept)
-			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper( comm.loc )
+			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper(comm.loc)
 			intercept.name = "Cent. Com. Status Summary"
 			intercept.info = intercepttext
-			var/obj/item/weapon/stamp/centcomm/S = new
-			S.stamp_paper(intercept)
+			stamp.stamp_paper(intercept)
 			intercept.update_icon()
 
 			comm.messagetitle.Add("Cent. Com. Status Summary")
 			comm.messagetext.Add(intercepttext)
 
+	qdel(stamp)
 	announcement_ping.play()
 
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В раунд старт оповещении о возможных агентах добавлена печать от ЦК
## Почему и что этот ПР улучшит
печать ЦК добавляет официальности и реализма
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: Добавлена печать ЦК на начальное оповещение