### PR TITLE
флип апдейт

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -203,6 +203,7 @@
 #define TRAIT_FAKELOYAL_VISUAL    "fakeloyal_visual"
 #define TRAIT_CHANGELING_ABSORBING "changeling_absorbing"
 #define TRAIT_FAST_WALKER         "fast_walker"
+#define TRAIT_BULLET_DODGER        "bullet_dodger"
 #define TRAIT_BORK_SKILLCHIP      "bork_skillchip"
 #define TRAIT_MIMING              "miming"
 #define TRAIT_CAN_LEAP            "can_leap"

--- a/code/datums/emotes/human/visual.dm
+++ b/code/datums/emotes/human/visual.dm
@@ -202,7 +202,7 @@
 	if(istype(user.buckled, /obj/structure/stool/bed/chair) && prob(80))
 		var/obj/structure/stool/bed/chair/ch = user.buckled
 		if((ch.can_flipped == TRUE) && (ch.flipped == FALSE))
-			user.visible_message("<span class='notice'>[user] flips \the [ch.name] down.</span>","<span class='notice'>You flips \the [ch.name] down.</span>")
+			user.visible_message("<span class='notice'>[user] flips \the [ch.name] down.</span>","<span class='notice'>You flip \the [ch.name] down.</span>")
 			ch.flip()
 			ch.unbuckle_mob()
 			user.apply_effect(2, WEAKEN, 0)

--- a/code/datums/emotes/human/visual.dm
+++ b/code/datums/emotes/human/visual.dm
@@ -181,12 +181,37 @@
 
 
 	message_1p = "You are doing a flip."
-	message_3p = "does flip."
+	message_3p = "does a flip."
 	required_stat = CONSCIOUS
 
 	required_bodyparts = list(BP_R_LEG, BP_L_LEG)
 
 
 /datum/emote/human/flip/do_emote(mob/living/carbon/human/user)
+	if(user.stunned || user.weakened)
+		return
+	if(user.crawling)
+		message_1p = "You are doing a tactical roll."
+		message_3p = "does a tactical roll."
+	else
+		message_1p = "You are doing a flip."
+		message_3p = "does a flip."
 	. = ..()
-	user.SpinAnimation(5,1)
+	var/cw = pick(TRUE, FALSE)
+	user.SpinAnimation(7, 1, cw)
+	if(istype(user.buckled, /obj/structure/stool/bed/chair) && prob(80))
+		var/obj/structure/stool/bed/chair/ch = user.buckled
+		if((ch.can_flipped == TRUE) && (ch.flipped == FALSE))
+			user.visible_message("<span class='notice'>[user] flips \the [ch.name] down.</span>","<span class='notice'>You flips \the [ch.name] down.</span>")
+			ch.flip()
+			ch.unbuckle_mob()
+			user.apply_effect(2, WEAKEN, 0)
+			user.apply_damage(3, BRUTE, BP_HEAD)
+	else if(user.crawling)
+		user.adjustHalLoss(20)
+		user.throw_at(get_step(user, user.dir), 1, 1)
+	else if(prob(1) || (user.drunkenness >= DRUNKENNESS_SLUR))
+		user.visible_message("<span class='warning'>[user] does a bad flip and lands right on his head. That must be pretty nasty!</span>","<span class='warning'OUCH!</span>")
+		user.apply_effect(10, WEAKEN, 0)
+		user.apply_damage(20, BRUTE, BP_HEAD)
+		user.adjustBrainLoss(5)

--- a/code/datums/qualities/positiveish.dm
+++ b/code/datums/qualities/positiveish.dm
@@ -447,3 +447,12 @@
 /datum/quality/positiveish/allchannels/add_effect(mob/living/carbon/human/H)
 	H.equip_or_collect(new /obj/item/device/encryptionkey/allchannels(H), SLOT_R_STORE)
 	to_chat(H, "<span class='notice'>Возможно, чтобы установить ключ шифрования, придётся расковырять наушник отверткой. Только не попадись охране!</span>")
+
+/datum/quality/positiveish/bullet_dodger
+	name = "Bullet Dodger"
+	desc = "В детстве тебе дали кличку \"Хрен попадёшь\". Интересно, с чего бы это?"
+	requirement = "Нет."
+
+/datum/quality/positiveish/bullet_dodger/add_effect(mob/living/carbon/human/H)
+	ADD_TRAIT(H, TRAIT_BULLET_DODGER, QUALITY_TRAIT)
+

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -155,6 +155,7 @@
 			for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2))
 				user.set_dir(i)
 				sleep(1)
+		user.emote("flip")
 
 /obj/item/weapon/dualsaber/Get_shield_chance()
 	if(HAS_TRAIT(src, TRAIT_DOUBLE_WIELDED) && !slicing)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -30,7 +30,7 @@
 		adjustHalLoss(15 * weight_diff_coef)	//thicc landing
 		if(isliving(AM))
 			var/mob/living/M = AM
-			M.adjustHalLoss(15 * weight_diff_coef)
+			M.AdjustWeakened(2 * weight_diff_coef)
 	else
 		AdjustWeakened(2 * weight_diff_coef)	//4 seconds is default slip
 		if(isliving(AM))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -28,8 +28,14 @@
 	var/weight_diff_coef = 1 + sqrt(size_diff_calculate)
 	if(shoes?.flags & AIR_FLOW_PROTECT || wear_suit?.flags & AIR_FLOW_PROTECT)
 		adjustHalLoss(15 * weight_diff_coef)	//thicc landing
+		if(isliving(AM))
+			var/mob/living/M = AM
+			M.adjustHalLoss(15 * weight_diff_coef)
 	else
 		AdjustWeakened(2 * weight_diff_coef)	//4 seconds is default slip
+		if(isliving(AM))
+			var/mob/living/M = AM
+			M.AdjustWeakened(2 * weight_diff_coef)
 	visible_message("<span class='warning'>[AM] falls on [src].</span>",
 					"<span class='warning'>[AM] falls on you!</span>",
 					"<span class='notice'>You hear something heavy fall.</span>")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -76,6 +76,9 @@
 		if(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
 			miss_chance = 60
 
+	if(HAS_TRAIT(target, TRAIT_BULLET_DODGER))
+		miss_chance += 50
+
 	if(!prob(miss_chance + miss_chance_mod)) // chance to hit
 		return zone
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -171,6 +171,9 @@
 /obj/item/projectile/proc/check_miss(mob/living/L)
 	if(L.prob_miss(src))
 		L.visible_message("<span class = 'notice'>\The [src] misses [L] narrowly!</span>")
+		if((L.stat == CONSCIOUS) && HAS_TRAIT(L, TRAIT_BULLET_DODGER))
+			L.emote("flip")
+			L.throw_at(get_step(L, pick(alldirs)), 1, 1)
 		playsound(L.loc, pick(SOUNDIN_BULLETMISSACT), VOL_EFFECTS_MASTER)
 		permutated.Add(L)
 		return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
добавлена особка связанная с эмоутом flip
персонаж с двойным энергомечём во время боя крутит сальтухи
добавлены очевидные и не очень приколы во время исполнения сальтухи

во избежание *определённых* абузов, теперь если бросить человечка в человечка, то застанятся оба, а не только тот на кого набросились
## Почему и что этот ПР улучшит
увеличение вариативности использования эмоута даст больше прикольных и смешных ситуаций
## Авторство
я
все совпадения случайны, а имена вымышлены
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
изменения не особо заметные, так что чеинжлог не нужен наверное
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
