### PR TITLE
Газовая аномалия выпускает больше газа

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -243,6 +243,14 @@
 		"impedrezene",
 		"adminordrazine"
 	)
+	var/list/atmos_gases = list(
+		"phoron",
+		"oxygen",
+		"nitrogen",
+		"carbon_dioxide",
+		"tritium",
+		"hydrogen"
+	)
 	var/release_time = 15 SECONDS
 	var/move_chance = 70
 
@@ -273,15 +281,18 @@
 
 /obj/effect/anomaly/gas/proc/release_gas()
 	var/selected_gas = pick(gas_types)
-
 	var/datum/effect/effect/system/smoke_spread/chem/S = new()
 	var/datum/reagents/R = new/datum/reagents(2700)
 	R.my_atom = src
 	R.add_reagent(selected_gas, 900)
 	S.set_up(R, 10, 0, loc, 60)
 	S.start()
-
 	playsound(src, 'sound/effects/air_release.ogg', VOL_EFFECTS_MASTER)
+
+	var/turf/simulated/T = get_turf(src)
+	if(istype(T))
+		var/chosen_gas = pick(atmos_gases)
+		T.assume_gas(chosen_gas, 1500)
 
 /obj/effect/anomaly/gas/proc/try_move()
 	var/turf/new_loc = get_step(src, pick(alldirs))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил чтобы аномалия выпускала не только дым с реагентом но и вот эти газы:
		"phoron",
		"oxygen",
		"nitrogen",
		"carbon_dioxide",
		"tritium",
		"hydrogen"
## Почему и что этот ПР улучшит
Газовая аномалия стала газовой
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: Газовая аномалия выпускает больше газа