### PR TITLE
Swallow fix

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/swallow.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/swallow.dm
@@ -53,7 +53,7 @@
 	                     "<span class='notice'>We have devour [target]!</span>")
 	to_chat(target, "<span class='danger'>You have been devoured by the changeling!</span>")
 	var/mob/living/carbon/human/changeling = user
-	changeling.mind.pluvian_social_credit += target.mind.pluvian_social_credit
+	changeling.mind.pluvian_social_credit += target.mind?.pluvian_social_credit
 	for(var/obj/item/I in target)
 		target.drop_from_inventory(I)
 	target.spawn_gibs()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

## Почему и что этот ПР улучшит
Чейнжлинг жрет жертву, но по какой-то причине у неё нет разума => 
социальный кредит плова не у чего отнимать => 
рантайм и прекращение прока => 
на линге остается трейт пожирания =>
линг не может больше жрать

Вчера подобная проблема возникла у одного из чейнжлингов
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
 - bugfix: Генокрад может поглощать мобов без разума без опаски сломаться