### PR TITLE
нерф стандроби

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -250,7 +250,7 @@
 	stun = 0
 	weaken = 0
 	stutter = 10
-	agony = 80
+	agony = 20
 	embed = 0
 	sharp = 0
 	dispersion = 2.0


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
уменьшает болеурон отдельной стандробинки до 20
для сравнения
чтобы оглушить человечка нужно нанести 100 болеурона
сейчас стандробь имеет 5 дробинок и каждая наносит 80 болеурона, всего 400 (!!!) боли
теперь стандробь имеет 5 дробинок и каждая будет наносить 20 болеурона, всего 100 боли

## Почему и что этот ПР улучшит
щас стандробь является хуйней которая нагибает и кладёт в стан всех у кого нет 100% резиста от боли или тока


## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- balance: Оглушающая (шоковая) дробь стала в 4 раза слабее.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
