### PR TITLE
Траллов можно отличить от обычного экипажа

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -486,6 +486,8 @@
 		var/obj/item/organ/external/head/BP = bodyparts_by_name[BP_HEAD]
 		if(istype(BP) && BP.disfigured)
 			msg += "<span class='warning'><b>[t_His] face is violently disfigured!</b></span>\n"
+		else if(isshadowthrall(src))
+			msg += "<span class='shadowling'><b>Their features seem unnaturally tight and drawn.</b></span>\n"
 
 	if((!skipface || !skipjumpsuit || !skipgloves))
 		if(HAS_TRAIT(src, TRAIT_BURNT))


### PR DESCRIPTION
## Описание изменений
при экзамайне траллов с открытым лицом пишется, что он выглядит странно
## Почему и что этот ПР улучшит
траллы теперь станут видны, если не закрывают лицо. избавляет от проблемы, что траллов абсолютно никак нельзя отличить от обычного экипажа и офицеры режут всех.
## Авторство
nasend_
## Чеинжлог

:cl: nasend_
 - add: Рабы тенелингов теперь выделяются от обычного экипажа.
