### PR TITLE
Фикс телепортирующих в нуллспейс диспозалов

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -38,7 +38,7 @@
 
 /obj/machinery/disposal/atom_init_late()
 	trunk = locate() in src.loc
-	if(!trunk)
+	if(!checkTrunk())
 		mode = 0
 		flush = 0
 	else
@@ -493,7 +493,7 @@
 	if(wrapcheck == 1)
 		H.tomail = 1
 
-	if(!trunk)
+	if(!checkTrunk())
 		expel(H)
 		return
 
@@ -516,6 +516,13 @@
 	update()	// update icon
 	return
 
+// return TRUE if disposal has a functional trunk underneath
+/obj/machinery/disposal/proc/checkTrunk()
+	if(isnull(trunk) || isnull(trunk.loc))
+		return FALSE
+	if(trunk.loc != loc)
+		return FALSE
+	return TRUE
 
 // called when holder is expelled from a disposal
 // should usually only occur if the pipe network is modified

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -495,11 +495,11 @@
 
 	if(!checkTrunk())
 		expel(H)
-		return
+	else
+		H.start(trunk) // start the holder processing movement
 
 	air_contents = new(PRESSURE_TANK_VOLUME)	// new empty gas resv.
 
-	H.start(trunk) // start the holder processing movement
 	flushing = 0
 	// now reset disposal state
 	flush = 0
@@ -1285,7 +1285,7 @@
 //a trunk joining to a disposal bin or outlet on the same turf
 /obj/structure/disposalpipe/trunk
 	icon_state = "pipe-t"
-	var/obj/linked 	// the linked obj/machinery/disposal or obj/disposaloutlet
+	var/obj/linked 	// the linked obj/machinery/disposal or /obj/structure/disposaloutlet
 
 /obj/structure/disposalpipe/trunk/atom_init()
 	..()
@@ -1294,6 +1294,12 @@
 
 /obj/structure/disposalpipe/trunk/atom_init_late()
 	getlinked()
+
+/obj/structure/disposalpipe/trunk/Destroy()
+	if(istype(linked, /obj/machinery/disposal))
+		var/obj/machinery/disposal/D = linked
+		D.trunk = null
+	. = ..()
 
 /obj/structure/disposalpipe/trunk/proc/getlinked()
 	linked = null

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -558,9 +558,9 @@
 
 	if(!checkTrunk())
 		expel(H)
-		return
+	else
+		H.start(trunk) // start the holder processing movement
 
-	H.start(trunk) // start the holder processing movement
 	flushing = 0
 	// now reset disposal state
 	flush = 0

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -556,7 +556,7 @@
 
 	var/obj/structure/disposalholder/H = new(null, contents, new /datum/gas_mixture)
 
-	if(!trunk)
+	if(!checkTrunk())
 		expel(H)
 		return
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Исправил проверку на наличие трубы под мусоропроводом, Так же добавил в деструктор отвязывание мусоропровода от удаляемой трубы, чтобы не висела ссылка на мёртвый объект.
## Почему и что этот ПР улучшит
fixes #9990 
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: мусорка и воронка отправляли мобов в нуллспейс, если под ними не было трубы
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
