### PR TITLE
Симплмобы больше не спамят в чатик при взаимодействии с объектами.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -66,6 +66,7 @@
 		playsound(loc, 'sound/weapons/slash.ogg', VOL_EFFECTS_MASTER, 100, TRUE)
 
 /obj/attack_animal(mob/living/simple_animal/user)
+	..()
 	if(!user.melee_damage) // TODO obj damage
 		user.me_emote("[user.friendly] [src].")
 		return FALSE

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -18,6 +18,7 @@
 	see_in_dark = 6
 	maxHealth = 15
 	health = 15
+	nutrition = NUTRITION_LEVEL_STARVING
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat = 1)
 	response_help  = "pets the"
 	response_disarm = "gently pushes aside the"
@@ -60,6 +61,8 @@
 			wander = TRUE
 		else if(prob(5))
 			emote("snuffles")
+	if(nutrition > 0 && prob(10))
+		nutrition -= 1
 
 /mob/living/simple_animal/mouse/atom_init()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -198,9 +198,13 @@
 	else if(ismouse(M))
 		var/mob/living/simple_animal/mouse/N = M
 		if(M.layer == MOB_LAYER)
-			N.visible_message("<span class ='notice'><b>[N]</b> nibbles away at [src].</span>", "<span class='notice'>You nibble away at [src].</span>")
-			N.health = min(N.health + 1, N.maxHealth)
-			reagents.remove_any(0.5 * bitesize)
+			if(N.nutrition < NUTRITION_LEVEL_HUNGRY)
+				N.visible_message("<span class ='notice'><b>[N]</b> nibbles away at [src].</span>", "<span class='notice'>You nibble away at [src].</span>")
+				N.health = min(N.health + 1, N.maxHealth)
+				N.nutrition += 0.5 * bitesize
+				reagents.remove_any(0.5 * bitesize)
+			else
+				to_chat(N, "<span class='warning'>You are too full to eat any more, greedy little mouse!</span>")
 			if(reagents.total_volume <= 0)
 				N.visible_message("<span class='notice'><b>[N]</b> just ate \the [src]!</span>", "<span class='notice'>You just ate \the [src], [pick("delicious", "wonderful", "smooth", "disgusting")]!</span>")
 				qdel(src)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -198,7 +198,7 @@
 	else if(ismouse(M))
 		var/mob/living/simple_animal/mouse/N = M
 		if(M.layer == MOB_LAYER)
-			if(N.nutrition < NUTRITION_LEVEL_HUNGRY)
+			if(N.nutrition < 80)
 				N.visible_message("<span class ='notice'><b>[N]</b> nibbles away at [src].</span>", "<span class='notice'>You nibble away at [src].</span>")
 				N.health = min(N.health + 1, N.maxHealth)
 				N.nutrition += 0.5 * bitesize


### PR DESCRIPTION
## Описание изменений

Больше никаких бесконечных "mouse nuzzles at the window" в чате. Кто-то когда-то просто забыл поставить ..()
Плюсом - теперь добавилась анимация.

https://github.com/user-attachments/assets/397ca004-0f98-4c4b-94be-362e99e83e3f

Проходил мимо - добавил мышам ограничение по количеству еды которые они могут скушать. У них теперь есть просто подобие голода.

Fixes #10265

## Чеинжлог

:cl: 
 - bugfix: Мобы больше не спамят в чат при взаимодействии с объектами (nuzzles at ...)
 - tweak: У мышей появилась сытость. Если мышь сыта - она не захочет кушать.

