### PR TITLE
Добавлены строки для корректного отображения иконки диска нуклеиновых кислот (GNA disk) в мире

### DIFF
--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -152,6 +152,7 @@
 		burning -= 1
 		if(!burning)
 			var/obj/item/weapon/diseasedisk/d = new /obj/item/weapon/diseasedisk(loc)
+			d.update_world_icon()
 			d.analysed = analysed
 			if(analysed)
 				if (memorybank)

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -152,7 +152,6 @@
 		burning -= 1
 		if(!burning)
 			var/obj/item/weapon/diseasedisk/d = new /obj/item/weapon/diseasedisk(loc)
-			d.update_world_icon()
 			d.analysed = analysed
 			if(analysed)
 				if (memorybank)

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -97,6 +97,8 @@
 	name = "blank GNA disk"
 	icon = 'icons/obj/disks.dmi'
 	icon_state = "datadisk0"
+	item_state_inventory = "datadisk0"
+	item_state_world = "datadisk0_world"
 	var/datum/disease2/effectholder/effect = null
 	var/list/species = null
 	var/stage = 1


### PR DESCRIPTION
## Описание изменений
Добавлена строка для обновления иконки мира.
Добавлена строка отображения иконки предмета в инвентаре.
Добавлена строка отображения иконки предмета в мире.

close https://github.com/TauCetiStation/TauCetiClassic/issues/14231
## Почему и что этот ПР улучшит
Было:
<img width="83" height="224" alt="image" src="https://github.com/user-attachments/assets/79e96ca3-fa9a-4e01-a231-0474e4aaa2cf" />

Стало:
<img width="103" height="142" alt="image" src="https://github.com/user-attachments/assets/b2dbd610-8e9d-4318-b921-a8174753131a" />

## Авторство
RichardJones1 и fukkatsumichanpewpew. Большое спасибо @RichardJones1 за помощь!

## Чеинжлог
:cl: RichardJones1 and fukkatsumichanpewpew
 - bugfix: Исправлено отображение диска нуклеиновых кислот (GNA disk).