### PR TITLE
исправление абуза таймера смерти после дефибрилляции

### DIFF
--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -398,6 +398,10 @@
 
 	if(IO.heart_status == HEART_FIBR)
 		if(H.stat == DEAD)
+			if((H.health < config.health_threshold_dead) || (H.suiciding))
+				make_announcement("buzzes, \"Defibrillation failed - Patinent's body is too wounded to sustain heart beating.\"")
+				playsound(src, 'sound/items/surgery/defib_failed.ogg', VOL_EFFECTS_MASTER, null, FALSE)
+				return
 			IO.heart_normalize()
 			H.reanimate_body(H)
 			H.stat = UNCONSCIOUS
@@ -411,11 +415,6 @@
 	else
 		H.adjustFireLoss(burn_damage_amt)
 	H.updatehealth()
-
-	if((H.health < config.health_threshold_dead) || (H.suiciding))
-		make_announcement("buzzes, \"Defibrillation failed - Patinent's body is too wounded to sustain heart beating.\"")
-		playsound(src, 'sound/items/surgery/defib_failed.ogg', VOL_EFFECTS_MASTER, null, FALSE)
-		return
 
 	if(wet)
 		var/turf/T = get_turf(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fixes #14365 
проверка не там стояла
## Почему и что этот ПР улучшит
багфикс
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
 - bugfix: Дефибриллятором можно было вечно сбрасывать таймер смерти.

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
-->
