### PR TITLE
Фиксы лечения мертвых органов

### DIFF
--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -113,6 +113,9 @@
 	target.sdisabilities &= ~BLIND
 	eyes.damage = 0
 
+	if(eyes.status & ORGAN_DEAD)
+		to_chat(user, "<span class='warning'>Despite your efforts, [target]'s optics don't seem to respond. The nerves are completely dead.</span>")
+
 /datum/surgery_step/eye/mend_eyes/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/internal/eyes/IO = target.organs_by_name[O_EYES]
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -113,9 +113,6 @@
 	target.sdisabilities &= ~BLIND
 	eyes.damage = 0
 
-	if(eyes.status & ORGAN_DEAD)
-		to_chat(user, "<span class='warning'>Despite your efforts, [target]'s optics don't seem to respond. The nerves are completely dead.</span>")
-
 /datum/surgery_step/eye/mend_eyes/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/internal/eyes/IO = target.organs_by_name[O_EYES]
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -101,6 +101,10 @@
 
 /obj/item/organ/internal/proc/rejuvenate()
 	damage = 0
+	status &= ~ORGAN_DEAD
+	germ_level = 0
+	if(owner)
+		START_PROCESSING(SSobj, src)
 
 /obj/item/organ/internal/proc/is_bruised()
 	return damage >= min_bruised_damage

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -90,6 +90,24 @@
 			break
 	return is_groin_organ_damaged
 
+/datum/surgery_step/groin_organs/fixing/prepare_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/groin/BP = target.get_bodypart(BP_GROIN)
+	var/list/dead_organs = list()
+	var/has_treatable = FALSE
+	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
+		if(IO.damage > 0)
+			if(IO.status & ORGAN_DEAD)
+				dead_organs += IO
+			else
+				has_treatable = TRUE
+
+	if(!has_treatable && dead_organs.len)
+		for(var/obj/item/organ/internal/IO in dead_organs)
+			user.visible_message("[target]'s [IO.name] is dead.")
+		return FALSE
+
+	return ..()
+
 /datum/surgery_step/groin_organs/fixing/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
@@ -103,7 +121,7 @@
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO.status & ORGAN_DEAD)
 			user.visible_message("[target]'s [IO.name] is dead.")
-			return
+			continue
 		if(IO && IO.damage > 0)
 			if(!IO.is_robotic())
 				user.visible_message("[user] starts treating damage to [target]'s [IO.name] with [tool_name].",
@@ -131,7 +149,7 @@
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO && IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
-				return
+				continue
 			if(!IO.is_robotic())
 				user.visible_message("<span class='notice'>[user] treats damage to [target]'s [IO.name] with [tool_name].</span>",
 				"<span class='notice'>You treat damage to [target]'s [IO.name] with [tool_name].</span>" )

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -102,7 +102,7 @@
 				has_treatable = TRUE
 
 	if(!has_treatable && dead_organs.len)
-		for(var/obj/item/organ/internal/IO in dead_organs)
+		for(var/obj/item/organ/internal/IO as anything in dead_organs)
 			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
 		return FALSE
 

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -103,7 +103,7 @@
 
 	if(!has_treatable && dead_organs.len)
 		for(var/obj/item/organ/internal/IO in dead_organs)
-			user.visible_message("[target]'s [IO.name] is dead.")
+			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
 		return FALSE
 
 	return ..()
@@ -120,7 +120,7 @@
 	var/obj/item/organ/external/groin/BP = target.get_bodypart(BP_GROIN)
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO.status & ORGAN_DEAD)
-			user.visible_message("[target]'s [IO.name] is dead.")
+			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
 			continue
 		if(IO && IO.damage > 0)
 			if(!IO.is_robotic())

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -93,9 +93,7 @@
 				has_treatable = TRUE
 	if(has_treatable)
 		return TRUE
-	if(dead_organs.len)
-		for(var/obj/item/organ/internal/IO as anything in dead_organs)
-			to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
+	warn_necrotic_organs(user, target, dead_organs)
 	return FALSE
 
 /datum/surgery_step/groin_organs/fixing/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -108,9 +106,10 @@
 		else
 			tool_name = "the bandaid"
 	var/obj/item/organ/external/groin/BP = target.get_bodypart(BP_GROIN)
+	var/list/dead_organs = list()
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO.status & ORGAN_DEAD)
-			to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
+			dead_organs += IO
 			continue
 		if(IO && IO.damage > 0)
 			if(!IO.is_robotic())
@@ -119,6 +118,7 @@
 			else
 				user.visible_message("<span class='notice'>[user] attempts to repair [target]'s mechanical [IO.name] with [tool_name]...</span>",
 				"<span class='notice'>You attempt to repair [target]'s mechanical [IO.name] with [tool_name]...</span>")
+	warn_necrotic_organs(user, target, dead_organs)
 
 	if(HAS_TRAIT(target, TRAIT_NO_PAIN))
 		to_chat(target, "You notice slight movement in your groin.")

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -82,31 +82,21 @@
 /datum/surgery_step/groin_organs/fixing/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
 		return FALSE
-	var/is_groin_organ_damaged = FALSE
-	var/obj/item/organ/external/groin/BP = target.get_bodypart(BP_GROIN)
-	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
-		if(IO.damage > 0)
-			is_groin_organ_damaged = TRUE
-			break
-	return is_groin_organ_damaged
-
-/datum/surgery_step/groin_organs/fixing/prepare_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/groin/BP = target.get_bodypart(BP_GROIN)
 	var/list/dead_organs = list()
 	var/has_treatable = FALSE
-	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
+	for(var/obj/item/organ/internal/IO as anything in BP.bodypart_organs)
 		if(IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
 				dead_organs += IO
 			else
 				has_treatable = TRUE
-
-	if(!has_treatable && dead_organs.len)
-		for(var/obj/item/organ/internal/IO in dead_organs)
-			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
-		return FALSE
-
-	return ..()
+	if(has_treatable)
+		return TRUE
+	if(dead_organs.len)
+		for(var/obj/item/organ/internal/IO as anything in dead_organs)
+			to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
+	return FALSE
 
 /datum/surgery_step/groin_organs/fixing/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/tool_name = "\the [tool]"
@@ -120,7 +110,7 @@
 	var/obj/item/organ/external/groin/BP = target.get_bodypart(BP_GROIN)
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO.status & ORGAN_DEAD)
-			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
+			to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
 			continue
 		if(IO && IO.damage > 0)
 			if(!IO.is_robotic())

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -93,7 +93,7 @@
 				has_treatable = TRUE
 	if(has_treatable)
 		return TRUE
-	warn_necrotic_organs(user, target, dead_organs)
+	necrotic_organs_warning(user, target, dead_organs)
 	return FALSE
 
 /datum/surgery_step/groin_organs/fixing/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -118,7 +118,7 @@
 			else
 				user.visible_message("<span class='notice'>[user] attempts to repair [target]'s mechanical [IO.name] with [tool_name]...</span>",
 				"<span class='notice'>You attempt to repair [target]'s mechanical [IO.name] with [tool_name]...</span>")
-	warn_necrotic_organs(user, target, dead_organs)
+	necrotic_organs_warning(user, target, dead_organs)
 
 	if(HAS_TRAIT(target, TRAIT_NO_PAIN))
 		to_chat(target, "You notice slight movement in your groin.")

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -210,28 +210,21 @@
 	if(target.op_stage.ribcage != 2)
 		return FALSE
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(BP_CHEST)
-	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
-		if(IO.damage > 0)
-			return TRUE
-	return FALSE
-
-/datum/surgery_step/ribcage/fix_chest_internal/prepare_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/chest/BP = target.get_bodypart(BP_CHEST)
 	var/list/dead_organs = list()
 	var/has_treatable = FALSE
-	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
+	for(var/obj/item/organ/internal/IO as anything in BP.bodypart_organs)
 		if(IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
 				dead_organs += IO
 			else
 				has_treatable = TRUE
+	if(has_treatable)
+		return TRUE
+	if(dead_organs.len)
+		for(var/obj/item/organ/internal/IO as anything in dead_organs)
+			to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
+	return FALSE
 
-	if(!has_treatable && dead_organs.len)
-		for(var/obj/item/organ/internal/IO in dead_organs)
-			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
-		return FALSE
-
-	return ..()
 
 /datum/surgery_step/ribcage/fix_chest_internal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/tool_name = "\the [tool]"
@@ -246,7 +239,7 @@
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO && IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
-				to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
+				to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
 				continue
 			if(!IO.is_robotic())
 				user.visible_message("[user] starts treating damage to [target]'s [IO.name] with [tool_name].", \

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -228,7 +228,7 @@
 
 	if(!has_treatable && dead_organs.len)
 		for(var/obj/item/organ/internal/IO in dead_organs)
-			user.visible_message("[target]'s [IO.name] is dead.")
+			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
 		return FALSE
 
 	return ..()
@@ -246,7 +246,7 @@
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO && IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
-				user.visible_message("[target]'s [IO.name] is dead.")
+				to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
 				continue
 			if(!IO.is_robotic())
 				user.visible_message("[user] starts treating damage to [target]'s [IO.name] with [tool_name].", \

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -215,6 +215,24 @@
 			return TRUE
 	return FALSE
 
+/datum/surgery_step/ribcage/fix_chest_internal/prepare_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/chest/BP = target.get_bodypart(BP_CHEST)
+	var/list/dead_organs = list()
+	var/has_treatable = FALSE
+	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
+		if(IO.damage > 0)
+			if(IO.status & ORGAN_DEAD)
+				dead_organs += IO
+			else
+				has_treatable = TRUE
+
+	if(!has_treatable && dead_organs.len)
+		for(var/obj/item/organ/internal/IO in dead_organs)
+			user.visible_message("[target]'s [IO.name] is dead.")
+		return FALSE
+
+	return ..()
+
 /datum/surgery_step/ribcage/fix_chest_internal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
@@ -229,6 +247,7 @@
 		if(IO && IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
 				user.visible_message("[target]'s [IO.name] is dead.")
+				continue
 			if(!IO.is_robotic())
 				user.visible_message("[user] starts treating damage to [target]'s [IO.name] with [tool_name].", \
 				"You start treating damage to [target]'s [IO.name] with [tool_name]." )
@@ -252,7 +271,7 @@
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO && IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
-				return
+				continue
 			if(!IO.is_robotic())
 				user.visible_message("[user] treats damage to [target]'s [IO.name] with [tool_name].", \
 				"<span class='notice'>You treat damage to [target]'s [IO.name] with [tool_name].</span>" )

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -220,7 +220,7 @@
 				has_treatable = TRUE
 	if(has_treatable)
 		return TRUE
-	warn_necrotic_organs(user, target, dead_organs)
+	necrotic_organs_warning(user, target, dead_organs)
 	return FALSE
 
 
@@ -246,7 +246,7 @@
 			else
 				user.visible_message("<span class='notice'>[user] attempts to repair [target]'s mechanical [IO.name] with [tool_name]...</span>", \
 				"<span class='notice'>You attempt to repair [target]'s mechanical [IO.name] with [tool_name]...</span>")
-	warn_necrotic_organs(user, target, dead_organs)
+	necrotic_organs_warning(user, target, dead_organs)
 
 	target.custom_pain("The pain in your chest is living hell!",1)
 	..()

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -220,9 +220,7 @@
 				has_treatable = TRUE
 	if(has_treatable)
 		return TRUE
-	if(dead_organs.len)
-		for(var/obj/item/organ/internal/IO as anything in dead_organs)
-			to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
+	warn_necrotic_organs(user, target, dead_organs)
 	return FALSE
 
 
@@ -236,10 +234,11 @@
 		else
 			tool_name = "the bandaid"
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(BP_CHEST)
+	var/list/dead_organs = list()
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO && IO.damage > 0)
 			if(IO.status & ORGAN_DEAD)
-				to_chat(user, "<span class='warning'>[target]'s [IO.name] has necrosed and can't be treated this way.</span>")
+				dead_organs += IO
 				continue
 			if(!IO.is_robotic())
 				user.visible_message("[user] starts treating damage to [target]'s [IO.name] with [tool_name].", \
@@ -247,6 +246,7 @@
 			else
 				user.visible_message("<span class='notice'>[user] attempts to repair [target]'s mechanical [IO.name] with [tool_name]...</span>", \
 				"<span class='notice'>You attempt to repair [target]'s mechanical [IO.name] with [tool_name]...</span>")
+	warn_necrotic_organs(user, target, dead_organs)
 
 	target.custom_pain("The pain in your chest is living hell!",1)
 	..()

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -227,7 +227,7 @@
 				has_treatable = TRUE
 
 	if(!has_treatable && dead_organs.len)
-		for(var/obj/item/organ/internal/IO in dead_organs)
+		for(var/obj/item/organ/internal/IO as anything in dead_organs)
 			to_chat(user, "<span class='warning'>[target]'s [IO.name] is dead.</span>")
 		return FALSE
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -63,6 +63,18 @@
 /datum/surgery_step/proc/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return null
 
+/// Outputs a consolidated warning about necrotic organs that can't be treated by "fix" step.
+/datum/surgery_step/proc/warn_necrotic_organs(mob/living/user, mob/living/carbon/human/target, list/dead_organs)
+	if(!length(dead_organs))
+		return
+	var/list/organ_names = list()
+	for(var/obj/item/organ/internal/IO as anything in dead_organs)
+		organ_names += IO.name
+	if(organ_names.len == 1)
+		to_chat(user, "<span class='warning'>[target]'s [organ_names[1]] is necrotic and can't be treated this way.</span>")
+	else
+		to_chat(user, "<span class='warning'>[target]'s [get_english_list(organ_names)] are necrotic and can't be treated this way.</span>")
+
 /proc/spread_germs_to_organ(obj/item/organ/external/BP, mob/living/carbon/human/user, obj/item/tool)
 	if(!istype(user) || !istype(BP))
 		return

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -64,7 +64,7 @@
 	return null
 
 /// Outputs a consolidated warning about necrotic organs that can't be treated by "fix" step.
-/datum/surgery_step/proc/warn_necrotic_organs(mob/living/user, mob/living/carbon/human/target, list/dead_organs)
+/datum/surgery_step/proc/necrotic_organs_warning(mob/living/user, mob/living/carbon/human/target, list/dead_organs)
 	if(!length(dead_organs))
 		return
 	var/list/organ_names = list()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
LLM-assisted код
1. Реджув теперь снимает `ORGAN_DEAD` и запускает процессинг органа
2. Разобрался с проблемой, когда наличие 1 мертвого органа блокирует лечение живого (при этом в чат выводится, что все успешно) через `continue` в нужных местах.
2.1 Добавил в can_use проверку, которая не даёт запустить do_after прогрессбар, если все органы в участке тела мертвы. Имеем копипасту, конечно, но я не сообразил, как можно сделать лучше, не переписывая всю хирургию

Протестил в игре:
1. Лечение в теле и паху всех мертвых органов - один раз выводим в чат, что органы мертвы, ду афтер не вызывается
2. Лечение в теле и паху, когда мертв только 1 орган (вылечиваем живой) - один раз выводим в чат что орган мертв, по второму органу выводится стандартное лечим-вылечили
3. Сочетания с протезами (1 протез+1 органик/фулл протезы) - ничего не сломалось
4. Реджув
6. Лечение участков тела без органов/с недостающими органами

Чейнжлог не пишу наверное, фиксы не особо заметны ингейм
## Почему и что этот ПР улучшит
fix #14563
fix #14562
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->
Lexakr
## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
