### PR TITLE
Множество BPM для одной песни

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -471,3 +471,14 @@
 			return two
 		else
 			return five
+
+/proc/has_multiple_matches(haystack, needle)
+	var/count = 0
+	var/pos = 1
+
+	while(pos && count < 2)
+		pos = findtext(haystack, needle, pos)
+		if(pos)
+			count += 1
+			pos += 1
+	return count > 1

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -25,7 +25,7 @@
 #define DEFAULT_TEMPO    120
 #define DEFAULT_VOLUME   100
 #define MAX_LINE_SIZE    50
-#define MAX_LINES_COUNT  150
+#define MAX_LINES_COUNT  450
 #define MAX_SONG_SIZE    MAX_LINE_SIZE*MAX_LINES_COUNT
 #define MAX_REPEAT_COUNT 10
 #define MAX_TEMPO_RATE   600
@@ -55,8 +55,9 @@ var/global/datum/notes_storage/note_cache_storage = new
 	var/obj/instrument  = null
 	var/sound_path      = ""
 
-	var/list/song_lines = list()
-	var/song_tempo      = DEFAULT_TEMPO
+	var/list/song_lines    = list()
+	var/song_tempo         = DEFAULT_TEMPO
+	var/multiple_tempos    = FALSE
 
 	var/playing   = FALSE
 	var/show_help = FALSE
@@ -96,7 +97,10 @@ var/global/datum/notes_storage/note_cache_storage = new
 		html += "<a href='byond://?src=\ref[src];import=1'>Import a Song</a><br><br>"
 
 		if(song_lines.len)
-			html += "<a href='byond://?src=\ref[src];change_tempo=1'>Tempo: [song_tempo] BPM</a><br><br>"
+			var/tempos_msg = "<a href='byond://?src=\ref[src];change_tempo=1'>Tempo: [song_tempo] BPM</a>"
+			if(multiple_tempos)
+				tempos_msg = "Tempo: [song_tempo] BPM (multiple tempos, edit BPM in the song text)"
+			html += "[tempos_msg]<br><br>"
 
 			html += "<table>"
 			for(var/line_num in 1 to song_lines.len)
@@ -232,6 +236,9 @@ var/global/datum/notes_storage/note_cache_storage = new
 			cur_acc[i] = "n"
 
 		for(var/line in song_lines)
+			// Use new BPM for the songlines
+			if(find_and_set_tempo(line))
+				continue
 			for(var/beat in splittext(lowertext(line), ","))
 
 				// Some browsers may delete last space on line when copying text in buffer,
@@ -298,18 +305,21 @@ var/global/datum/notes_storage/note_cache_storage = new
 
 	var/list/lines = splittext(song_text, "\n")
 
-	if(copytext(lines[1], 1, 5) == "BPM:")
-		song_tempo = clamp(text2num(copytext(lines[1], 5)), 1, MAX_TEMPO_RATE)
+	multiple_tempos = has_multiple_matches(song_text, "BPM:")
+	if(find_and_set_tempo(lines[1]) && !multiple_tempos)
 		lines.Cut(1, 2)
-
-	if(lines.len > MAX_LINES_COUNT)
-		lines.Cut(MAX_LINES_COUNT + 1)
 
 	for(var/line_num in 1 to lines.len)
 		if(length(lines[line_num]) > MAX_LINE_SIZE)
 			lines[line_num] = copytext(lines[line_num], 1, MAX_LINE_SIZE)
 
 	song_lines = lines
+
+/datum/music_player/proc/find_and_set_tempo(song_line)
+	if(copytext(song_line, 1, 5) == "BPM:")
+		song_tempo = clamp(text2num(copytext(song_line, 5)), 1, MAX_TEMPO_RATE)
+		return TRUE
+	return FALSE
 
 #undef COUNT_PAUSE
 #undef DEFAULT_TEMPO


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Раньше БПМ ставился 1 раз на всю песню, но у нашего друга с перьями возникла потребность это число варьировать. Я сделал довольно простую и рабочую реализацию (знаю, что можно лучше). Для старых песен не должно быть никакого влияние, только для новых.

Для изменения BPM нужно просто на новой строчке написать его и все. Поэтому был увеличен лимит строк с 150 до 450. Вроде эффекта на производительность не должно быть, да и Пернатый сказал, что было бы не плохо.

Старое
![image](https://github.com/user-attachments/assets/e16a8b8c-9a8b-4ccd-a13b-3a9984f03c3e)

Новое
![image](https://github.com/user-attachments/assets/2de30876-b517-439e-a016-e09501127a80)


## Почему и что этот ПР улучшит
Больше инструментов сс-миди-творцам

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - tweak: Увеличен лимит строк в одной песне.
 - tweak: В одной песне может быть несколько BPM ритмов

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
