### PR TITLE
повреждения случайных органов только когда голова или грудак впитали достаточно урона

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -343,9 +343,9 @@ This function restores all bodyparts.
 	damageoverlaytemp = 20
 	switch(damagetype)
 		if(BRUTE)
-			created_wound = BP.take_damage(damage, 0, damage_flags, used_weapon, impact_direction = impact_direction)
+			created_wound = BP.take_damage(damage, 0, damage_flags, used_weapon, impact_direction = impact_direction, protection = blocked)
 		if(BURN)
-			created_wound = BP.take_damage(0, damage, damage_flags, used_weapon, impact_direction = impact_direction)
+			created_wound = BP.take_damage(0, damage, damage_flags, used_weapon, impact_direction = impact_direction,  protection = blocked)
 	if(damage > 8 && (BP.status & ORGAN_SPLINTED))
 		BP.status &= ~ORGAN_SPLINTED
 		playsound(src, 'sound/effects/splint_broke.ogg', VOL_EFFECTS_MASTER)

--- a/code/modules/surgery/organs/external/flesh.dm
+++ b/code/modules/surgery/organs/external/flesh.dm
@@ -92,7 +92,7 @@
 		damage_amt += burn
 		cur_damage += BP.burn_dam
 
-	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage || (((sharp && damage_amt >= 5) || damage_amt >= 10) && prob(5))))
+	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage) && prob(5))
 	// Damage an internal organ
 		var/obj/item/organ/internal/IO = pick(BP.bodypart_organs)
 		IO.take_damage(damage_amt / 2)

--- a/code/modules/surgery/organs/external/flesh.dm
+++ b/code/modules/surgery/organs/external/flesh.dm
@@ -65,7 +65,7 @@
 // Paincrit knocks someone down once they hit 60 shock_stage, so by default make it so that close to 100 additional damage needs to be dealt,
 // so that it's similar to PAIN. Lowered it a bit since hitting paincrit takes much longer to wear off than a halloss stun.
 // These control the damage thresholds for the various ways of removing limbs
-/datum/bodypart_controller/proc/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection)
+/datum/bodypart_controller/proc/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection = 0)
 	brute = round(brute * BP.owner.mob_brute_mod.Get(), 0.1)
 	burn = round(burn * BP.owner.mob_burn_mod.Get(), 0.1)
 

--- a/code/modules/surgery/organs/external/flesh.dm
+++ b/code/modules/surgery/organs/external/flesh.dm
@@ -97,8 +97,10 @@
 		damage_amt += burn
 		cur_damage += BP.burn_dam
 
+	var/is_parent_damaged_enough = cur_damage + damage_amt >= BP.max_damage + cutoff_internal_organ_damage_threshold
+	var/are_organs_unprotected = protection <= PROTECTION_REQUERED_FOR_ORGANS
 
-	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage + cutoff_internal_organ_damage_threshold) && (protection <= PROTECTION_REQUERED_FOR_ORGANS))
+	if(BP.bodypart_organs.len && is_parent_damaged_enough && are_organs_unprotected)
 	// Damage an internal organ
 		var/obj/item/organ/internal/IO = pick(BP.bodypart_organs)
 		IO.take_damage(damage_amt / 10)

--- a/code/modules/surgery/organs/external/flesh.dm
+++ b/code/modules/surgery/organs/external/flesh.dm
@@ -88,11 +88,16 @@
 	var/cur_damage = BP.brute_dam
 	var/pure_brute = brute
 	var/pure_burn = burn
+	var/cutoff_internal_organ_damage_threshold = 10
+	if(sharp)
+		cutoff_internal_organ_damage_threshold = 5
+
 	if(laser)
 		damage_amt += burn
 		cur_damage += BP.burn_dam
 
-	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage) && prob(5))
+
+	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage + cutoff_internal_organ_damage_threshold) && prob(5))
 	// Damage an internal organ
 		var/obj/item/organ/internal/IO = pick(BP.bodypart_organs)
 		IO.take_damage(damage_amt / 2)

--- a/code/modules/surgery/organs/external/flesh.dm
+++ b/code/modules/surgery/organs/external/flesh.dm
@@ -57,6 +57,7 @@
 /datum/bodypart_controller/proc/emp_act(severity)
 	return // meatbags do not care about EMP
 
+#define PROTECTION_REQUERED_FOR_ORGANS 25  //The percentage of protection required to prevent organ damage
 
 /mob/living/carbon/human
 	var/next_autoheal_allowed = 0 // turns off autoheal on damage for period of time
@@ -64,7 +65,7 @@
 // Paincrit knocks someone down once they hit 60 shock_stage, so by default make it so that close to 100 additional damage needs to be dealt,
 // so that it's similar to PAIN. Lowered it a bit since hitting paincrit takes much longer to wear off than a halloss stun.
 // These control the damage thresholds for the various ways of removing limbs
-/datum/bodypart_controller/proc/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null)
+/datum/bodypart_controller/proc/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection)
 	brute = round(brute * BP.owner.mob_brute_mod.Get(), 0.1)
 	burn = round(burn * BP.owner.mob_burn_mod.Get(), 0.1)
 
@@ -97,10 +98,10 @@
 		cur_damage += BP.burn_dam
 
 
-	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage + cutoff_internal_organ_damage_threshold) && prob(5))
+	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage + cutoff_internal_organ_damage_threshold) && (protection <= PROTECTION_REQUERED_FOR_ORGANS))
 	// Damage an internal organ
 		var/obj/item/organ/internal/IO = pick(BP.bodypart_organs)
-		IO.take_damage(damage_amt / 2)
+		IO.take_damage(damage_amt / 10)
 
 	if(used_weapon)
 		if(brute > 0 && burn == 0)
@@ -229,6 +230,8 @@
 		BP.owner.UpdateDamageIcon(BP)
 
 	return created_wound
+
+#undef PROTECTION_REQUERED_FOR_ORGANS
 
 /datum/bodypart_controller/proc/heal_damage(brute, burn, internal = 0, robo_repair = 0)
 	if(bodypart_type == BODYPART_ROBOTIC && !robo_repair)

--- a/code/modules/surgery/organs/external/skeleton.dm
+++ b/code/modules/surgery/organs/external/skeleton.dm
@@ -12,7 +12,7 @@
 	return 0
 
 // Bones just fly away if damage is too high. They also don't care about lasers
-/datum/bodypart_controller/skeleton/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection)
+/datum/bodypart_controller/skeleton/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection = 0)
 	if(!BP.owner)
 		return
 	brute = round(brute * BP.owner.mob_brute_mod.Get(), 0.1)

--- a/code/modules/surgery/organs/external/skeleton.dm
+++ b/code/modules/surgery/organs/external/skeleton.dm
@@ -12,7 +12,7 @@
 	return 0
 
 // Bones just fly away if damage is too high. They also don't care about lasers
-/datum/bodypart_controller/skeleton/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null)
+/datum/bodypart_controller/skeleton/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection)
 	if(!BP.owner)
 		return
 	brute = round(brute * BP.owner.mob_brute_mod.Get(), 0.1)

--- a/code/modules/surgery/organs/external/stump.dm
+++ b/code/modules/surgery/organs/external/stump.dm
@@ -52,7 +52,7 @@
 /obj/item/organ/external/stump/emp_act(severity)
 	return
 
-/obj/item/organ/external/stump/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null)
+/obj/item/organ/external/stump/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection)
 	return
 
 /obj/item/organ/external/stump/heal_damage(brute, burn, internal = 0, robo_repair = 0)

--- a/code/modules/surgery/organs/external/stump.dm
+++ b/code/modules/surgery/organs/external/stump.dm
@@ -52,7 +52,7 @@
 /obj/item/organ/external/stump/emp_act(severity)
 	return
 
-/obj/item/organ/external/stump/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection)
+/obj/item/organ/external/stump/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection = 0)
 	return
 
 /obj/item/organ/external/stump/heal_damage(brute, burn, internal = 0, robo_repair = 0)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -1450,7 +1450,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	controller_type = /datum/bodypart_controller/plant
 
 
-/obj/item/organ/external/head/take_damage(brute, burn, damage_flags, used_weapon, impact_direction = null, protection)
+/obj/item/organ/external/head/take_damage(brute, burn, damage_flags, used_weapon, impact_direction = null, protection = 0)
 	if(!disfigured)
 		if(brute_dam > 40)
 			if (prob(50))

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -408,10 +408,10 @@
 /obj/item/organ/external/emp_act(severity)
 	controller.emp_act(severity)
 
-/obj/item/organ/external/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null)
+/obj/item/organ/external/take_damage(brute = 0, burn = 0, damage_flags = 0, used_weapon = null, impact_direction = null, protection)
 	if(!isnum(burn))
 		return // prevent basic take_damage usage (TODO remove workaround)
-	return controller.take_damage(brute, burn, damage_flags, used_weapon, impact_direction = impact_direction)
+	return controller.take_damage(brute, burn, damage_flags, used_weapon, impact_direction = impact_direction,  protection = protection)
 
 /obj/item/organ/external/proc/heal_damage(brute, burn, internal = 0, robo_repair = 0)
 	return controller.heal_damage(brute, burn, internal, robo_repair)
@@ -1449,7 +1449,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/r_leg/diona/podman
 	controller_type = /datum/bodypart_controller/plant
 
-/obj/item/organ/external/head/take_damage(brute, burn, damage_flags, used_weapon, impact_direction = null)
+
+/obj/item/organ/external/head/take_damage(brute, burn, damage_flags, used_weapon, impact_direction = null, protection)
 	if(!disfigured)
 		if(brute_dam > 40)
 			if (prob(50))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
альтернатива #14610
шанс повредить органы появляется только если часть тела впитала достаточно урона (75 для сундука и головы) и не имеет хотя бы 25% защиты от соответствующего урона
## Почему и что этот ПР улучшит
внезапная смерть от первого же выстрела из лазгана по тебе - не круто
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- balance: Шанс на повреждение органов появляется только тогда, когда часть тела получила достаточно большое количество урона и не имеет бронезащиты.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
