### PR TITLE
Фиксит баг с токсинами у скреллов

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -168,6 +168,7 @@
 			. = on_serpentid_digest(M)
 		else
 			return TRUE
+		return .
 
 /datum/reagent/proc/on_skrell_digest(mob/living/M)
 	return TRUE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -168,7 +168,6 @@
 			. = on_serpentid_digest(M)
 		else
 			return TRUE
-	return TRUE
 
 /datum/reagent/proc/on_skrell_digest(mob/living/M)
 	return TRUE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -168,7 +168,7 @@
 			. = on_serpentid_digest(M)
 		else
 			return TRUE
-		return .
+	return .
 
 /datum/reagent/proc/on_skrell_digest(mob/living/M)
 	return TRUE


### PR DESCRIPTION
## Описание изменений
Fixes #14216

На локалке проверял, люди получают toxloss и урон - скреллы нет.

## Чеинжлог

:cl:
 - bugfix: Пофикшен метаболизм у не-хуманов (Иммунитет к токсинам у скреллов, тд.)
