### PR TITLE
Fixes smoked door electronics

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1188,6 +1188,7 @@ var/global/list/airlock_overlays = list()
 
 	if(operating == -1)
 		ae.icon_state = "door_electronics_smoked"
+		ae.item_state_inventory = "door_electronics_smoked"
 		ae.item_state_world = "door_electronics_smoked_w"
 		ae.broken = TRUE
 		operating = 0

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -3,6 +3,7 @@
 	desc = "Looks like a circuit. Probably is."
 	icon = 'icons/obj/doors/door_electronics.dmi'
 	icon_state = "door_electronics"
+	item_state_inventory = "door_electronics"
 	item_state_world = "door_electronics_w"
 	w_class = SIZE_TINY
 	m_amt = 50

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -88,6 +88,7 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/door/window, windowdoor_list)
 		ae.unres_sides = unres_sides
 		if(operating == -1)
 			ae.icon_state = "door_electronics_smoked"
+			ae.item_state_inventory = "door_electronics_smoked"
 			ae.item_state_world = "door_electronics_smoked_w"
 			ae.broken = TRUE
 			operating = 0
@@ -317,6 +318,7 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/door/window, windowdoor_list)
 
 						if(operating == -1)
 							ae.icon_state = "door_electronics_smoked"
+							ae.item_state_inventory = "door_electronics_smoked"
 							ae.item_state_world = "door_electronics_smoked_w"
 							ae.broken = TRUE
 							operating = 0


### PR DESCRIPTION
## Описание изменений
Емагнутая плата шлюза отображалась неправильно, когда поднимали ее в руку - становилась обычной.
Потому что update_world_icon() берет initial(icon_state), а оно у нас спрайт обычной платы.

Фиксится это добавлением item_state_inventory.

## Чеинжлог

:cl:
 - image: Исправлено отображение емагнутой платы шлюза.
