### PR TITLE
Снижает шанс спавна котика рантайма

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -66,7 +66,7 @@ var/global/total_runtimes_skipped = 0
 			usrinfo += "  usr.loc: [locinfo]"
 			// Create a Dusty at the runtime location
 			var/static/cat_teleport = 0.0
-			if(usr.loc && prob(5) && (world.time - cat_teleport > CAT_COOLDOWN) && (cat_number < CAT_MAX_NUMBER)) // Avoid runtime spam spawning lots of Dusty
+			if(usr.loc && prob(5) && (world.time - cat_teleport > CAT_COOLDOWN) && (cat_number < CAT_MAX_NUMBER)) // Avoid runtime spam spawning lots of ~~Dusty~~ Runtimes
 				new /mob/living/simple_animal/cat/runtime(get_turf(usr), E.line)
 				cat_teleport = world.time
 


### PR DESCRIPTION
## Описание изменений

Часто слишком стал видеть этого котика, и он иногда ломает атмосферу ХАЙ ЭРПЭ.

Пока что предлагаю снизить вдвое шанс появления, пока не расчистим хоть какое то норм количество рантаймов.

<s>Эх а вот бы доступ к логам рантаймов было бы так удобно их фиксить эх</s>