### PR TITLE
eminence fix

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/eminence.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/eminence.dm
@@ -52,13 +52,11 @@
 	var/datum/religion/cult/R = global.cult_religion
 	if(R.eminence && R.eminence != src)
 		R.remove_member(src)
-		stack_trace("Cult got second Eminence, deleting one")
 		qdel(src)
 		return
 	R.eminence = src
 	tome.religion = R
-	if(!R.add_member(src, CULT_ROLE_HIGHPRIEST))
-		stack_trace("[src] is not Cultist!")
+	R.add_member(src, CULT_ROLE_HIGHPRIEST)
 	to_chat(src, "<span class='cult large'>Вы стали Возвышенным!</span>")
 	to_chat(src, "<span class='cult'>Будучи Возвышенным, вы ведёте весь культ за собой. Весь культ услышит то, что вы скажите.</span>")
 	to_chat(src, "<span class='cult'>Вы можете двигаться невзирая на стены, вы бестелесны, и в большинстве случаев не сможете напрямую влиять на мир, за исключением нескольких особых способов.</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В рефакторе имплантов заменили моба на ливинга в проверке на возможность конверта у культа, а мы имеем /mob/camera/eminence, т.е. у него нет переменной имплантов, следовательно рантайм, следовательно возвышенный не культист.

## Почему и что этот ПР улучшит
<img width="938" height="114" alt="image" src="https://github.com/user-attachments/assets/55b07f9a-80c2-454b-89f2-a90ef3044c5e" />
## Авторство


## Чеинжлог

:cl:
 - bugfix: Возвышенный вновь играбелен
