### PR TITLE
Теперь печати ЦК отоброжаются на приказах от ЦК во время ревы

### DIFF
--- a/code/game/gamemodes/factions/revolution.dm
+++ b/code/game/gamemodes/factions/revolution.dm
@@ -159,16 +159,20 @@
 		last_command_report = 4
 
 /datum/faction/revolution/proc/command_report(message)
-	for (var/obj/machinery/computer/communications/comm in communications_list)
-		if (!(comm.stat & (BROKEN | NOPOWER)) && comm.prints_intercept)
-			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper( comm.loc )
+	var/obj/item/weapon/stamp/centcomm/stamp = new
+
+	for(var/obj/machinery/computer/communications/comm in communications_list)
+		if(!(comm.stat & (BROKEN | NOPOWER)) && comm.prints_intercept)
+			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper(comm.loc)
 			intercept.name = "Cent. Com. Announcement"
 			intercept.info = message
+			stamp.stamp_paper(intercept)
 			intercept.update_icon()
 
 			comm.messagetitle.Add("Cent. Com. Announcement")
 			comm.messagetext.Add(message)
 
+	qdel(stamp)
 	announcement_ping.play()
 
 /datum/faction/revolution/build_scorestat()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В приказах ЦК во время ревы будут печати ЦК
## Почему и что этот ПР улучшит
печать ЦК добавляет официальности и реализма
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - bugfix: В приказах ЦК во время ревы будут печати ЦК