### PR TITLE
fix #14620 (бесполезный второй глок у медика ОБР)

### DIFF
--- a/code/datums/outfits/misc/responders.dm
+++ b/code/datums/outfits/misc/responders.dm
@@ -135,7 +135,7 @@
 
 	suit_store = /obj/item/weapon/gun/medbeam
 
-	backpack_contents = list(/obj/item/weapon/gun/energy/gun/nuclear, /obj/item/bodybag/cryobag = 2, /obj/item/weapon/storage/box/bodybags, /obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/storage/firstaid/adv, /obj/item/weapon/shockpaddles/standalone, /obj/item/weapon/gun/projectile/automatic/pistol/glock/spec, /obj/item/weapon/crowbar/red, /obj/item/weapon/melee/baton)
+	backpack_contents = list(/obj/item/weapon/gun/energy/gun/nuclear, /obj/item/bodybag/cryobag = 2, /obj/item/weapon/storage/box/bodybags, /obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/storage/firstaid/adv, /obj/item/weapon/shockpaddles/standalone, /obj/item/weapon/melee/baton)
 
 	assignment = "Emergency Response Team Medic"
 
@@ -143,7 +143,8 @@
 	name = "Responders: NT ERT Medic (EMT)"
 
 	l_pocket = /obj/item/weapon/storage/pouch/medical_supply/combat
-
+	backpack_contents = list(/obj/item/weapon/gun/energy/gun/nuclear, /obj/item/bodybag/cryobag = 2, /obj/item/weapon/storage/box/bodybags, /obj/item/weapon/storage/firstaid/adv, /obj/item/weapon/shockpaddles/standalone, /obj/item/weapon/melee/baton, /obj/item/weapon/gun/projectile/automatic/pistol/glock/spec)
+	r_ear = /obj/item/weapon/reagent_containers/syringe
 	assignment = "Emergency Medical Team Medic"
 
 /datum/outfit/responders/nanotrasen_ert/medic/emt/surgeon


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В этом пре #14620  при спауне обычного медика ОБР у него появлялось два глока, что не есть хорошо, поэтому попроавил это дело и выдал глоки именно Responders: NT ERT Medic и Emergency Medical Team Surgeon
Ну и удалил лом, потому что фикшу эту проблему в этом пре #14652
## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->
Riverz
## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - bugfix: Убрал второй глок у медика ОБР