### PR TITLE
jobs occupation in lobby

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -68,6 +68,21 @@
 
 			stat("Players:", "[SSticker.totalPlayers]")
 			stat("Players Ready:", "[SSticker.totalPlayersReady]")
+			for(var/datum/job/J as anything in SSjob.active_occupations)
+				var/job_occupations = 0
+				for(var/mob/dead/new_player/player in global.new_player_list)
+					if((player.client == null) || (player.ready != TRUE))
+						continue
+					if((!istype(J, /datum/job/assistant)) && (player.client.prefs.job_preferences["Assistant"] != JP_LOW) && (player.client.prefs.job_preferences[J.title] == JP_HIGH))
+						job_occupations += 1
+					else if(istype(J, /datum/job/assistant) && (player.client.prefs.job_preferences[J.title] == JP_LOW)) // assistant > other jobs
+						job_occupations += 1
+				if(job_occupations >= 1)
+					if(istype(J, /datum/job/assistant))
+						stat("[J.title]", "[job_occupations]/∞")
+					else
+						stat("[J.title]", "[job_occupations]/[J.total_positions]")
+
 
 /mob/dead/new_player/Topic(href, href_list[])
 	if(src != usr || !client)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -78,7 +78,7 @@
 					else if(istype(J, /datum/job/assistant) && (player.client.prefs.job_preferences[J.title] == JP_LOW)) // assistant > other jobs
 						job_occupations += 1
 				if(job_occupations >= 1)
-					if(istype(J, /datum/job/assistant))
+					if(J.total_positions == -1)
 						stat("[J.title]", "[job_occupations]/∞")
 					else
 						stat("[J.title]", "[job_occupations]/[J.total_positions]")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
в лобби, до начала раунда, можно увидеть сколько игроков выставило высокий преф на получение той или иной профки
учитываются только игроки с высоким выставленным приоритетом на профессию и нажатой кнопкой ready

(слева число желающих, справа количество слотов для профы)
<img width="234" height="118" alt="ready1" src="https://github.com/user-attachments/assets/a2f8ece3-0ff4-4a15-ad94-766422435f5a" />

## Почему и что этот ПР улучшит
resolves #14276 
Что это решает:
Игроки и так, на лоупопах (А они теперь у нас постоянные) перестанут задавать вопрос - Кто-то возьмет имя_профессии?
Может уменьшит случаи, когда в раунд. Деклерятся 7 врачей. 1 инженер, 1 км и 1 детектив.
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- experiment: В лобби до начала раунда показывается количество игроков с высоким приоритетом на ту или иную профессию.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
