### PR TITLE
Игроки в лобби больше не слышат, как кто-то одевается

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -6,6 +6,7 @@
 	canmove = FALSE
 	anchored = TRUE // don't get pushed around
 	hud_possible = list()
+	ear_deaf = 1000 // so we don't hear unnecessary sounds
 
 	var/ready             = FALSE
 	var/spawning          = FALSE // Referenced when you want to delete the new_player later on in the code.


### PR DESCRIPTION
## Описание изменений
fixes #9949

Любые локал саундс для dead/new_player теперь не слышны. Музыка в лобби все еще слышна.


## Чеинжлог


:cl:
 - bugfix: Игроки в лобби больше не слышат, как кто-то одевается.

