### PR TITLE
Убирание смещений у игральных карт.

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1398,7 +1398,6 @@ Owl & Griffin toys
 	var/cardname = null
 	var/obj/item/toy/cards/parentdeck = null
 	var/flipped = 0
-	pixel_x = -5
 
 /obj/item/toy/singlecard/examine(mob/user)
 	..()


### PR DESCRIPTION
## Описание изменений
Игральные карты при переворачивании больше не двигаются влево-вправо, что часто на самом деле больше мешало игре, чем помогало.

## Почему и что этот ПР улучшит
Карты перестанут двигаться туда-сюда при перевороте.

## Авторство
AndreyGysev

## Чеинжлог
:cl: AndreyGysev
 - tweak: Игральные карты больше не двигаются влево-вправо при переворотах. Проще играть в покер и пр. игры через альтклик по карте.
