### PR TITLE
make prox_sensor ignore non-living mobs

### DIFF
--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -49,9 +49,14 @@
 	log_game("[key_name(user)] attached \the [A] to \the [src].")
 
 /obj/item/device/assembly/prox_sensor/HasProximity(atom/movable/AM)
-	if (istype(AM, /obj/effect/beam))	return
-	if (AM.move_speed < 12)	sense()
-	return
+	if(istype(AM, /obj/effect/beam))
+		return
+	if(ismob(AM) && !isliving(AM))
+		return
+	if(AM.move_speed >= 12)
+		return
+
+	sense()
 
 /obj/item/device/assembly/prox_sensor/proc/sense()
 	var/turf/mainloc = get_turf(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
resolves #2457

## Почему и что этот ПР улучшит
duh

## Авторство
remindme

## Чеинжлог

:cl:
 - bugfix: Proximity sensor в опредёленных случаях срабатывал на призраков
