### PR TITLE
фикс возвышенных плувийцев

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -26,9 +26,6 @@
 	P.real_name = dna.real_name
 	P.dna = dna.Clone()
 	P.UpdateAppearance()
-	P.b_eyes = 200
-	P.g_eyes = 255
-	P.r_eyes = 255
 	P.regenerate_icons(update_body_preferences = TRUE)
 	P.my_corpse = src
 	mind.transfer_to(P)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -489,8 +489,6 @@
 	)
 	flags = list(
 	,NO_DNA = TRUE
-	,HAS_SKIN_COLOR = TRUE
-	,HAS_HAIR_COLOR = TRUE
 	,HAS_UNDERWEAR = TRUE
 	)
 	min_age = 25


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл, теперь плувийцы после респавна в раю не негры
## Почему и что этот ПР улучшит
багфикс
## Авторство
я, нашел фатфат
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: maleyvich, FatFat
- bugfix: Возвышенные плувийцы при респавне в раю имели некорректный покрас.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
