### PR TITLE
Позорная ненаблюдательность. Фикс неспавна посылок раундстартом.

### DIFF
--- a/code/game/objects/random/random_trader_product.dm
+++ b/code/game/objects/random/random_trader_product.dm
@@ -19,7 +19,7 @@
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "spacecash10"
 
-/obj/random/trader_product/item_to_spawn()
+/obj/random/trader_product_safer/item_to_spawn()
 	return pickweight(list(
 	/obj/random/trader_product/civ = 40,
 	/obj/random/trader_product/med = 30,

--- a/code/modules/cargo/shop.dm
+++ b/code/modules/cargo/shop.dm
@@ -313,6 +313,7 @@ ADD_TO_GLOBAL_LIST(/obj/random_shop_item, random_gruztorg_items)
 	var/item_path = PATH_OR_RANDOM_PATH(/obj/random/trader_product_safer)
 
 	if(!item_path)
+		qdel(src)
 		return
 
 	var/obj/item/Item = new item_path(loc)


### PR DESCRIPTION
## Описание изменений
Посылки теперь спавнятся раундстартом.
Было:
<img width="639" height="343" alt="image" src="https://github.com/user-attachments/assets/7fbe1e35-6524-477a-8ee0-8098d1678c6a" />
<img width="240" height="49" alt="image" src="https://github.com/user-attachments/assets/d035898e-1baa-47c7-926e-61907e696a21" />

Стало:
<img width="614" height="404" alt="image" src="https://github.com/user-attachments/assets/e3ac4efb-debe-4a82-a5b5-8896878f1f5c" />
<img width="792" height="49" alt="image" src="https://github.com/user-attachments/assets/6c91dfc7-fa44-4cb2-9043-93d3848322ce" />

На этот раз проверил и перепроверил.

## Почему и что этот ПР улучшит
При фиксе ОПшных посылок забыл проставить верный тип и посылки не спавнились.

## Авторство
Позорник AndreyGysev

## Чеинжлог

:cl: AndreyGysev
 - bugfix: Раундстартовые посылки теперь продолжаются спавниться.