### PR TITLE
AI rev fix

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -41,7 +41,7 @@ SUBSYSTEM_DEF(job)
 		var/datum/department/department = new D()
 		departments += department
 		name_departments[department.title] = department
-		if(department.head)
+		if(department.head && department.title != DEP_SILICON)
 			heads_positions[department.head] = department
 		departments_occupations[department.title] = list()
 


### PR DESCRIPTION

## Описание изменений
ИИ больше не цель у реверов. 

Я фиг знает, что оно может сломать, ТМ обязателен

В теории, конечно, можно было бы пофиксить иначе, но как бы странно, что ИИ в целом глава. Да и фиксить уже дальше по прокам как по мне - некрасиво.
## Почему и что этот ПР улучшит

## Авторство


## Чеинжлог

:cl:
 - bugfix: ИИ более не цель ревы
