### PR TITLE
хотфикс сообщения удара головой

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -71,9 +71,9 @@
 			playsound(src, 'sound/effects/bang.ogg', VOL_EFFECTS_MASTER, 25)
 			var/armor_block = H.run_armor_check(BP_HEAD, "melee")
 			if(armor_block)
-				visible_message("<span class='userdanger'>[H] headbutts the airlock.</span>")
-			else
 				visible_message("<span class='userdanger'>[H] headbutts the airlock. Good thing they're wearing a helmet.</span>")
+			else
+				visible_message("<span class='userdanger'>[H] headbutts the airlock.</span>")
 			if(H.apply_damage(10, BRUTE, BP_HEAD, armor_block))
 				H.Stun(2)
 				H.Weaken(5)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -155,9 +155,9 @@ var/global/list/wedge_image_cache = list()
 				playsound(src, 'sound/effects/bang.ogg', VOL_EFFECTS_MASTER, 25)
 				var/armor_block = H.run_armor_check(BP_HEAD, "melee")
 				if(armor_block)
-					visible_message("<span class='userdanger'> [user] headbutts the airlock.</span>")
-				else
 					visible_message("<span class='userdanger'> [user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
+				else
+					visible_message("<span class='userdanger'> [user] headbutts the airlock.</span>")
 				if(H.apply_damage(10, BRUTE, BP_HEAD, armor_block))
 					H.Stun(2)
 					H.Weaken(5)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
меняет местами сообщения об ударе об шлюз со шлемом с упоминанием шлема и наоборот
## Почему и что этот ПР улучшит
хотфикс спустя 4 года
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Правильное отображение сообщения об ударе головой со шлемом и наоборот.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
