### PR TITLE
Добавляет возможность делать флафф для в меру упитанных персонажей.

### DIFF
--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -22,11 +22,13 @@
 #define FLUFF_TYPE_LABCOAT "labcoat"
 #define FLUFF_TYPE_BACKPACK "backpack"
 #define FLUFF_TYPE_TIE  "tie"
+#define FLUFF_TYPE_BEDSHEET "bedsheet"
+#define FLUFF_TYPE_HOODED "hooded"
 // other
 //#define FLUFF_TYPE_ROBOT "robot"
 #define FLUFF_TYPE_GHOST "ghost"
 
-#define FLUFF_TYPES_LIST list(FLUFF_TYPE_NORMAL, FLUFF_TYPE_SMALL, FLUFF_TYPE_LIGHTER, FLUFF_TYPE_HAT, FLUFF_TYPE_UNIFORM, FLUFF_TYPE_SUIT, FLUFF_TYPE_MASK, FLUFF_TYPE_GLASSES, FLUFF_TYPE_GLOVES, FLUFF_TYPE_SHOES, FLUFF_TYPE_ACCESSORY, FLUFF_TYPE_LABCOAT, FLUFF_TYPE_BACKPACK, FLUFF_TYPE_GHOST, FLUFF_TYPE_TIE)
+#define FLUFF_TYPES_LIST list(FLUFF_TYPE_NORMAL, FLUFF_TYPE_SMALL, FLUFF_TYPE_LIGHTER, FLUFF_TYPE_HAT, FLUFF_TYPE_UNIFORM, FLUFF_TYPE_SUIT, FLUFF_TYPE_MASK, FLUFF_TYPE_GLASSES, FLUFF_TYPE_GLOVES, FLUFF_TYPE_SHOES, FLUFF_TYPE_ACCESSORY, FLUFF_TYPE_LABCOAT, FLUFF_TYPE_BACKPACK, FLUFF_TYPE_GHOST, FLUFF_TYPE_TIE, FLUFF_TYPE_BEDSHEET, FLUFF_TYPE_HOODED)
 
 
 /obj/item/customitem
@@ -75,6 +77,18 @@
 
 /obj/item/clothing/neck/custom
 	name = "Custom tie"
+
+/obj/item/weapon/bedsheet/custom
+	name = "Custom bedsheet"
+
+/obj/item/clothing/suit/hooded/custom
+	name = "Custom hooded"
+	hoodtype = /obj/item/clothing/head/customhood
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+
+/obj/item/clothing/head/customhood
+	name = "Custom hood"
+	render_flags = parent_type::render_flags | HIDE_TOP_HAIR
 
 /datum/custom_item
 	var/item_type // FLUFF_TYPES_LIST
@@ -272,9 +286,15 @@
 			if(FLUFF_TYPE_HAT)
 				item = new /obj/item/clothing/head/custom()
 			if(FLUFF_TYPE_UNIFORM)
-				item = new /obj/item/clothing/under/custom()
+				var/obj/item/clothing/under/custom/U = new /obj/item/clothing/under/custom()
+				if("[custom_item_info.icon_state]_mob_fat" in icon_states(custom_item_info.icon))
+					U.flags |= ONESIZEFITSALL
+				item = U
 			if(FLUFF_TYPE_SUIT)
-				item = new /obj/item/clothing/suit/custom()
+				var/obj/item/clothing/suit/custom/S = new /obj/item/clothing/suit/custom()
+				if("[custom_item_info.icon_state]_mob_fat" in icon_states(custom_item_info.icon))
+					S.flags |= ONESIZEFITSALL
+				item = S
 			if(FLUFF_TYPE_MASK)
 				item = new /obj/item/clothing/mask/custom()
 			if(FLUFF_TYPE_GLASSES)
@@ -297,6 +317,18 @@
 					labcoat.can_button_up = FALSE
 				labcoat.base_icon_state = custom_item_info.icon_state
 				item = labcoat
+			if(FLUFF_TYPE_BEDSHEET)
+				item = new /obj/item/weapon/bedsheet/custom()
+			if(FLUFF_TYPE_HOODED)
+				var/obj/item/clothing/suit/hooded/custom/hooded = new /obj/item/clothing/suit/hooded/custom()
+				if(hooded.hood)
+					hooded.hood.icon_custom = custom_item_info.icon
+					hooded.hood.icon_state = "[custom_item_info.icon_state]_hood"
+					hooded.hood.item_state = "[custom_item_info.icon_state]_hood_mob"
+				hooded.icon_suit_up = "[custom_item_info.icon_state]_t"
+				if("[custom_item_info.icon_state]_mob_fat" in icon_states(custom_item_info.icon))
+					hooded.flags |= ONESIZEFITSALL
+				item = hooded
 
 		if(!item)
 			continue
@@ -308,6 +340,9 @@
 		item.icon_custom = custom_item_info.icon
 		item.icon_state = custom_item_info.icon_state
 		item.item_state = custom_item_info.icon_state
+		if("[custom_item_info.icon_state]_w" in icon_states(custom_item_info.icon))
+			item.item_state_inventory = custom_item_info.icon_state
+			item.item_state_world = "[custom_item_info.icon_state]_w"
 
 		switch(custom_item_info.hair_flags)
 			if(FLUFF_HAIR_HIDE_HEAD)

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -23,12 +23,11 @@
 #define FLUFF_TYPE_BACKPACK "backpack"
 #define FLUFF_TYPE_TIE  "tie"
 #define FLUFF_TYPE_BEDSHEET "bedsheet"
-#define FLUFF_TYPE_HOODED "hooded"
 // other
 //#define FLUFF_TYPE_ROBOT "robot"
 #define FLUFF_TYPE_GHOST "ghost"
 
-#define FLUFF_TYPES_LIST list(FLUFF_TYPE_NORMAL, FLUFF_TYPE_SMALL, FLUFF_TYPE_LIGHTER, FLUFF_TYPE_HAT, FLUFF_TYPE_UNIFORM, FLUFF_TYPE_SUIT, FLUFF_TYPE_MASK, FLUFF_TYPE_GLASSES, FLUFF_TYPE_GLOVES, FLUFF_TYPE_SHOES, FLUFF_TYPE_ACCESSORY, FLUFF_TYPE_LABCOAT, FLUFF_TYPE_BACKPACK, FLUFF_TYPE_GHOST, FLUFF_TYPE_TIE, FLUFF_TYPE_BEDSHEET, FLUFF_TYPE_HOODED)
+#define FLUFF_TYPES_LIST list(FLUFF_TYPE_NORMAL, FLUFF_TYPE_SMALL, FLUFF_TYPE_LIGHTER, FLUFF_TYPE_HAT, FLUFF_TYPE_UNIFORM, FLUFF_TYPE_SUIT, FLUFF_TYPE_MASK, FLUFF_TYPE_GLASSES, FLUFF_TYPE_GLOVES, FLUFF_TYPE_SHOES, FLUFF_TYPE_ACCESSORY, FLUFF_TYPE_LABCOAT, FLUFF_TYPE_BACKPACK, FLUFF_TYPE_GHOST, FLUFF_TYPE_TIE, FLUFF_TYPE_BEDSHEET)
 
 
 /obj/item/customitem
@@ -80,15 +79,6 @@
 
 /obj/item/weapon/bedsheet/custom
 	name = "Custom bedsheet"
-
-/obj/item/clothing/suit/hooded/custom
-	name = "Custom hooded"
-	hoodtype = /obj/item/clothing/head/customhood
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-
-/obj/item/clothing/head/customhood
-	name = "Custom hood"
-	render_flags = parent_type::render_flags | HIDE_TOP_HAIR
 
 /datum/custom_item
 	var/item_type // FLUFF_TYPES_LIST
@@ -319,16 +309,6 @@
 				item = labcoat
 			if(FLUFF_TYPE_BEDSHEET)
 				item = new /obj/item/weapon/bedsheet/custom()
-			if(FLUFF_TYPE_HOODED)
-				var/obj/item/clothing/suit/hooded/custom/hooded = new /obj/item/clothing/suit/hooded/custom()
-				if(hooded.hood)
-					hooded.hood.icon_custom = custom_item_info.icon
-					hooded.hood.icon_state = "[custom_item_info.icon_state]_hood"
-					hooded.hood.item_state = "[custom_item_info.icon_state]_hood_mob"
-				hooded.icon_suit_up = "[custom_item_info.icon_state]_t"
-				if("[custom_item_info.icon_state]_mob_fat" in icon_states(custom_item_info.icon))
-					hooded.flags |= ONESIZEFITSALL
-				item = hooded
 
 		if(!item)
 			continue

--- a/code/modules/fluff/fluffmenu.dm
+++ b/code/modules/fluff/fluffmenu.dm
@@ -327,7 +327,7 @@ var/global/list/editing_item_oldname_list = list()
 		if(icon_states.len == 0)
 			to_chat(user, "This icon has no states")
 			return
-		if(icon_states.len > 6)
+		if(icon_states.len > 12)
 			to_chat(user, "This icon has too many states")
 			return
 		if(I.Width() != 32 || I.Height() != 32)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -115,6 +115,8 @@ Please contact me on #coderbus IRC. ~Carn x
 	if(icon_custom)
 		if(sprite_sheet_slot != SPRITE_SHEET_HELD)
 			icon_state_appendix = "_mob"
+			if(sprite_sheet_slot == SPRITE_SHEET_UNIFORM_FAT || sprite_sheet_slot == SPRITE_SHEET_SUIT_FAT)
+				icon_state_appendix = "_mob_fat"
 		icon_path = icon_custom
 	else if(icon_override)
 		icon_path = icon_override


### PR DESCRIPTION
## Описание изменений

Готовимся к хэлоуину. 

 * Во флаффные униформы и suits можно добавлять icon_state "название_mob_fat", при наличии которого флафф будет автоматически доступен толстым.
 
 * Добавил простыни в флафф, за код и идею спасибо Пермяку!
 
 * Добавил возможность добавлять флаффу инворлд иконки, просто добавив в файл "название_w"

## Почему и что этот ПР улучшит

Больше кастомизации флафф предметов, особенно актуально перед конкурсом костюмов!

## Авторство



## Чеинжлог

:cl: Richard Jones & Permyack
 - tweak: Для кастомизированной одежды (флафф) теперь можно добавить "толстую" версию спрайта, добавив в файл "название_mob_fat". Подробнее читайте на вики в статье Fluff!
 - tweak: Для кастомизированной одежды (флафф) теперь можно выбирать иконку "в мире", добавив в файл "название_w".
 - tweak: Добавлена возможность получить кастомизированный предмет-простыню.
 