### PR TITLE
один предмет стака крафтит вещи

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -164,10 +164,11 @@
 		if (!do_skilled(user, user, R.time, R.required_skills, -0.2))
 			return
 
+	var/atom/build_loc = loc
+
 	if(!use(R.req_amount*multiplier))
 		return
 
-	var/atom/build_loc = loc
 	var/atom/movable/O = new R.result_type(build_loc)
 	user.try_take(O, build_loc)
 	O.set_dir(user.dir)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fix: #14570 
use() удалял стак через qdel(), поэтому loc куда должен появится предмет передавался null, решено сохранением loc до удаления стака
## Почему и что этот ПР улучшит
багфикс
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Один предмет стака теперь может крафтить вещи.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
