### PR TITLE
Ботинки клоуна больше не замедляют ходьбу.

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -64,7 +64,6 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN + 1.0
 
 /obj/item/clothing/shoes/clown_shoes/Destroy()
 	if(slot_equipped == SLOT_SHOES)
@@ -74,12 +73,9 @@
 	return ..()
 
 /obj/item/clothing/shoes/clown_shoes/proc/start_waddling(mob/user)
-	if(user.IsClumsy())
-		slowdown = SHOES_SLOWDOWN
 	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_PIXELMOVE))
 
 /obj/item/clothing/shoes/clown_shoes/proc/stop_waddling(mob/user)
-	slowdown = SHOES_SLOWDOWN + 1.0
 	qdel(user.GetComponent(/datum/component/waddle))
 
 /obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)


### PR DESCRIPTION
## Описание изменений

fixes #6978
fixes #10366

## Почему и что этот ПР улучшит

Не понятно зачем вообще эти ботинки должны кого-то замедлять. 

## Чеинжлог

:cl:
 - tweak: Ботинки клоуна больше не замедляют ходьбу.
