### PR TITLE
Eventmaker flags button add

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -71,6 +71,7 @@ var/global/list/admin_cooldowns_list = list(
 #define R_HOST			65535
 
 #define ADMIN_RANK_ROUND   "Temporary Round Admin"
+#define ADMIN_RANK_EVENT_MAKER "Event Maker"
 #define ADMIN_RANK_SANDBOX "Sandbox Admin"
 #define ADMIN_RANK_REMOVED "Removed"
 

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -335,42 +335,24 @@ var elements = document.getElementsByName('rights');
 			log_query.Execute()
 			to_chat(usr, "<span class='notice'>Admin rank changed.</span>")
 
-/client/proc/add_round_admin()
-	set category = "Admin"
-	set name = "Round Admin / Event Maker"
-	set desc = "Add or remove temporary admin"
-
+/client/proc/add_temp_admin(rank, flags)
 	if(!check_rights(R_PERMISSIONS))
 		return
 
-	var/client/target = input("Select client to add (or remove) [ADMIN_RANK_ROUND]/[ADMIN_RANK_EVENT_MAKER] rank for the duration of the round.") as null|anything in clients
-
+	var/client/target = input("Select client to add/remove [rank] for the duration of the round.") as null|anything in clients
 	if(!target)
 		return
 
 	if(!target.holder)
-		var/confirm = tgui_alert(usr, "Choose rank to give.", "Confirmation", list("Round Admin", "Event Maker", "Return"))
-		if (confirm == "Round Admin")
-			new /datum/admins(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN), target.ckey)
-			target.holder = admin_datums[target.ckey]
-			target.holder.associate(target)
+		new /datum/admins(rank, flags, target.ckey)
+		target.holder = admin_datums[target.ckey]
+		target.holder.associate(target)
 
-			message_admins("[key_name_admin(usr)] added [key_name_admin(target)] to the admins list as [ADMIN_RANK_ROUND]")
-			log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_ROUND]")
+		message_admins("[key_name_admin(usr)] added [key_name_admin(target)] to the admins list as [rank]")
+		log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [rank]")
 
-		if (confirm == "Event Maker")
-			new /datum/admins(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE), target.ckey)
-			target.holder = admin_datums[target.ckey]
-			target.holder.associate(target)
-
-			message_admins("[key_name_admin(usr)] added [key_name_admin(target)] to the admins list as [ADMIN_RANK_EVENT_MAKER]")
-			log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_EVENT_MAKER]")
-
-		if (confirm == "Return")
-			return
-
-	else if(target.holder && target.holder.rank == ADMIN_RANK_ROUND || ADMIN_RANK_EVENT_MAKER)
-		var/confirm = tgui_alert(usr, "You want to remove temporary permissions from [target.ckey], are you sure?", "Confirmation", list("Yes", "No"))
+	else if(target.holder && target.holder.rank == rank)
+		var/confirm = tgui_alert(usr, "Remove temporary permissions from [target.ckey]?", "Confirmation", list("Yes", "No"))
 		if (confirm != "Yes")
 			return
 
@@ -378,7 +360,22 @@ var elements = document.getElementsByName('rights');
 		admin_datums -= target.ckey
 		D.disassociate()
 
-		message_admins("[key_name_admin(usr)] temporary permissions from [target.ckey]")
+		message_admins("[key_name_admin(usr)] removed temporary permissions from [target.ckey]")
 		log_admin("[key_name(usr)] removed temporary permissions from [target.ckey]")
 	else
 		to_chat(usr, "<span class='alert'>Wrong client!</span>")
+
+/client/proc/add_round_admin()
+	set category = "Admin"
+	set name = "Round Admin / Event Maker"
+	set desc = "Add or remove temporary admin"
+
+	var/choice = tgui_alert(usr, "Choose rank to give.", "Confirmation", list(ADMIN_RANK_ROUND, ADMIN_RANK_EVENT_MAKER, "Return"))
+	if(choice == "Return" || !choice)
+		return
+
+	switch(choice)
+		if("Round Admin")
+			add_temp_admin(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN), ADMIN_RANK_ROUND)
+		if("Event Maker")
+			add_temp_admin(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE), ADMIN_RANK_EVENT_MAKER)

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -337,35 +337,34 @@ var elements = document.getElementsByName('rights');
 
 /client/proc/add_round_admin()
 	set category = "Admin"
-	set name = "Round Admin"
+	set name = "Round Admin / Event Maker"
 	set desc = "Add or remove temporary admin"
 
 	if(!check_rights(R_PERMISSIONS))
 		return
 
-	var/client/target = input("Select client to add (or remove) [ADMIN_RANK_ROUND] rank for the duration of the round.") as null|anything in clients
+	var/client/target = input("Select client to add (or remove) [ADMIN_RANK_ROUND]/[ADMIN_RANK_EVENT_MAKER] rank for the duration of the round.") as null|anything in clients
 
 	if(!target)
 		return
 
-	if(!target.hub_authenticated)
-		to_chat(usr, "<span class='alert'>Client is not authorized through the hub!</span>")
-		return
-
 	if(!target.holder)
-		var/confirm = tgui_alert(usr, "You want to grant permissions for [target.ckey], are you sure?", "Confirmation", list("Yes", "No"))
-		if (confirm != "Yes")
-			return
+		var/confirm = tgui_alert(usr, "Choose rank to give.", "Confirmation", list("Round Admin", "Event Maker"))
+		if (confirm == "Round Admin")
+			new /datum/admins(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE), target.ckey)
+			target.holder = admin_datums[target.ckey]
+			target.holder.associate(target)
 
-		new /datum/admins(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN), target.ckey)
-		target.holder = admin_datums[target.ckey]
-		target.holder.associate(target)
+		if (confirm == "Event Maker")
+			new /datum/admins(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN), target.ckey)
+			target.holder = admin_datums[target.ckey]
+			target.holder.associate(target)
 
 		message_admins("[key_name_admin(usr)] added [key_name_admin(target)] to the admins list as [ADMIN_RANK_ROUND]")
 		log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_ROUND]")
 
-	else if(target.holder && target.holder.rank == ADMIN_RANK_ROUND)
-		var/confirm = tgui_alert(usr, "You want to remove [ADMIN_RANK_ROUND] permissions from [target.ckey], are you sure?", "Confirmation", list("Yes", "No"))
+	else if(target.holder && target.holder.rank == ADMIN_RANK_ROUND || ADMIN_RANK_EVENT_MAKER)
+		var/confirm = tgui_alert(usr, "You want to remove temporary permissions from [target.ckey], are you sure?", "Confirmation", list("Yes", "No"))
 		if (confirm != "Yes")
 			return
 

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -375,7 +375,7 @@ var elements = document.getElementsByName('rights');
 		return
 
 	switch(choice)
-		if("Round Admin")
+		if(ADMIN_RANK_ROUND)
 			add_temp_admin(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN))
-		if("Event Maker")
+		if(ADMIN_RANK_EVENT_MAKER)
 			add_temp_admin(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE))

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -376,6 +376,6 @@ var elements = document.getElementsByName('rights');
 
 	switch(choice)
 		if("Round Admin")
-			add_temp_admin(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN), ADMIN_RANK_ROUND)
+			add_temp_admin(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN))
 		if("Event Maker")
-			add_temp_admin(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE), ADMIN_RANK_EVENT_MAKER)
+			add_temp_admin(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE))

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -351,7 +351,7 @@ var elements = document.getElementsByName('rights');
 	if(!target.holder)
 		var/confirm = tgui_alert(usr, "Choose rank to give.", "Confirmation", list("Round Admin", "Event Maker", "Return"))
 		if (confirm == "Round Admin")
-			new /datum/admins(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE), target.ckey)
+			new /datum/admins(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN), target.ckey)
 			target.holder = admin_datums[target.ckey]
 			target.holder.associate(target)
 
@@ -359,7 +359,7 @@ var elements = document.getElementsByName('rights');
 			log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_ROUND]")
 
 		if (confirm == "Event Maker")
-			new /datum/admins(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN), target.ckey)
+			new /datum/admins(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE), target.ckey)
 			target.holder = admin_datums[target.ckey]
 			target.holder.associate(target)
 
@@ -378,7 +378,7 @@ var elements = document.getElementsByName('rights');
 		admin_datums -= target.ckey
 		D.disassociate()
 
-		message_admins("[key_name_admin(usr)] temporary permissions from [target.ckey] from the admins list")
+		message_admins("[key_name_admin(usr)] temporary permissions from [target.ckey]")
 		log_admin("[key_name(usr)] removed temporary permissions from [target.ckey]")
 	else
 		to_chat(usr, "<span class='alert'>Wrong client!</span>")

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -349,19 +349,25 @@ var elements = document.getElementsByName('rights');
 		return
 
 	if(!target.holder)
-		var/confirm = tgui_alert(usr, "Choose rank to give.", "Confirmation", list("Round Admin", "Event Maker"))
+		var/confirm = tgui_alert(usr, "Choose rank to give.", "Confirmation", list("Round Admin", "Event Maker", "Return"))
 		if (confirm == "Round Admin")
 			new /datum/admins(ADMIN_RANK_ROUND, (R_ADMIN | R_BAN | R_FUN | R_EVENT | R_SPAWN | R_BUILDMODE | R_SERVER | R_REJUVINATE), target.ckey)
 			target.holder = admin_datums[target.ckey]
 			target.holder.associate(target)
+
+			message_admins("[key_name_admin(usr)] added [key_name_admin(target)] to the admins list as [ADMIN_RANK_ROUND]")
+			log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_ROUND]")
 
 		if (confirm == "Event Maker")
 			new /datum/admins(ADMIN_RANK_EVENT_MAKER, (R_ADMIN | R_BAN), target.ckey)
 			target.holder = admin_datums[target.ckey]
 			target.holder.associate(target)
 
-		message_admins("[key_name_admin(usr)] added [key_name_admin(target)] to the admins list as [ADMIN_RANK_ROUND]")
-		log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_ROUND]")
+			message_admins("[key_name_admin(usr)] added [key_name_admin(target)] to the admins list as [ADMIN_RANK_EVENT_MAKER]")
+			log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_EVENT_MAKER]")
+
+		if (confirm == "Return")
+			return
 
 	else if(target.holder && target.holder.rank == ADMIN_RANK_ROUND || ADMIN_RANK_EVENT_MAKER)
 		var/confirm = tgui_alert(usr, "You want to remove temporary permissions from [target.ckey], are you sure?", "Confirmation", list("Yes", "No"))
@@ -372,7 +378,7 @@ var elements = document.getElementsByName('rights');
 		admin_datums -= target.ckey
 		D.disassociate()
 
-		message_admins("[key_name_admin(usr)] removed [ADMIN_RANK_ROUND] [key_name_admin(target)] from the admins list")
-		log_admin("[key_name(usr)] removed [ADMIN_RANK_ROUND] [key_name(target)] from the admins list")
+		message_admins("[key_name_admin(usr)] temporary permissions from [target.ckey] from the admins list")
+		log_admin("[key_name(usr)] removed temporary permissions from [target.ckey]")
 	else
 		to_chat(usr, "<span class='alert'>Wrong client!</span>")

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -360,8 +360,8 @@ var elements = document.getElementsByName('rights');
 		admin_datums -= target.ckey
 		D.disassociate()
 
-		message_admins("[key_name_admin(usr)] removed temporary permissions from [target.ckey]")
-		log_admin("[key_name(usr)] removed temporary permissions from [target.ckey]")
+		message_admins("[key_name_admin(usr)] removed temporary permissions ([rank]) from [target.ckey]")
+		log_admin("[key_name(usr)] removed temporary permissions ([rank]) from [target.ckey]")
 	else
 		to_chat(usr, "<span class='alert'>Wrong client!</span>")
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Добавлена кнопка для выдачи прав ивент мейкера на раунд

## Почему и что этот ПР улучшит

Можно быстро выдать права для ивент мейкера на раунд

## Авторство

@maleyvich @L4rever 

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

- rscadd: Добавлена кнопка для выдачи прав ивент мейкера на раунд

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
