### PR TITLE
Fix fat skrell

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -666,6 +666,7 @@
 	eyes_colorable_layer = null
 	eyes_static_layer = "skrell"
 	gender_body_icons = FALSE
+	fat_limb_icons = TRUE
 
 	language = LANGUAGE_SKRELLIAN
 	primitive = /mob/living/carbon/monkey/skrell


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fixes: https://github.com/TauCetiStation/TauCetiClassic/issues/14346
<img width="190" height="183" alt="image" src="https://github.com/user-attachments/assets/ba2109c5-d778-43f1-b6ef-91e5a31367c8" />
<img width="139" height="141" alt="image" src="https://github.com/user-attachments/assets/35a6fdae-66d4-479d-8c8d-8f10b4af1bdc" />

## Почему и что этот ПР улучшит
Спрайты толстых скреллов теперь отображаются нормально

## Авторство
@Udokun 
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
