### PR TITLE
Увеличиваем область видимости в ширину [WIP]

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -1,3 +1,8 @@
+//Two types of the supported client view
+#define WIDESCREEN_VIEWPORT_SIZE "17x15"
+#define SQUARE_VIEWPORT_SIZE "15x15"
+#define VIEWPORT_USE_PREF "use_pref"
+
 //Preference toggles (it had more bits, but updating player saves without wiping method is a bit more complex).
 #define SHOW_ANIMATIONS	16
 #define SHOW_PROGBAR	32

--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -18,6 +18,9 @@
 #define VOL_LINEAR_TO_NON(vol_raw) ((20 ** clamp(vol_raw * 0.01, 0, 1.0)) - 0.99) / (20 - 0.99) // this converts byond's linear volume into non linear (don't change anything without heavy testing with debug, even 0.01 difference may break the sound or functions that connects with this).
 #define SANITIZE_VOL(vol) vol * 0.5 // environment setting can overload sound that use 100% volume (0.5 actually is max, if you want pure sound with anything).
 
+// default sound range
+#define SOUND_RANGE 17
+
 //sound channels, max is 1024
 #define CHANNEL_AMBIENT 1
 #define CHANNEL_AMBIENT_LOOP 2

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1271,8 +1271,9 @@ var/global/list/WALLITEMS = typecacheof(list(
 	tY = tY[1]
 	tX = splittext(tX[1], ":")
 	tX = tX[1]
-	tX = clamp(origin.x + text2num(tX) - world.view - 1, 1, world.maxx)
-	tY = clamp(origin.y + text2num(tY) - world.view - 1, 1, world.maxy)
+	var/list/actual_view = getviewsize(world.view)
+	tX = clamp(origin.x + text2num(tX) - actual_view[1] - 1, 1, world.maxx)
+	tY = clamp(origin.y + text2num(tY) - actual_view[2] - 1, 1, world.maxy)
 	return locate(tX, tY, tZ)
 
 /proc/screen_loc2turf(text, turf/origin)

--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -1,4 +1,4 @@
-/proc/getviewsize(view)
+/proc/getviewsize(view = world.view)
 	var/viewX
 	var/viewY
 	if(isnum(view))

--- a/code/controllers/subsystem/lag_switch.dm
+++ b/code/controllers/subsystem/lag_switch.dm
@@ -98,7 +98,7 @@ SUBSYSTEM_DEF(lag_switch)
 		if(DISABLE_GHOST_ZOOM)
 			if(state)
 				for(var/mob/user as anything in global.observer_list)
-					user.client?.change_view(world.view)
+					user.client?.view_size?.setDefault(VIEWPORT_USE_PREF)
 				to_chat(observer_list, "<span class='bold notice'>Observer zoom has been disabled.</span>")
 			else
 				to_chat(observer_list, "<span class='bold notice'>Observer zoom has been enabled.</span>")

--- a/code/datums/components/zoom.dm
+++ b/code/datums/components/zoom.dm
@@ -65,7 +65,7 @@
 	UnregisterSignal(zoomer, list(COMSIG_MOB_DIED, COMSIG_PARENT_QDELETING))
 	if(!can_move)
 		UnregisterSignal(zoomer, list(COMSIG_MOVABLE_MOVED))
-	zoomer.client?.change_view(world.view)
+	zoomer.client?.view_size?.setDefault(VIEWPORT_USE_PREF)
 	zoomer.hud_used?.show_hud(HUD_STYLE_STANDARD)
 	zoomer = null
 
@@ -73,7 +73,7 @@
 	SIGNAL_HANDLER
 	zoomer = user
 	zoomer.hud_used?.show_hud(HUD_STYLE_REDUCED)
-	zoomer.client?.change_view(zoom_view_range)
+	zoomer.client?.view_size?.setDefault(zoom_view_range)
 	RegisterSignal(zoomer, list(COMSIG_MOB_DIED, COMSIG_PARENT_QDELETING), PROC_REF(reset_zoom))
 	if(!can_move)
 		RegisterSignal(zoomer, list(COMSIG_MOVABLE_MOVED), PROC_REF(reset_zoom))

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -1,0 +1,37 @@
+///Container for client viewsize
+/datum/view_data
+	/// This client's current "default" view, in the format "WidthxHeight"
+	/// We add/remove from this when we want to change their window size
+	var/default = ""
+	/// The client that owns this view packet
+	var/client/chief = null
+
+/datum/view_data/New(client/owner)
+	chief = owner
+	default = getScreenSize()
+	apply()
+
+/datum/view_data/Destroy()
+	chief = null
+	return ..()
+
+/datum/view_data/proc/setDefault(string)
+	if(string == VIEWPORT_USE_PREF)
+		default = getScreenSize()
+	else
+		default = string
+	apply()
+
+/datum/view_data/proc/getScreenSize()
+	if(chief.prefs.widescreenpref)
+		return WIDESCREEN_VIEWPORT_SIZE
+	return SQUARE_VIEWPORT_SIZE
+
+/datum/view_data/proc/apply()
+	chief?.change_view(getView())
+	if(chief?.prefs.auto_fit_viewport)
+		chief.fit_viewport()
+
+/datum/view_data/proc/getView()
+	var/list/temp = getviewsize(default)
+	return "[temp[1]]x[temp[2]]"

--- a/code/game/gamemodes/modes_gameplays/cult/eminence.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/eminence.dm
@@ -113,7 +113,8 @@
 /mob/camera/eminence/can_use_topic(src_object)
 	if(!client)
 		return STATUS_CLOSE
-	if(get_dist(src_object, src) <= client.view)
+	var/clientviewlist = getviewsize(client.view)
+	if(get_dist(src_object, src) < max(clientviewlist[1], clientviewlist[2]))
 		return STATUS_INTERACTIVE
 
 	return STATUS_CLOSE

--- a/code/game/machinery/build_crane.dm
+++ b/code/game/machinery/build_crane.dm
@@ -80,7 +80,7 @@
 	occupant = user
 	occupant.reset_view(src, force_remote_viewing = TRUE)
 	occupant.client.click_intercept = src
-	occupant.client.change_view(12)
+	occupant.client.view_size?.setDefault("22x20")
 	eject_action.Grant(occupant, src)
 	update_icon()
 
@@ -92,7 +92,7 @@
 	occupant.forceMove(loc)
 	occupant.reset_view(null, force_remote_viewing = FALSE)
 	occupant.client.click_intercept = null
-	occupant.client.change_view(world.view)
+	occupant.client.view_size?.setDefault(VIEWPORT_USE_PREF)
 	eject_action.Remove(occupant)
 	occupant = null
 	update_icon()

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -173,16 +173,16 @@
 		log_message("Toggled zoom mode.")
 		occupant_message("<font color='[src.zoom_mode?"blue":"red"]'>Zoom mode [zoom_mode?"en":"dis"]abled.</font>")
 		if(zoom_mode)
-			occupant.client.change_view(12)
+			occupant.client.view_size?.setDefault("22x20")
 			occupant.playsound_local(null, 'sound/mecha/imag_enh.ogg', VOL_EFFECTS_MASTER, null, FALSE)
 		else
-			occupant.client.change_view(world.view)
+			occupant.client.view_size?.setDefault(VIEWPORT_USE_PREF)
 	return
 
 
 /obj/mecha/combat/marauder/go_out()
 	if(src.occupant && src.occupant.client)
-		occupant.client.change_view(world.view)
+		occupant.client.view_size?.setDefault(VIEWPORT_USE_PREF)
 		src.zoom_mode = FALSE
 	..()
 	return

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -47,7 +47,7 @@ voluminosity = if FALSE, removes the difference between left and right ear.
 	if(!turf_source) // In null space, no one can hear you scream.
 		return
 
-	var/max_distance = (world.view + extrarange) * 3
+	var/max_distance = (SOUND_RANGE + extrarange) * 3
 
 	// Looping through the player list has the added bonus of working for mobs inside containers
 	for (var/P in player_list)
@@ -99,7 +99,7 @@ voluminosity = if FALSE, removes the difference between left and right ear.
 		//sound volume falloff with distance
 		var/distance = get_dist(T, turf_source) * distance_multiplier
 
-		S.volume -= max(distance - world.view, 0) * 2 //multiplicative falloff to add on top of natural audio falloff.
+		S.volume -= max(distance - SOUND_RANGE, 0) * 2 //multiplicative falloff to add on top of natural audio falloff.
 
 		if (S.volume <= 0) // no volume means no sound, early check to save on atmos calls
 			return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -810,7 +810,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	var/viewx = clamp(input("Enter view width (1-127)") as num, 1, 127) * 2 + 1
 	var/viewy = clamp(input("Enter view height (1-127)") as num, 1, 127) * 2 + 1
 
-	change_view("[viewx]x[viewy]")
+	view_size?.setDefault("[viewx]x[viewy]")
 	if(prefs.auto_fit_viewport)
 		fit_viewport()
 

--- a/code/modules/client/character_menu/global.dm
+++ b/code/modules/client/character_menu/global.dm
@@ -55,6 +55,10 @@
 	. += 					"<td><a href='byond://?_src_=prefs;preference=see_looc'><b>[(chat_toggles & CHAT_LOOC) ? "Shown" : "Hidden"]</b></a></td>"
 	. += 				"</tr>"
 	. += 				"<tr>"
+	. += 					"<td width='45%'>Widescreen (Wider view size):</td>"
+	. += 					"<td><a href='byond://?_src_=prefs;preference=widescreenpref'><b>[widescreenpref ? "Enabled" : "Disabled"]</b></a></td>"
+	. += 				"</tr>"
+	. += 				"<tr>"
 	. += 					"<td width='45%'>Parallax (Fancy Space)</td>"
 	. += 					"<td><b><a href='byond://?_src_=prefs;preference=parallaxdown' oncontextmenu='window.location.href=\"byond://?_src_=prefs;preference=parallaxup\";return false;'>"
 	switch (parallax)
@@ -141,7 +145,7 @@
 
 		if("tgui_lock")
 			tgui_lock = !tgui_lock
-		
+
 		if("window_scale")
 			window_scale = !window_scale
 
@@ -188,6 +192,11 @@
 			if(isnewplayer(user))
 				var/mob/dead/new_player/M = user
 				M.show_titlescreen()
+
+		if("widescreenpref")
+			widescreenpref = !widescreenpref
+			if(parent)
+				parent.view_size?.setDefault(VIEWPORT_USE_PREF)
 
 		if("auto_fit_viewport")
 			auto_fit_viewport = !auto_fit_viewport

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -118,6 +118,9 @@
 
 	var/fullscreen = NONE
 
+	// for dealing with client view size
+	var/datum/view_data/view_size
+
 	/// Messages currently seen by this client
 	var/list/seen_messages
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -362,6 +362,12 @@ var/global/list/blacklisted_builds
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
 
+	if(!view_size)
+		view_size = new /datum/view_data(src)
+
+	if(prefs.widescreenpref)
+		view_size?.setDefault(VIEWPORT_USE_PREF)
+
 	if(prefs.auto_fit_viewport)
 		fit_viewport()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -173,6 +173,7 @@ var/global/list/datum/preferences/preferences_datums = list()
 	var/ambientocclusion = TRUE
 	var/auto_fit_viewport = TRUE
 	var/lobbyanimation = FALSE
+	var/widescreenpref = TRUE
 	// lighting settings
 	var/glowlevel = GLOW_MED // or bloom
 	var/lampsexposure = TRUE // idk how we should name it

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -470,9 +470,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		ipc_head = initial(ipc_head)
 		// fuck named hairstyles, we should just move it to indexes
 		var/static/list/ipc_hairstyles_reset = list(
-			"alien IPC screen", 
-			"double IPC screen", 
-			"pillar IPC screen", 
+			"alien IPC screen",
+			"double IPC screen",
+			"pillar IPC screen",
 			"human IPC screen"
 		)
 		if(h_style in ipc_hairstyles_reset)
@@ -625,6 +625,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["eye_blur_effect"]   >> eye_blur_effect
 	S["auto_fit_viewport"] >> auto_fit_viewport
 	S["lobbyanimation"]    >> lobbyanimation
+	S["widescreenpref"]    >> widescreenpref
 	S["tooltip"]           >> tooltip
 	S["tooltip_size"]      >> tooltip_size
 	S["tooltip_font"]      >> tooltip_font
@@ -685,6 +686,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	lampsexposure	= sanitize_integer(lampsexposure, 0, 1, initial(lampsexposure))
 	lampsglare		= sanitize_integer(lampsglare, 0, 1, initial(lampsglare))
 	lobbyanimation	= sanitize_integer(lobbyanimation, 0, 1, initial(lobbyanimation))
+	widescreenpref	= sanitize_integer(widescreenpref, 0, 1, initial(widescreenpref))
 	auto_fit_viewport	= sanitize_integer(auto_fit_viewport, 0, 1, initial(auto_fit_viewport))
 	tooltip = sanitize_integer(tooltip, 0, 1, initial(tooltip))
 	tooltip_size 	= sanitize_integer(tooltip_size, 1, 15, initial(tooltip_size))
@@ -750,6 +752,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["lampsexposure"]     << lampsexposure
 	S["lampsglare"]        << lampsglare
 	S["lobbyanimation"]    << lobbyanimation
+	S["widescreenpref"]    << widescreenpref
 	S["auto_fit_viewport"] << auto_fit_viewport
 	S["tooltip"]           << tooltip
 	S["tooltip_size"]      << tooltip_size

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -735,6 +735,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(SSlag_switch.measures[DISABLE_GHOST_ZOOM])
 		return
 
-	client.change_view("[viewx]x[viewy]")
+	client.view_size?.setDefault("[viewx]x[viewy]")
 	if(client.prefs.auto_fit_viewport)
 		client.fit_viewport()

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -107,7 +107,7 @@
 				H.remove_language(L.name)
 
 	if(!(sdisabilities & DEAF) && !ear_deaf)
-		if (speech_sound && (get_dist(speaker, src) <= world.view && src.z == speaker.z))
+		if (speech_sound && (get_dist(speaker, src) <= SOUND_RANGE && src.z == speaker.z))
 			var/turf/source = speaker? get_turf(speaker) : get_turf(src)
 			playsound_local(source, speech_sound, VOL_EFFECTS_MASTER, sound_vol)
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -94,7 +94,7 @@
 	if(client.click_intercept)
 		client.click_intercept.post_login()
 
-	client.change_view(world.view)
+	client.view_size?.setDefault(VIEWPORT_USE_PREF)
 
 	var/turf/T = get_turf(src)
 	if(T && last_z != T.z)

--- a/code/modules/nano/nanointeraction.dm
+++ b/code/modules/nano/nanointeraction.dm
@@ -41,7 +41,8 @@
 	if(custom_state && (custom_state.flags & NANO_IGNORE_DISTANCE))
 		return STATUS_INTERACTIVE
 	// robots can interact with things they can see within their view range
-	if((src_object in view(src)) && get_dist(src_object, src) <= client.view)
+	var/clientviewlist = getviewsize(client.view)
+	if((src_object in view(src)) && get_dist(src_object, src) <= max(clientviewlist[1], clientviewlist[2]))
 		return STATUS_INTERACTIVE	// interactive (green visibility)
 	return STATUS_DISABLED			// no updates, completely disabled (red visibility)
 
@@ -75,13 +76,14 @@
 		return STATUS_INTERACTIVE
 
 	// If we're installed in a chassi, rather than transfered to an inteliCard or other container, then check if we have camera view
+	var/clientviewlist = getviewsize(client.view)
 	if(is_in_chassis())
 		//stop AIs from leaving windows open and using then after they lose vision
 		//apc_override is needed here because AIs use their own APC when powerless
 		if(cameranet && !cameranet.checkTurfVis(get_turf(src_object)))
 			return apc_override ? STATUS_INTERACTIVE : STATUS_CLOSE
 		return STATUS_INTERACTIVE
-	else if(get_dist(src_object, src) <= client.view)	// View does not return what one would expect while installed in an inteliCard
+	else if(get_dist(src_object, src) <= max(clientviewlist[1], clientviewlist[2]))	// View does not return what one would expect while installed in an inteliCard
 		return STATUS_INTERACTIVE
 
 	return 	STATUS_CLOSE

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -424,7 +424,8 @@
 		if(M.eyecheck() > 0 && dist > 0)
 			continue
 		M.flash_eyes()
-		if(dist < world.view)
+		var/list/actual_view = getviewsize(world.view)
+		if(dist < actual_view[1])
 			var/duration = floor(sqrt(created_volume) / 2) / sqrt(dist + 1)
 			M.Stun(duration)
 			M.Weaken(duration * 1.2)

--- a/code/world.dm
+++ b/code/world.dm
@@ -2,6 +2,6 @@
 	mob = /mob/dead/new_player
 	turf = /turf/environment/space
 	area = /area/space
-	view = "15x15"
+	view = "17x15"
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	fps = 20

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -92,7 +92,7 @@ ALLOW_AI 1
 ## 0 - blocked
 ## 1 - lobby only (for alternative login methods like server password)
 ## 2 - game access
-GUEST_MODE 0
+GUEST_MODE 2
 
 ## Set to jobban everyone who's key is not listed in data/whitelist.txt from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
 ## Uncomment to 1 to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans)

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -321,6 +321,7 @@
 #include "code\datums\spell.dm"
 #include "code\datums\unarmed_attacks.dm"
 #include "code\datums\uplinks_items.dm"
+#include "code\datums\view.dm"
 #include "code\datums\weakrefs.dm"
 #include "code\datums\willpower_effects.dm"
 #include "code\datums\announcements\_announcements.dm"


### PR DESCRIPTION
## Описание изменений
Область видимости на других серверах давно шире, причем на два тайла в ширину.  Вот как это выглядит:

<details>
<summary>
Пример
</summary>

<img width="2559" height="1404" alt="Снимок экрана 2025-07-14 170700" src="https://github.com/user-attachments/assets/7f8490e2-8792-4df6-9fc9-8f4e745edacd" />

</details>

Мне кажется два тайла это слишком, поэтому увеличил на один. Не 19х15, как на тг и прочих, а 17х15

<details>
<summary>
Было
</summary>

<img width="2560" height="1514" alt="image" src="https://github.com/user-attachments/assets/5565a7c8-3e9c-4dc4-b037-e6c981c9250f" />

</details>

<details>
<summary>
Стало
</summary>

<img width="2560" height="1514" alt="image" src="https://github.com/user-attachments/assets/5e5de777-3950-4559-a637-9d4f7bd025fb" />

</details>

Я добавил возможность поменять в настройках персонажа видимость назад на 15х15, для игроков которым это удобнее.

Предлагаю потыкаться в ТМ-е и решить надо ли нам такое

WIP потому что мне нужна помощь понять как позволить гостям заходить за персонажей на локалке. не могу тестить слышимость речи и тд.

## Почему и что этот ПР улучшит
Видим больше всякого на экране! То что говорят люди уже давно есть над куклами.

## Чеинжлог

:cl:
 - tweak: Увеличена область видимости в ширину. Это опциональная настройка, которую можно отключить в Setup Character -> Global.
