### PR TITLE
Fix traditional clothes

### DIFF
--- a/code/modules/clothing/suits/alien.dm
+++ b/code/modules/clothing/suits/alien.dm
@@ -6,6 +6,7 @@
 	icon_state = "robe-unathi"
 	item_state = "robe-unathi"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
+	species_restricted = list(UNATHI)
 
 //Taj clothing.
 
@@ -15,8 +16,10 @@
 	icon_state = "zhan_furs"
 	item_state = "zhan_furs"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	species_restricted = list(TAJARAN)
 
 /obj/item/clothing/head/tajaran/scarf
 	name = "headscarf"
 	desc = "A scarf of coarse fabric. Seems to have ear-holes."
 	icon_state = "zhan_scarf"
+	species_restricted = list(TAJARAN)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fixes https://github.com/TauCetiStation/TauCetiClassic/issues/13862
## Почему и что этот ПР улучшит
Теперь никто не посмеет надеть традиционную одежду другой расы.
## Авторство
@Udokun 
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 
- bugfix: Теперь традиционную одежду унатхов и таяран могут надеть только унатхи и таяране.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
