### PR TITLE
Фикс взрывного импланта нюкеров

### DIFF
--- a/code/game/objects/items/weapons/implants/_implant.dm
+++ b/code/game/objects/items/weapons/implants/_implant.dm
@@ -131,7 +131,7 @@
 	if(implanted_mob)
 		RegisterSignal(implanted_mob, COMSIG_MOB_EMOTE, PROC_REF(on_emote), override = TRUE)
 
-/obj/item/weapon/implant/proc/on_emote(emote, intentional)
+/obj/item/weapon/implant/proc/on_emote(mob/user, emote, intentional)
 	SHOULD_CALL_PARENT(TRUE)
 
 	if(!activation_emote || emote != activation_emote)


### PR DESCRIPTION
## Описание изменений

Взрывной имплант нюкеров не работал после рефактора имплантов, причина: `SEND_SIGNAL(src, COMSIG_MOB_EMOTE, act, intentional)` в `emote()` передает `(user, act, intentional)`, а мы в проке `on_emote()` принимали только `(act, intentional)`, изза чего на место act попадал user.

fixes #14322

мерж мерж мерж мерж, на локалке все потестчено