### PR TITLE
Теперь зарядка батарей идет гораздо быстрее

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -11,7 +11,7 @@
 	var/obj/item/weapon/stock_parts/cell/charging = null
 	var/chargelevel = -1
 	var/recharge_coeff = 1
-	var/efficiency = 0.875	//<1.0 means some power is lost in the charging process, >1.0 means free energy.
+	var/efficiency = 0.875 //<1.0 means some power is lost in the charging process, >1.0 means free energy.
 
 /obj/machinery/cell_charger/atom_init()
 	. = ..()
@@ -22,37 +22,59 @@
 
 /obj/machinery/cell_charger/RefreshParts()
 	..()
-
 	for(var/obj/item/weapon/stock_parts/capacitor/C in component_parts)
 		recharge_coeff = C.rating
 
 /obj/machinery/cell_charger/proc/updateicon()
 	icon_state = "ccharger[charging ? 1 : 0]"
-
 	if(charging && !(stat & (BROKEN|NOPOWER)) )
-
-		var/newlevel = 	round(charging.percent() * 4.0 / 99)
-		//world << "nl: [newlevel]"
-
+		var/newlevel =  round(charging.percent() * 4.0 / 99)
 		if(chargelevel != newlevel)
-
 			cut_overlays()
 			add_overlay("ccharger-o[newlevel]")
-
 			chargelevel = newlevel
 	else
 		cut_overlays()
+
 /obj/machinery/cell_charger/examine(mob/user)
 	..()
 	if(user.Adjacent(src))
 		to_chat(user, "There's [charging ? "a" : "no"] cell in the charger.")
 		if(charging)
 			to_chat(user, "Current charge: [charging.charge]")
+			var/charge_rate = get_charge_rate()
+			var/charge_speed_desc = get_charge_speed_description(charge_rate)
+			to_chat(user, "<span class='notice'>Charging speed: [charge_speed_desc]</span>")
+
+/obj/machinery/cell_charger/proc/get_charge_rate()
+	if(!charging)
+		return 1.0
+
+	var/base_rate = recharge_coeff * efficiency
+	var/cell_quality_modifier = charging.get_charge_efficiency()
+
+	return base_rate * cell_quality_modifier
+
+/obj/machinery/cell_charger/proc/get_charge_speed_description(rate)
+	switch(rate)
+		if(0 to 0.01)
+			return "<span class='bad'>Extremely Slow</span> (Potato)"
+		if(0.01 to 0.1)
+			return "<span class='bad'>Very Slow</span> (Crap/AA)"
+		if(0.1 to 0.5)
+			return "<span class='warning'>Slow</span> (Secborg/APC)"
+		if(0.5 to 5)
+			return "<span class='notice'>Normal</span> (High-capacity)"
+		if(5 to 15)
+			return "<span class='good'>Fast</span> (Super-capacity)"
+		if(15 to 50)
+			return "<span class='good'>Very Fast</span> (Hyper-capacity)"
+		if(50 to INFINITY)
+			return "<span class='good'>Ultra Fast</span> (Bluespace/Infinite)"
 
 /obj/machinery/cell_charger/attackby(obj/item/weapon/W, mob/user)
 	if(stat & BROKEN)
 		return
-
 	if(istype(W, /obj/item/weapon/stock_parts/cell) && anchored)
 		if(charging)
 			to_chat(user, "<span class='warning'>There is already a cell in the charger.</span>")
@@ -64,7 +86,6 @@
 			if(a.power_equip == 0) // There's no APC in this area, don't try to cheat power!
 				to_chat(user, "<span class='warning'>The [name] blinks red as you try to insert the cell!</span>")
 				return
-
 			user.drop_from_inventory(W, src)
 			charging = W
 			user.visible_message("[user] inserts a cell into the charger.", "You insert a cell into the charger.")
@@ -77,7 +98,6 @@
 		anchored = !anchored
 		to_chat(user, "You [anchored ? "attach" : "detach"] the cell charger [anchored ? "to" : "from"] the ground")
 		playsound(src, 'sound/items/Ratchet.ogg', VOL_EFFECTS_MASTER)
-
 	if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), W))
 		update_icon()
 		return
@@ -88,12 +108,10 @@
 	. = ..()
 	if(.)
 		return
-
 	if(charging)
 		usr.put_in_hands(charging)
 		charging.add_fingerprint(user)
 		charging.updateicon()
-
 		charging = null
 		user.visible_message("[user] removes the cell from the charger.", "You remove the cell from the charger.")
 		chargelevel = -1
@@ -110,17 +128,17 @@
 		charging.emplode(severity)
 	..(severity)
 
-
 /obj/machinery/cell_charger/process()
 	//world << "ccpt [charging] [stat]"
 	if(!charging || (stat & (BROKEN|NOPOWER)) || !anchored)
 		return
 
-	var/power_used = 100000	//for 200 units of charge. Yes, thats right, 100 kW. Is something wrong with CELLRATE?
+	var/base_power = 100000
+	var/charge_rate = get_charge_rate()
+	var/power_used = base_power * charge_rate //for 200 units of charge. Yes, thats right, 100 kW. Is something wrong with CELLRATE?
 
-	power_used = charging.give(recharge_coeff*power_used*CELLRATE*efficiency)
+	power_used = charging.give(power_used * CELLRATE)
 	use_power(power_used)
-
 	updateicon()
 
 /obj/machinery/cell_charger/deconstruct(disassembled = TRUE)

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -16,8 +16,24 @@
 	var/init_full = TRUE // initialize charge with maxcharge
 	m_amt = 700
 	g_amt = 50
-	var/rigged = 0		// true if rigged to explode
+	var/rigged = 0 // true if rigged to explode
 	var/minor_fault = 0 //If not 100% reliable, it will build up faults.
+	var/charge_efficiency = 0.033
+
+
+/obj/item/weapon/stock_parts/cell/proc/get_charge_efficiency()
+	var/base_efficiency = charge_efficiency
+
+
+	if(minor_fault)
+		base_efficiency *= 0.8
+
+
+	var/wear_factor = 1.0
+	if(reliability < 100)
+		wear_factor = 0.7 + (reliability / 150.0)
+
+	return base_efficiency * wear_factor
 
 /obj/item/weapon/stock_parts/cell/set_prototype_qualities(rel_val=100, mark=0)
 	..()
@@ -42,13 +58,15 @@
 	init_full = FALSE
 	g_amt = 40
 	rating = 2
+	charge_efficiency = 0.1
 
 /obj/item/weapon/stock_parts/cell/secborg
 	name = "security borg rechargable D battery"
 	origin_tech = "powerstorage=1"
-	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
+	maxcharge = 600 //600 max charge / 100 charge per shot = six shots
 	g_amt = 40
 	rating = 2.5
+	charge_efficiency = 0.2
 
 /obj/item/weapon/stock_parts/cell/secborg/empty
 	init_full = FALSE
@@ -59,6 +77,7 @@
 	origin_tech = "powerstorage=1"
 	maxcharge = 500
 	g_amt = 40
+	charge_efficiency = 0.2
 
 /obj/item/weapon/stock_parts/cell/high
 	name = "high-capacity power cell"
@@ -67,6 +86,7 @@
 	maxcharge = 10000
 	g_amt = 60
 	rating = 3
+	charge_efficiency = 5
 
 /obj/item/weapon/stock_parts/cell/high/empty
 	init_full = FALSE
@@ -78,6 +98,7 @@
 	maxcharge = 20000
 	g_amt = 70
 	rating = 4
+	charge_efficiency = 13.33
 
 /obj/item/weapon/stock_parts/cell/super/empty
 	init_full = FALSE
@@ -89,6 +110,7 @@
 	maxcharge = 30000
 	g_amt = 80
 	rating = 5
+	charge_efficiency = 23
 
 /obj/item/weapon/stock_parts/cell/hyper/empty
 	init_full = FALSE
@@ -100,7 +122,7 @@
 	maxcharge = 40000
 	g_amt = 80
 	rating = 6
-	//chargerate = 4000
+	charge_efficiency = 46
 
 /obj/item/weapon/stock_parts/cell/bluespace/empty
 	init_full = FALSE
@@ -108,10 +130,11 @@
 /obj/item/weapon/stock_parts/cell/infinite
 	name = "infinite-capacity power cell!"
 	icon_state = "icell"
-	origin_tech =  null
+	origin_tech = null
 	maxcharge = 30000
 	g_amt = 80
 	rating = 6
+	charge_efficiency = 80
 
 /obj/item/weapon/stock_parts/cell/infinite/use()
 	return 1
@@ -120,14 +143,15 @@
 	name = "potato battery"
 	desc = "A rechargable starch based power cell."
 	origin_tech = "powerstorage=1"
-	icon = 'icons/obj/power.dmi' //'icons/obj/hydroponics/harvest.dmi'
-	icon_state = "potato_cell" //"potato_battery"
+	icon = 'icons/obj/power.dmi'
+	icon_state = "potato_cell"
 	charge = 100
 	maxcharge = 300
 	m_amt = 0
 	g_amt = 0
 	minor_fault = 1
 	rating = 1
+	charge_efficiency = 0.1
 
 /obj/item/weapon/stock_parts/cell/slime
 	name = "charged slime core"
@@ -139,3 +163,4 @@
 	m_amt = 0
 	g_amt = 0
 	rating = 3
+	charge_efficiency = 23


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Данный PR перерабатывает систему отображения скорости зарядки батарей в зарядных устройствах, а также увеличивать скорость заряда, вот примерные градации скорости

Crap (AA battery) | 500 | 0.1 | ~71 секунд
Secborg | 600 | 0.2 | ~43 секунды
APC | 500 | 0.2 | ~36 секунд
High | 10000 | 5.0 | ~29 секунд
Super | 20000 | 13.33 | ~20 секунд
Hyper | 30000 | 23 | ~17 секунд
Bluespace | 40000 | 46 | ~13 секунд
Potato | 300 | 0.1 |  ~45 секунд
Slime | 10000 | 23 | ~5 секунд

## Почему и что этот ПР улучшит
закрывает https://github.com/TauCetiStation/TauCetiClassic/issues/14166#issuecomment-2990215107

## Авторство

Riverz

## Чеинжлог

:cl:Riverz
- tweak: Теперь зарядка батарей идет гораздо быстрее