### PR TITLE
Create Antagonist не переэкипировывает уже существующих антагов

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -626,8 +626,8 @@
 	candidates = shuffle(candidates)
 
 	if(fac_type)
+		var/is_new = !find_faction_by_type(fac_type)
 		var/datum/faction/FF = create_uniq_faction(fac_type)
-		var/list/datum/role/new_roles = list()
 		while(count > 0 && candidates.len)
 			var/mob/M = pick(candidates)
 			candidates -= M
@@ -637,14 +637,12 @@
 			if(isobserver(M))
 				M = makeBody(M)
 
-			var/datum/role/new_role = add_faction_member(FF, M, FALSE, FALSE)
-			if(new_role)
-				new_roles += new_role
+			if(add_faction_member(FF, M, FALSE, !is_new))
 				recruit_count++
 				count--
 
-		for(var/datum/role/R in new_roles)
-			R.OnPostSetup()
+		if(is_new)
+			FF.OnPostSetup()
 
 	if(role_type)
 		while(count > 0 && candidates.len)


### PR DESCRIPTION


<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fix: #14601 
OnPostSetup() вызывался для существующих ролей отдельной фракции, что вызывало повторную выдачу выдаваемой экипировки и отображаемой информации при добавлении новых членов через Create Antagonist(makeAntag), добавлена проверка существования фракции перед вызовом OnPostSetup(), из за чего каждая новая роль при существовании фракции сетапится индивидуально, в случае новой фракции вызовется полный сетап
## Почему и что этот ПР улучшит
багфикс 
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Create Antagonist не переэкипировывает уже существующих антагов
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
