### PR TITLE
фикс откручивания рояля

### DIFF
--- a/code/modules/musical_instruments/piano.dm
+++ b/code/modules/musical_instruments/piano.dm
@@ -32,6 +32,7 @@
 		if (anchored)
 			to_chat(user, "<span class='notice'>You begin to loosen \the [src]'s casters...</span>")
 			if (O.use_tool(src, user, 40, volume = 50))
+				anchored = !anchored
 				user.visible_message(
 					"<span class='notice'>[user] loosens \the [src]'s casters.</span>",
 					"<span class='notice'>You have loosened \the [src]. Now it can be pulled somewhere else.</span>",
@@ -40,13 +41,12 @@
 		else
 			to_chat(user, "<span class='notice'>You begin to tighten \the [src] to the floor...</span>")
 			if(O.use_tool(src, user, 20, volume = 50))
+				anchored = !anchored
 				user.visible_message(
 					"<span class='notice'>[user] tightens \the [src]'s casters.</span>",
 					"<span class='notice'>You have tightened \the [src]'s casters. Now it can be played again.</span>",
 					"<span class='notice'>You hear ratchet.</span>"
 				)
-
-		anchored = !anchored
 	else
 		..()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
сейчас дуафтер на откручивание влияет ток на то, отобразится сообщение в чатике или нет, а откручивание прокнет даже если прервать его.
## Почему и что этот ПР улучшит
исправляем это
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - fix: Исправлено откручивание рояля.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
