### PR TITLE
фикс 2 предметов в 1 кармане с особкой дека

### DIFF
--- a/code/datums/qualities/positiveish.dm
+++ b/code/datums/qualities/positiveish.dm
@@ -115,6 +115,7 @@
 	H.equip_or_collect(new /obj/item/ammo_box/speedloader/c45rubber(H), SLOT_L_STORE)
 	H.equip_or_collect(new /obj/item/ammo_box/speedloader/c45rubber(H), SLOT_R_STORE)
 
+
 /datum/quality/positiveish/all_affairs
 	name = "All Affairs"
 	desc = "У тебя полный доступ. Да начнётся расследование."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fixes #14397
Фиксит баг при котором у детектива спавнилось 2 предмета в одном кармане, если он получал особку Big Iron. Патроны с особки перемещены из карманов в рюкзак.
## Почему и что этот ПР улучшит
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: У детектива больше не появляется два предмета в одном кармане при особке Big Iron
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
