### PR TITLE
Не показывать "active: " в лейтджоине если не надо

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -363,7 +363,10 @@
 
 			department_data += "<a class='jobPosition [quota_class] [head_class]' href='byond://?src=\ref[src];SelectedJob=[J.title]'>[J.title]"
 			if(J.current_positions)
-				department_data += " ([J.current_positions])<br><i>(Active: [SSjob.GetActiveCount(J.title)])</i>"
+				department_data += " ([J.current_positions])"
+				var/active = SSjob.GetActiveCount(J.title)
+				if(active < J.current_positions)
+					department_data += "<br><i>(Active: [active])</i>"
 			department_data += "</a>"
 		if(length(department_data))
 			var/datum/department/D = SSjob.name_departments[department_tag]


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
После #14238 в меню лейтджоина всегда пишется `Active: ` сколько-то там
После этого ПРа восстанавливается старое поведение: `Active: ` после профессии добавляется только если число активных игроков на этой профессии не совпадает с числом всего игроков на этой профессии

<img width="682" height="732" alt="image" src="https://github.com/user-attachments/assets/b0d112ca-1282-42db-8924-c9ba08c21a89" />


## Почему и что этот ПР улучшит
Меньше ненужной информации

## Авторство

remindme

## Чеинжлог

:cl: remindme
- fix: Регрессия: число активных игроков на профессии показывалось всегда, а не только при наличии неактивных игроков

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
