### PR TITLE
Фикс абдуктор рекол импланта и невидимых абдуктор инструментов

### DIFF
--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -449,34 +449,46 @@
 /obj/item/weapon/scalpel/alien
 	name = "alien scalpel"
 	icon = 'icons/obj/abductor.dmi'
+	item_state_world = null
 	toolspeed = 0.3
 
 /obj/item/weapon/hemostat/alien
 	name = "alien hemostat"
 	icon = 'icons/obj/abductor.dmi'
+	item_state_world = null
 	toolspeed = 0.3
 
 /obj/item/weapon/retractor/alien
 	name = "alien retractor"
 	icon = 'icons/obj/abductor.dmi'
+	item_state_world = null
 	toolspeed = 0.3
 
 /obj/item/weapon/circular_saw/alien
 	name = "alien saw"
 	icon = 'icons/obj/abductor.dmi'
+	item_state_world = null
 	icon_state = "saw"
 	toolspeed = 0.3
 
 /obj/item/weapon/surgicaldrill/alien
 	name = "alien drill"
 	icon = 'icons/obj/abductor.dmi'
+	item_state_world = null
 	toolspeed = 0.3
 
 /obj/item/weapon/cautery/alien
 	name = "alien cautery"
 	icon = 'icons/obj/abductor.dmi'
+	item_state_world = null
 	toolspeed = 0.3
 
+/obj/item/weapon/bonegel/alien
+	name = "alien ectoplasm"
+	desc = "Contains ecotplasm. In the case of ingestion can cause to stomach pains."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "ectoplasm"
+	item_state_world = null
 
 // OPERATING TABLE / BEDS / LOCKERS	/ OTHER
 /obj/machinery/optable/abductor
@@ -571,12 +583,6 @@
 	icon_state  = "abductor"
 	icon_opened = "abductoropen"
 	icon_closed = "abductor"
-
-/obj/item/weapon/bonegel/alien
-	name = "alien ectoplasm"
-	desc = "Contains ecotplasm. In the case of ingestion can cause to stomach pains."
-	icon = 'icons/obj/abductor.dmi'
-	icon_state = "ectoplasm"
 
 /obj/item/weapon/paper/abductor
 	name = "Dissection Guide"

--- a/code/game/gamemodes/roles/abductor.dm
+++ b/code/game/gamemodes/roles/abductor.dm
@@ -101,11 +101,6 @@
 	var/mob/living/carbon/human/scientist = antag.current
 	var/obj/item/device/abductor/gizmo/G = new /obj/item/device/abductor/gizmo(scientist)
 	scientist.equip_to_slot_or_del(G, SLOT_IN_BACKPACK)
-
-	var/datum/faction/abductors/A = faction
-	if(!istype(A))
-		return
-
 	var/obj/item/weapon/implant/abductor/beamplant = new /obj/item/weapon/implant/abductor(scientist)
 	for(var/obj/machinery/abductor/console/console in range(2, scientist))
 		console.gizmo = G

--- a/code/game/objects/items/weapons/implants/_implant.dm
+++ b/code/game/objects/items/weapons/implants/_implant.dm
@@ -35,7 +35,6 @@
 	global.implant_list += src
 	if(iscarbon(loc))
 		inject(loc)
-		loc = null
 
 /obj/item/weapon/implant/Destroy()
 	if(implanted_mob)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убирает у инструментов абдуктора наследуемый item_world_state из-за чего они были невидимые.
Фиксит action кнопки у имплантов которые были созданы через new /obj/item/weapon/implant(human)
## Почему и что этот ПР улучшит
Можно будет играть за абдукторов без педальского вмешательства.
## Авторство
AirBlack
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


-->

:cl: AirBlack
 - bugfix: Фикс world иконок инструментов абдуктора
 - bugfix: Фикс нерабочих action кнопок у имплантов имплантируемых через new 
