### PR TITLE
low/high pain threshold rework

### DIFF
--- a/code/__DEFINES/quirks.dm
+++ b/code/__DEFINES/quirks.dm
@@ -1,5 +1,6 @@
 /// Quirk names defines. To ease keeping track.
 // positive quirks.
+#define QUIRK_HIGH_PAIN_THRESHOLD "Высокий Болевой Порог"
 #define QUIRK_MULTITASKING "Многозадачность"
 #define QUIRK_CHILD_OF_NATURE "Дитя Природы"
 #define QUIRK_STRONG_MIND "Психологическая Устойчивость"
@@ -11,12 +12,11 @@
 #define QUIRK_HEMOPHILIAC "Гемофилия"
 
 // neutral quirks.
-#define QUIRK_HIGH_PAIN_THRESHOLD "Высокий Болевой Порог"
-#define QUIRK_LOW_PAIN_THRESHOLD "Низкий Болевой Порог"
 #define QUIRK_AGEUSIA "Агевзия"
 #define QUIRK_DALTONISM "Дальтонизм"
 
 // negative quirks.
+#define QUIRK_LOW_PAIN_THRESHOLD "Низкий Болевой Порог"
 #define QUIRK_BLIND "Слепота"
 #define QUIRK_COUGHING "Кашель"
 #define QUIRK_DEAF "Глухота"

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -12,6 +12,10 @@
 		TRAIT_NO_PAIN,
 	)
 
+/datum/quirk/low_pain_threshold/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.mob_halloss_mod.ModMultiplicative(1.3, src)
+
 
 /datum/quirk/blindness
 	name = QUIRK_BLIND

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -1,5 +1,18 @@
 //predominantly negative traits
 
+/datum/quirk/low_pain_threshold
+	name = QUIRK_LOW_PAIN_THRESHOLD
+	desc = "Вы более чувствительны к боли."
+	value = -3
+	mob_trait = TRAIT_LOW_PAIN_THRESHOLD
+	gain_text = "<span class='danger'>Даже небольшие царапины вызывают у вас сильную боль!</span>"
+	lose_text = "<span class='notice'>Ваши болевые рецепторы снова в норме.</span>"
+
+	blacklisted_species_traits = list(
+		TRAIT_NO_PAIN,
+	)
+
+
 /datum/quirk/blindness
 	name = QUIRK_BLIND
 	desc = "Вы абсолютно слепы. Ничто не в силах это изменить."

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -1,31 +1,3 @@
-/datum/quirk/high_pain_threshold
-	name = QUIRK_HIGH_PAIN_THRESHOLD
-	desc = "Ваш болевой порог повышен. Влияет только на издаваемые вами звуки."
-	value = 0
-	mob_trait = TRAIT_HIGH_PAIN_THRESHOLD
-	gain_text = "<span class='danger'>Вы хотите показать свою силу. Вы попытаетесь игнорировать любую боль.</span>"
-	lose_text = "<span class='notice'>Вы устали превозмогать боль.</span>"
-
-	blacklisted_species_traits = list(
-		TRAIT_NO_PAIN,
-	)
-
-
-
-/datum/quirk/low_pain_threshold
-	name = QUIRK_LOW_PAIN_THRESHOLD
-	desc = "Ваш болевой порог понижен. Влияет только на издаваемые вами звуки. "
-	value = 0
-	mob_trait = TRAIT_LOW_PAIN_THRESHOLD
-	gain_text = "<span class='danger'>Вам страшно от одной лишь мысли о боли.</span>"
-	lose_text = "<span class='notice'>Вы больше не хотите выглядеть слабаком. Теперь вы пытаетесь терпеть боль.</span>"
-
-	blacklisted_species_traits = list(
-		TRAIT_NO_PAIN,
-	)
-
-
-
 /datum/quirk/no_taste
 	name = QUIRK_AGEUSIA
 	desc = "Всё для вас одинаково пресно на вкус! Токсичная еда остаётся ядовитой для вас."

--- a/code/datums/quirks/positive.dm
+++ b/code/datums/quirks/positive.dm
@@ -10,6 +10,10 @@
 		TRAIT_NO_PAIN,
 	)
 
+/datum/quirk/high_pain_threshold/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.mob_halloss_mod.ModMultiplicative(0.7, src)
+
 
 /datum/quirk/multitasking
 	name = QUIRK_MULTITASKING

--- a/code/datums/quirks/positive.dm
+++ b/code/datums/quirks/positive.dm
@@ -1,3 +1,16 @@
+/datum/quirk/high_pain_threshold
+	name = QUIRK_HIGH_PAIN_THRESHOLD
+	desc = "Вы менее чувствительны к боли."
+	value = 3
+	mob_trait = TRAIT_HIGH_PAIN_THRESHOLD
+	gain_text = "<span class='green'>Ваши болевые рецепторы притупились.</span>"
+	lose_text = "<span class='notice'>Ваши болевые рецепторы снова в норме.</span>"
+
+	blacklisted_species_traits = list(
+		TRAIT_NO_PAIN,
+	)
+
+
 /datum/quirk/multitasking
 	name = QUIRK_MULTITASKING
 	desc = "Вы можете действовать обеими руками одновременно!"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -3,7 +3,7 @@
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
 
-#define SAVEFILE_VERSION_MAX 54
+#define SAVEFILE_VERSION_MAX 55
 
 //For repetitive updates, should be the same or below SAVEFILE_VERSION_MAX
 //set this to (current SAVEFILE_VERSION_MAX)+1 when you need to update:
@@ -470,9 +470,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		ipc_head = initial(ipc_head)
 		// fuck named hairstyles, we should just move it to indexes
 		var/static/list/ipc_hairstyles_reset = list(
-			"alien IPC screen", 
-			"double IPC screen", 
-			"pillar IPC screen", 
+			"alien IPC screen",
+			"double IPC screen",
+			"pillar IPC screen",
 			"human IPC screen"
 		)
 		if(h_style in ipc_hairstyles_reset)
@@ -526,6 +526,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				s_tone = /datum/skin_tone/dark_brown::name
 			else
 				s_tone = initial(s_tone)
+
+		if(current_version < 55)
+			ResetQuirks()
 
 //
 /datum/preferences/proc/repetitive_updates_character(current_version, savefile/S)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -8,7 +8,7 @@
 //For repetitive updates, should be the same or below SAVEFILE_VERSION_MAX
 //set this to (current SAVEFILE_VERSION_MAX)+1 when you need to update:
 #define SAVEFILE_VERSION_SPECIES_JOBS 51 // job preferences after breaking changes to any /datum/job/
-#define SAVEFILE_VERSION_QUIRKS 30 // quirks preferences after breaking changes to any /datum/quirk/
+#define SAVEFILE_VERSION_QUIRKS 55 // quirks preferences after breaking changes to any /datum/quirk/
 //breaking changes is when you remove any existing quirk/job or change their restrictions
 //Don't forget to bump SAVEFILE_VERSION_MAX too
 
@@ -527,8 +527,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			else
 				s_tone = initial(s_tone)
 
-		if(current_version < 55)
-			ResetQuirks()
 
 //
 /datum/preferences/proc/repetitive_updates_character(current_version, savefile/S)
@@ -549,6 +547,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				popup(parent, "Your character([real_name]) had incompatible quirks on them. This character's quirks have been reset.", "Preferences")
 				ResetQuirks()
 				break
+			if(GetQuirkBalance < 0)
+				ResetQuirks()
 
 /// checks through keybindings for outdated unbound keys and updates them
 /datum/preferences/proc/check_keybindings()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -527,7 +527,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			else
 				s_tone = initial(s_tone)
 
-
 //
 /datum/preferences/proc/repetitive_updates_character(current_version, savefile/S)
 
@@ -547,8 +546,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				popup(parent, "Your character([real_name]) had incompatible quirks on them. This character's quirks have been reset.", "Preferences")
 				ResetQuirks()
 				break
-			if(GetQuirkBalance < 0)
-				ResetQuirks()
+		if(GetQuirkBalance() < 0)
+			ResetQuirks()
 
 /// checks through keybindings for outdated unbound keys and updates them
 /datum/preferences/proc/check_keybindings()

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -17,12 +17,6 @@
 	1.0	* getCloneLoss() + 		\
 	1.0	* halloss
 
-	if(HAS_TRAIT(src, TRAIT_LOW_PAIN_THRESHOLD))
-		traumatic_shock *= 1.3
-
-	else if(HAS_TRAIT(src, TRAIT_HIGH_PAIN_THRESHOLD))
-		traumatic_shock *= 0.7
-
 	// broken or ripped off bodyparts will add quite a bit of pain
 	if(ishuman(src))
 		var/mob/living/carbon/human/M = src
@@ -116,5 +110,11 @@
 		painkiller_effect *= min((DRUNKENNESS_PASS_OUT - drunkenness) / 1000, 1)
 	if(analgesic && !reagents.has_reagent("prismaline"))
 		painkiller_effect = 0
+
+	if(HAS_TRAIT(src, TRAIT_LOW_PAIN_THRESHOLD))
+		painkiller_effect *= 1.3
+
+	else if(HAS_TRAIT(src, TRAIT_HIGH_PAIN_THRESHOLD))
+		painkiller_effect *= 0.7
 
 	return painkiller_effect

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -17,6 +17,12 @@
 	1.0	* getCloneLoss() + 		\
 	1.0	* halloss
 
+	if(HAS_TRAIT(src, TRAIT_LOW_PAIN_THRESHOLD))
+		traumatic_shock *= 1.3
+
+	else if(HAS_TRAIT(src, TRAIT_HIGH_PAIN_THRESHOLD))
+		traumatic_shock *= 0.7
+
 	// broken or ripped off bodyparts will add quite a bit of pain
 	if(ishuman(src))
 		var/mob/living/carbon/human/M = src

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -52,6 +52,7 @@
 	qdel(mob_tox_mod)
 	qdel(mob_clone_mod)
 	qdel(mob_brain_mod)
+	qdel(mob_halloss_mod)
 
 	qdel(mob_general_damage_mod)
 
@@ -408,10 +409,7 @@
 	if(amount > 0 && HAS_TRAIT(src, TRAIT_NO_PAIN))
 		return
 	if(amount > 0)
-		if(HAS_TRAIT(src, TRAIT_LOW_PAIN_THRESHOLD))
-			amount *= 1.3
-		else if(HAS_TRAIT(src, TRAIT_HIGH_PAIN_THRESHOLD))
-			amount *= 0.7
+		amount *= mob_halloss_mod.Get()
 		add_combo_value_all(amount)
 	halloss = clamp(halloss + amount, 0, maxHealth * 2)
 	return amount

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -408,11 +408,11 @@
 	if(amount > 0 && HAS_TRAIT(src, TRAIT_NO_PAIN))
 		return
 	if(amount > 0)
-		add_combo_value_all(amount)
 		if(HAS_TRAIT(src, TRAIT_LOW_PAIN_THRESHOLD))
 			amount *= 1.3
 		else if(HAS_TRAIT(src, TRAIT_HIGH_PAIN_THRESHOLD))
 			amount *= 0.7
+		add_combo_value_all(amount)
 	halloss = clamp(halloss + amount, 0, maxHealth * 2)
 	return amount
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -409,6 +409,10 @@
 		return
 	if(amount > 0)
 		add_combo_value_all(amount)
+		if(HAS_TRAIT(src, TRAIT_LOW_PAIN_THRESHOLD))
+			amount *= 1.3
+		else if(HAS_TRAIT(src, TRAIT_HIGH_PAIN_THRESHOLD))
+			amount *= 0.7
 	halloss = clamp(halloss + amount, 0, maxHealth * 2)
 	return amount
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -21,6 +21,7 @@
 	var/datum/modval/mob_tox_mod = new (base_value = 1)
 	var/datum/modval/mob_clone_mod = new (base_value = 1)
 	var/datum/modval/mob_brain_mod = new (base_value = 1)
+	var/datum/modval/mob_halloss_mod = new (base_value = 1)
 
 	// this used as multiplicative mod of every other damage modval
 	// change it if you want to affect all damage at once


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
 **у всех у кого до мержа этого пра стоял квирк на высокий болевой порог будут сброшены перки**
квирки связанные с болевым порогом более не являются нейтральными и они теперь влияют на чувствительность персонажа к боли (это касается и получаемого голоурона от всяких шокеров и резиновых пуль)
квирк на низкий болевой порог повышает чувствительность персонажа к боли на 30%  и даёт 3 очка.
квирк на высокий болевой порог понижает чувствительно персонажа к боли на 30% и стоит 3 очка.
## Почему и что этот ПР улучшит
квирки которые влияют на геймплей это круто
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- tweak[link]: Особенные черты персонажа (quirks) связанные с болевым порогом получили новые эффекты и теперь являются позитивными или негативными.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
