### PR TITLE
Фиксит блющилд имплант

### DIFF
--- a/code/game/objects/items/weapons/implants/misc.dm
+++ b/code/game/objects/items/weapons/implants/misc.dm
@@ -211,7 +211,7 @@
 	if(!COOLDOWN_FINISHED(src, penalty_cooldown))
 		return
 
-	COOLDOWN_START(src, penalty_cooldown, 5 MINUTES)
+	COOLDOWN_START(src, penalty_cooldown, 4 MINUTES)
 
 	// check if there is any heads on the station
 	// todo: store crew in jobs/departments datums

--- a/code/game/objects/items/weapons/implants/misc.dm
+++ b/code/game/objects/items/weapons/implants/misc.dm
@@ -227,7 +227,7 @@
 		penalty_stack++
 		return
 
-	switch(++penalty_stack)
+	switch(penalty_stack++)
 		if(1)
 			to_chat(implanted_mob, "<span class='bold warning'>Кто-то из глав или АВД должны быть на станции. Следует проверить их, или имплант напомнит о себе.</span>")
 		if(2)

--- a/code/game/objects/items/weapons/implants/misc.dm
+++ b/code/game/objects/items/weapons/implants/misc.dm
@@ -198,7 +198,7 @@
 	UnregisterSignal(implanted_mob, COMSIG_MOB_EXAMINED)
 	. = ..()
 
-/obj/item/weapon/implant/blueshield/proc/on_examine(mob/M)
+/obj/item/weapon/implant/blueshield/proc/on_examine(mob/user, mob/M)
 	if(M.mind && (M.mind.assigned_role in protected_jobs))
 		penalty_stack = 0
 		COOLDOWN_RESET(src, penalty_cooldown)
@@ -222,6 +222,9 @@
 
 	if(!length(to_protect))
 		penalty_stack = 0
+		return
+	if(!penalty_stack) // so we dont immediately go to 1, prevents spamming when examining players
+		penalty_stack++
 		return
 
 	switch(++penalty_stack)


### PR DESCRIPTION
## Описание изменений

Я вам: фикс импланта блющилда. Вы мне: #14240 в ТМ... 😺 

Во первых пофиксил что не работало сбивание penalty_stack  при экзаймене глав (забыли поставить в проке mob/user, в итоге блющилд каждый раз как бы экзайменил себя 😄 )

fixes #14279

Во вторых пока тестил заметил, что при экзамене глав мы сразу же переходим penalty_stack от 0 к 1, и после экзаймена нам в чат сразу пишет ярко красным "идите найдите главу иначе током ударим". 

Пофиксил, добавил стадию с penalty_stack  = 0, на которой ничего не показывается. Чтобы время первого удара сильно не менялось, уменьшил таймер до 4 минут. 
Тем самым первый удар после экзамина:
Был: 5+5=на 10 минуте
Теперь: 4+4+4= на 12 минуте

## Почему и что этот ПР улучшит

Имплант блющилда теперь работает. имплант блющилда не спамит в чат при экзамене глав.

## Чеинжлог


:cl:
 - bugfix: Пофикшена работа импланта блющилд офицера.
 
