### PR TITLE
Добавление СПУ новых борговских эмоутов

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1298,6 +1298,13 @@
 		/datum/emote/robot/beep,
 		/datum/emote/robot/ping,
 		/datum/emote/robot/buzz,
+		/datum/emote/robot/confirm,
+		/datum/emote/robot/deny,
+		/datum/emote/robot/scary,
+		/datum/emote/robot/woop,
+		/datum/emote/robot/boop,
+		/datum/emote/robot/robochirp,
+		/datum/emote/robot/calling
 	)
 
 	default_mood_event = /datum/mood_event/machine


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений 
Когда-то давно, когда я добавлял боргам новые эмоции и забыл совсем их добавить СПУшкам. Исправляем косяк.
## Почему и что этот ПР улучшит
Теперь СПУ также могут издавать новые эмоуты которые уже 2 года имеют борги
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl: Azzy.Dreemurr
 - sound: СПУ(IPS) теперь смогут издавать новые эмоуты боргов: *confirm, *deny, *scary, *woop, *boop, *chirp *call