### PR TITLE
Фиксит телекристаллы

### DIFF
--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -8,16 +8,18 @@
 	full_w_class = SIZE_SMALL
 	max_amount = 50
 
-/obj/item/stack/telecrystal/attack(atom/target, mob/user, proximity, params)
-	if(isliving(target) && target == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.
-		var/mob/living/L = target
+/obj/item/stack/telecrystal/attack(mob/living/M, mob/user, proximity, params)
+	if(isliving(M) && M == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.
+		var/mob/living/L = M
 		for(var/obj/item/weapon/implant/uplink/I in L.implants)
 			if(I.hidden_uplink)
 				I.hidden_uplink.uses += amount
 				use(amount)
 				to_chat(user, "<span class='notice'>You press [src] onto yourself and charge your hidden uplink.</span>")
+				return
 
-	else if(isitem(target) && proximity)
+/obj/item/stack/telecrystal/afterattack(atom/target, mob/user, proximity, params)
+	if(isitem(target) && proximity)
 		var/obj/item/I = target
 		if(I.hidden_uplink)
 			I.hidden_uplink.uses += amount


### PR DESCRIPTION
## Описание изменений

У нас уже 2 месяца не работают телекристаллы (не впихиваются в аплинк). Заметили только сегодня на нюке.

Вся проблема была в том что мистел волес в #14106 запихнул логику работы кристалла с Аплинком-предметом из afterattack в attack. А этот прок item/attack у нас работает только с mob/living/M а не предметами.

Переписывать item/proc/attack ради этого я не буду, просто вернул как было до ПР-а воласа (логику с тыком по хуману не трогал, все должно работать и так)

## Чеинжлог

:cl:
 - bugfix: Пофикшена работа телекристаллов.

