### PR TITLE
efields generator for forts

### DIFF
--- a/code/game/machinery/computer/fort_console.dm
+++ b/code/game/machinery/computer/fort_console.dm
@@ -307,6 +307,16 @@
 /datum/fort_console_lot/rocket_piercing/purchase()
 	. = new /obj/structure/storage_box/rocket/piercing
 
+/datum/fort_console_lot/shieldgen
+	name = "Shield Generator"
+	desc = "Crate containing a shield generator capable of protecting a 5x5 area from missiles. Does not interfere with the movement of humans. Explode when struck by an EMP."
+	price = 250
+
+	order = 35
+
+/datum/fort_console_lot/shieldgen/purchase()
+	. = new /obj/machinery/forts_shieldgen
+
 // 50-60
 /datum/fort_console_lot/drill
 	name = "Drill set"

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -53,3 +53,11 @@
 	//Outputs: Boolean if can pass.
 
 	return !density
+
+//allows people to pass through it
+
+/obj/effect/energy_field/forts
+	desc = "Impenetrable field of energy, capable of blocking anything unlive as long as it's active."
+
+/obj/effect/energy_field/forts/CanPass(atom/movable/mover, turf/target, height=1.5)
+	return ishuman(mover)

--- a/code/modules/shieldgen/forts.dm
+++ b/code/modules/shieldgen/forts.dm
@@ -1,0 +1,65 @@
+#define SHIELDGEN_STATE_OFF 0
+#define SHIELDGEN_STATE_ON 1
+
+/obj/machinery/forts_shieldgen
+	name = "shield generator"
+	desc = "Shield generator, allows living creatures to pass through but not projectiles. Not resistant to EMP."
+	var/list/created_field = list()
+	var/state = SHIELDGEN_STATE_OFF
+	var/field_radius = 5
+	density = TRUE
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "shieldoff"
+
+/obj/machinery/forts_shieldgen/proc/get_shielded_turfs()
+	var/list/out = list()
+	for(var/turf/T in range(field_radius, src))
+		if(get_dist(src,T) == field_radius)
+			out.Add(T)
+
+	return out
+
+/obj/machinery/forts_shieldgen/attack_hand(mob/user)
+	if(user.is_busy(src) || !do_after(user, 5 SECONDS, target = src))
+		return
+	if(state == SHIELDGEN_STATE_OFF)
+		activate()
+		return
+	deactivate()
+
+/obj/machinery/forts_shieldgen/proc/activate()
+	playsound(src, 'sound/machines/cfieldstart.ogg', VOL_EFFECTS_MASTER, null, FALSE)
+	anchored = TRUE
+	state = SHIELDGEN_STATE_ON
+	icon_state = "shieldon"
+
+	var/list/covered_turfs = get_shielded_turfs()
+	to_chat(world, get_shielded_turfs())
+	var/turf/T = get_turf(src)
+	if(T in covered_turfs)
+		covered_turfs.Remove(T)
+	for(var/turf/O in covered_turfs)
+		var/obj/effect/energy_field/forts/ef = new(O)
+		ef.strength = 50
+		ef.density = TRUE
+		ef.anchored = TRUE
+		ef.invisibility = 0
+		created_field.Add(ef)
+
+	covered_turfs = null
+
+/obj/machinery/forts_shieldgen/proc/deactivate()
+	playsound(src, 'sound/machines/cfieldfail.ogg', VOL_EFFECTS_MASTER, null, FALSE, null, -4)
+	anchored = FALSE
+	state = SHIELDGEN_STATE_OFF
+	icon_state = "shieldoff"
+
+	for(var/obj/effect/energy_field/forts/ef in created_field)
+		created_field.Remove(ef)
+		qdel(ef)
+
+/obj/machinery/forts_shieldgen/emp_act(severity)
+	if(state == SHIELDGEN_STATE_OFF)
+		return
+	deactivate()
+	explosion(loc, 0, 1, 6)

--- a/code/modules/shieldgen/forts.dm
+++ b/code/modules/shieldgen/forts.dm
@@ -34,7 +34,6 @@
 	icon_state = "shieldon"
 
 	var/list/covered_turfs = get_shielded_turfs()
-	to_chat(world, get_shielded_turfs())
 	var/turf/T = get_turf(src)
 	if(T in covered_turfs)
 		covered_turfs.Remove(T)

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -2487,6 +2487,7 @@
 #include "code\modules\security_levels\security_levels.dm"
 #include "code\modules\shieldgen\circuits_and_designs.dm"
 #include "code\modules\shieldgen\energy_field.dm"
+#include "code\modules\shieldgen\forts.dm"
 #include "code\modules\shieldgen\shield_capacitor.dm"
 #include "code\modules\shieldgen\shield_gen.dm"
 #include "code\modules\shieldgen\shield_gen_external.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавляет генератор поля за 250 очков.
Поле пропускает человечков и не пропускает всё остальное (включая ракеты). ЭМИ отключает генератор и вызывает широкий взрыв.


https://github.com/user-attachments/assets/edaa8e1c-dff0-48c5-b11a-bcd24fd21fca


## Почему и что этот ПР улучшит
resolves #14257
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- add [link]: Добавлен генератор защитного поля для режима-ивента forts.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
