### PR TITLE
БС аномалия больше не телепортирует на первый слой

### DIFF
--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -14,7 +14,9 @@
 			var/obj/item/device/radio/beacon/chosen
 			var/list/possible = list()
 			for(var/obj/item/device/radio/beacon/W in radio_beacon_list)
-				possible += W
+				var/turf/R = get_turf(W)
+				if(!is_centcom_level(R.z))
+					possible += W
 
 			if(possible.len > 0)
 				chosen = pick(possible)


### PR DESCRIPTION

## Описание изменений
БС аномалия больше не выбирает маячки с первого слоя для смещения
## Почему и что этот ПР улучшит
Фиксим #10742
## Авторство
Йааааааааааааааааа


:cl:
 - bugfix: БС аномалия больше не переместит Мерка на первый слой.

