### PR TITLE
лярвы снова больше не застревают в мартышках

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -15,6 +15,9 @@
 	var/obj/item/alien_embryo/E = locate() in buckled_mob
 	if(E && E.stage >= 5)
 		return
+	var/mob/living/carbon/xenomorph/larva/L = locate() in buckled_mob
+	if(L)
+		return
 	buckled_mob.heal_bodypart_damage(5, 5)
 	buckled_mob.adjustToxLoss(-5)
 	buckled_mob.adjustOxyLoss(-10)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fix: #14635 
#14513 фиксил только если в мартышке сидел эмбрион который сделал ИИ фейсхаггер, если фейсхаггером был игрок он не считался за эмбриона
## Почему и что этот ПР улучшит
снова багфикс
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Лярвы снова не застревают в мартышках.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
