### PR TITLE
небольшие изменения в аспекте на крутую охрану

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -21,7 +21,8 @@
 
 /datum/outfit/job/hos/pre_equip(mob/living/carbon/human/H)
 	if(HAS_ROUND_ASPECT(ROUND_ASPECT_HF_AGENT))
-		implants += /obj/item/weapon/implant/obedience
+		l_ear = /obj/item/device/radio/headset/headset_sec/nt_pmc/hos
+
 
 // WARDEN OUTFIT
 /datum/outfit/job/warden
@@ -91,7 +92,6 @@
 
 /datum/outfit/job/officer/pre_equip(mob/living/carbon/human/H)
 	if(HAS_ROUND_ASPECT(ROUND_ASPECT_ELITE_SECURITY))
-		implants += /obj/item/weapon/implant/mind_protect/loyalty
 		implants += /obj/item/weapon/implant/dexplosive
 		uniform = /obj/item/clothing/under/syndicate
 		uniform_f = /obj/item/clothing/under/syndicate

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -21,7 +21,10 @@
 
 /datum/outfit/job/hos/pre_equip(mob/living/carbon/human/H)
 	if(HAS_ROUND_ASPECT(ROUND_ASPECT_HF_AGENT))
+		implants += /obj/item/weapon/implant/obedience
+	if(HAS_ROUND_ASPECT(ROUND_ASPECT_ELITE_SECURITY))
 		l_ear = /obj/item/device/radio/headset/headset_sec/nt_pmc/hos
+
 
 
 // WARDEN OUTFIT

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -165,6 +165,9 @@
 	icon_state = "nt_pmc_earset"
 	item_state = "nt_pmc_earset"
 
+/obj/item/device/radio/headset/headset_sec/nt_pmc/hos
+	ks2type = /obj/item/device/encryptionkey/heads/hos
+
 /obj/item/device/radio/headset/headset_sec/marinad
 	name = "marine headset"
 	icon_state = "marinad"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
хосу теперь тож выдаются крутые тактикульные наушники, имплант подчинения удалён
у офиков теперь нет импланта лояльности
## Почему и что этот ПР улучшит
на худах офицеры выглядят как гирлянда, в целом автор первоначальной идеи не против этого дела потому-что "не очень то и хорошо заставлять людей отыгрывать лояльность если они не хотят", в чём я и соглашусь
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- tweak: При аспекте на усиленное СБ, офицеры не получают имплант лояльности. ГСБ получает крутые тактикульные наушники, как и свои подчинённые
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
