### PR TITLE
Однорукие больше не стреляют из двуручного оружия

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -79,6 +79,11 @@
 		if(M.get_inactive_hand())
 			to_chat(M, "<span class='notice'>Your other hand must be free before firing! This weapon requires both hands to use.</span>")
 			return FALSE
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(!H.can_use_two_hands())
+				to_chat(M, "<span class='notice'>Both of your hands must be functional to fire this weapon!</span>")
+				return FALSE
 	return TRUE
 
 /obj/item/weapon/gun/proc/shoot_with_empty_chamber(mob/living/user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Больше нельзя стрелять из оружия, требующего две руки, если вторая рука отсутствует, сломана или по иной причине не функционирует.
## Почему и что этот ПР улучшит
fixes #4609
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: из двуручного огнестрела можно было стрелять со сломанной или отсутствующей второй рукой
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
