### PR TITLE
Быстронерф раундстарт товаров

### DIFF
--- a/code/game/objects/random/random_trader_product.dm
+++ b/code/game/objects/random/random_trader_product.dm
@@ -13,6 +13,19 @@
 	/obj/random/trader_product/sec = 10,
 	/obj/random/trader_product/contraband = 10))
 
+/obj/random/trader_product_safer
+	name = "Random Safer Trader Product"
+	desc = "This is random safer trader product."
+	icon = 'icons/obj/economy.dmi'
+	icon_state = "spacecash10"
+
+/obj/random/trader_product/item_to_spawn()
+	return pickweight(list(
+	/obj/random/trader_product/civ = 40,
+	/obj/random/trader_product/med = 30,
+	/obj/random/trader_product/eng = 20,
+	/obj/random/trader_product/rnd = 10))
+
 /obj/random/trader_product/civ
 	name = "Random Civilian Trader Product"
 	desc = "This is random trader product."

--- a/code/modules/cargo/shop.dm
+++ b/code/modules/cargo/shop.dm
@@ -310,7 +310,7 @@ ADD_TO_GLOBAL_LIST(/obj/random_shop_item, random_gruztorg_items)
 	flags = ABSTRACT
 
 /obj/random_shop_item/proc/generate_shop_item()
-	var/item_path = PATH_OR_RANDOM_PATH(/obj/random/trader_product)
+	var/item_path = PATH_OR_RANDOM_PATH(/obj/random/trader_product_safer)
 
 	if(!item_path)
 		return


### PR DESCRIPTION
## Описание изменений
В раундстартовых товарах теперь на 99% меньше контрабанды.

## Почему и что этот ПР улучшит
Нет головной боли админам. Замержить до момента, когда проставим цены и нельзя будет раундстартом выкупить ЕГАН за 57 рублей.

## Авторство
AndreyGysev
Luduk

## Чеинжлог
:cl: AndreyGysev, Luduk
 - tweak: В раундстартовых товарах теперь на 99% меньше контрабанды.
