### PR TITLE
Фиксит спрайт маленьких аптечек

### DIFF
--- a/code/game/objects/items/weapons/medical.dm
+++ b/code/game/objects/items/weapons/medical.dm
@@ -33,6 +33,9 @@
 	new /obj/item/stack/medical/suture(src)
 	new /obj/item/device/healthanalyzer(src)
 
+/obj/item/weapon/storage/firstaid/small_firstaid_kit
+	item_state_world = null
+
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/combat
 	name = "Combat first-aid small kit"
 	icon_state = "first_aid_kit_com"


### PR DESCRIPTION
## Описание изменений
Когда делали респрайт аптечек, маленьким не нарисовали inworld иконки, но они унаследовали неправильную от родителя. Легко исправляем этот казус.

## Чеинжлог

:cl:
 - image: Исправлено отображение маленьких аптечек.

