### PR TITLE
прикольный админский шёпот

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1737,7 +1737,7 @@
 			attachment_color = BRIDGE_COLOR_ADMINCOM,
 		)
 
-		to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. <b>\"[input]\"</b>  Message ends.\"")
+		to_chat(H, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='orange'>Центрального Командования</font></b>. Передаю: <b>\"[input]\"</b> Конец связи.\"")
 
 	else if(href_list["SyndicateReply"])
 		var/mob/living/carbon/human/H = locate(href_list["SyndicateReply"])
@@ -1763,7 +1763,7 @@
 			attachment_msg = input,
 			attachment_color = BRIDGE_COLOR_ADMINCOM,
 		)
-		to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from your benefactor.  Message as follows, agent. <b>\"[input]\"</b>  Message ends.\"")
+		to_chat(H, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='red'><i>Синдиката</i></font></b>. Слушайте внимательно, агент: <b>\"[input]\"</b> Конец связи.\"")
 
 	else if(href_list["CentcommFaxViewInfo"])
 		var/info = locate(href_list["CentcommFaxViewInfo"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1737,7 +1737,7 @@
 			attachment_color = BRIDGE_COLOR_ADMINCOM,
 		)
 
-		to_chat(H, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='orange'>Центрального Командования</font></b>. Передаю: <b>\"[input]\"</b> Конец связи.\"")
+		to_chat(H, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"На связи <b><font color='blue'>Центральное Командование</font></b>. Прослушайте внимательно следующую информацию: <b>\"[input]\"</b> Конец связи.\"")
 
 	else if(href_list["SyndicateReply"])
 		var/mob/living/carbon/human/H = locate(href_list["SyndicateReply"])

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -53,7 +53,7 @@
 		to_chat(src, "Only administrators may use this command.")
 		return
 
-	var/source = tgui_alert(src, "Выберите источник сообщения:", "Subtle Message для [M.key]", list("Голос в голове", "ЦК", "Синдикат", "Custom"))
+	var/source = tgui_alert(src, "Выберите источник сообщения:", "Subtle Message для [M.key]", list("Голос в голове", "ЦК", "Синдикат", "Свой"))
 	if(!source)
 		return
 
@@ -79,7 +79,7 @@
 
 	var/custom_color = "green"
 	var/custom_sender = ""
-	if(source == "Custom")
+	if(source == "Свой")
 		var/col_choice = tgui_alert(src, "Выберите цвет имени:", "Цвет", list("Зелёный", "Синий", "ХОНК", "Серый"))
 		if(!col_choice)
 			return
@@ -107,13 +107,13 @@
 						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"На связи <b><font color='blue'>Центральное Командование</font></b>. Прослушайте внимательно следующую информацию: <b>\"[msg]\"</b> Конец связи.\"")
 					if("Синдикат")
 						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='red'><i>Синдиката</i></font></b>. Слушайте внимательно, агент: <b>\"[msg]\"</b> Конец связи.\"")
-					if("Custom")
+					if("Свой")
 						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='[custom_color]'>[custom_sender]</font></b>. Сообщение: <b>\"[msg]\"</b> Конец связи.\"")
 
 	log_admin("SubtlePM([source]): [key_name(usr)] -> [key_name(M)] : [msg]")
 	message_admins("<span class='notice'><b>SubtleMessage([source])</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")
 
-	if(source != "Голос в голове" && source != "Custom")
+	if(source != "Голос в голове" && source != "Свой")
 		world.send2bridge(
 			type = list(BRIDGE_ADMINCOM),
 			attachment_title = "[source == "ЦК" ? ":regional_indicator_c:" : ":regional_indicator_s:"] **[key_name(usr)]** replied to **[key_name(M)]** via Subtle Message",

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -88,9 +88,9 @@
 					if("Voice in head")
 						to_chat(M, "<b>You hear a voice in your head... <i>[msg]</i></b>")
 					if("CentCom")
-						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. <b>\"[msg]\"</b>  Message ends.\"")
+						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from <b><font color='orange'>Central Command</font></b>.  Message as follows. <b>\"[msg]\"</b>  Message ends.\"")
 					if("Syndicate")
-						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from your benefactor.  Message as follows, agent. <b>\"[msg]\"</b>  Message ends.\"")
+						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from <b><font color='red'>YOUR BENEFACTOR</font></b>.  Message as follows, agent. <b>\"[msg]\"</b>  Message ends.\"")
 
 	log_admin("SubtlePM([source]): [key_name(usr)] -> [key_name(M)] : [msg]")
 	message_admins("<span class='notice'><b>SubtleMessage([source])</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -86,11 +86,11 @@
 			if(usr.client.holder)
 				switch(source)
 					if("Voice in head")
-						to_chat(M, "<b>You hear a voice in your head... <i>[msg]</i></b>")
+						to_chat(M, "<b>Вы слышите голос в своей голове... <i>[msg]</i></b>")
 					if("CentCom")
-						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from <b><font color='orange'>Central Command</font></b>.  Message as follows. <b>\"[msg]\"</b>  Message ends.\"")
+						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='orange'>Центрального Командования</font></b>. Передаю: <b>\"[msg]\"</b> Конец связи.\"")
 					if("Syndicate")
-						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from <b><font color='red'>YOUR BENEFACTOR</font></b>.  Message as follows, agent. <b>\"[msg]\"</b>  Message ends.\"")
+						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='red'><i>Синдиката</i></font></b>. Слушайте внимательно, агент: <b>\"[msg]\"</b> Конец связи.\"")
 
 	log_admin("SubtlePM([source]): [key_name(usr)] -> [key_name(M)] : [msg]")
 	message_admins("<span class='notice'><b>SubtleMessage([source])</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")
@@ -176,14 +176,24 @@
 	if(!M)
 		return
 
+	var/style = tgui_alert(src, "Choose narration style:", "Direct Narrate to [M.key]", list("Narration", "Feeling", "Vision"))
+	if(!style)
+		return
+
 	var/msg = sanitize(input("Message:", text("Enter the text you wish to appear to your target:")) as text)
 
 	if( !msg )
 		return
 
-	to_chat(M, msg)
-	log_admin("DirectNarrate: [key_name(usr)] to [key_name(M)]: [msg]")
-	message_admins("<span class='notice'><b>DirectNarrate</b>: [key_name(usr)] to [key_name(M)]: [msg]<BR></span>")
+	switch(style)
+		if("Narration")
+			to_chat(M, "<big><b><span class='notice'><i>[msg]</i></span></b></big>")
+		if("Feeling")
+			to_chat(M, "<big><b><span class='notice'><i>Вы чувствуете... [msg]</i></span></b></big>")
+		if("Vision")
+			to_chat(M, "<big><b><span class='notice'><i>Вы замечаете... [msg]</i></span></b></big>")
+	log_admin("DirectNarrate([style]): [key_name(usr)] to [key_name(M)]: [msg]")
+	message_admins("<span class='notice'><b>DirectNarrate([style])</b>: [key_name(usr)] to [key_name(M)]: [msg]<BR></span>")
 	feedback_add_details("admin_verb","DIRN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_godmode(mob/living/M as mob in mob_list)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -97,29 +97,27 @@
 
 	if (!msg)
 		return
-	if(usr)
-		if (usr.client)
-			if(usr.client.holder)
-				switch(source)
-					if("Голос в голове")
-						to_chat(M, "<b>Вы слышите голос в своей голове... <i>[msg]</i></b>")
-					if("ЦК")
-						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"На связи <b><font color='blue'>Центральное Командование</font></b>. Прослушайте внимательно следующую информацию: <b>\"[msg]\"</b> Конец связи.\"")
-					if("Синдикат")
-						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='red'><i>Синдиката</i></font></b>. Слушайте внимательно, агент: <b>\"[msg]\"</b> Конец связи.\"")
-					if("Свой")
-						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='[custom_color]'>[custom_sender]</font></b>. Сообщение: <b>\"[msg]\"</b> Конец связи.\"")
+	if(usr?.client?.holder)
+		switch(source)
+			if("Голос в голове")
+				to_chat(M, "<b>Вы слышите голос в своей голове... <i>[msg]</i></b>")
+			if("ЦК")
+				to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"На связи <b><font color='blue'>Центральное Командование</font></b>. Прослушайте внимательно следующую информацию: <b>\"[msg]\"</b> Конец связи.\"")
+			if("Синдикат")
+				to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='red'><i>Синдиката</i></font></b>. Слушайте внимательно, агент: <b>\"[msg]\"</b> Конец связи.\"")
+			if("Свой")
+				to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='[custom_color]'>[custom_sender]</font></b>. Сообщение: <b>\"[msg]\"</b> Конец связи.\"")
 
-	log_admin("SubtlePM([source]): [key_name(usr)] -> [key_name(M)] : [msg]")
-	message_admins("<span class='notice'><b>SubtleMessage([source])</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")
+		log_admin("SubtlePM([source]): [key_name(usr)] -> [key_name(M)] : [msg]")
+		message_admins("<span class='notice'><b>SubtleMessage([source])</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")
 
-	if(source != "Голос в голове" && source != "Свой")
-		world.send2bridge(
-			type = list(BRIDGE_ADMINCOM),
-			attachment_title = "[source == "ЦК" ? ":regional_indicator_c:" : ":regional_indicator_s:"] **[key_name(usr)]** replied to **[key_name(M)]** via Subtle Message",
-			attachment_msg = msg,
-			attachment_color = BRIDGE_COLOR_ADMINCOM,
-		)
+		if(source == "ЦК" || source == "Синдикат")
+			world.send2bridge(
+				type = list(BRIDGE_ADMINCOM),
+				attachment_title = "[source == "ЦК" ? ":regional_indicator_c:" : ":regional_indicator_s:"] **[key_name(usr)]** replied to **[key_name(M)]** via Subtle Message",
+				attachment_msg = msg,
+				attachment_color = BRIDGE_COLOR_ADMINCOM,
+			)
 
 	feedback_add_details("admin_verb","SMS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -53,6 +53,30 @@
 		to_chat(src, "Only administrators may use this command.")
 		return
 
+	var/source = tgui_alert(src, "Choose message source:", "Subtle Message to [M.key]", list("Voice in head", "CentCom", "Syndicate"))
+	if(!source)
+		return
+
+	if(source == "CentCom")
+		if(isliving(M))
+			var/mob/living/L = M
+			if(!L.CanObtainCentcommMessage())
+				to_chat(src, "The person you are trying to contact is not wearing a headset.")
+				return
+		else
+			to_chat(src, "CentCom messages can only be sent to living mobs.")
+			return
+
+	if(source == "Syndicate")
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(!istype(H.l_ear, /obj/item/device/radio/headset) && !istype(H.r_ear, /obj/item/device/radio/headset))
+				to_chat(src, "The person you are trying to contact is not wearing a headset.")
+				return
+		else
+			to_chat(src, "Syndicate messages can only be sent to humans.")
+			return
+
 	var/msg = sanitize(input("Message:", text("Subtle PM to [M.key]")) as text)
 
 	if (!msg)
@@ -60,10 +84,25 @@
 	if(usr)
 		if (usr.client)
 			if(usr.client.holder)
-				to_chat(M, "<b>You hear a voice in your head... <i>[msg]</i></b>")
+				switch(source)
+					if("Voice in head")
+						to_chat(M, "<b>You hear a voice in your head... <i>[msg]</i></b>")
+					if("CentCom")
+						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. <b>\"[msg]\"</b>  Message ends.\"")
+					if("Syndicate")
+						to_chat(M, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from your benefactor.  Message as follows, agent. <b>\"[msg]\"</b>  Message ends.\"")
 
-	log_admin("SubtlePM: [key_name(usr)] -> [key_name(M)] : [msg]")
-	message_admins("<span class='notice'><b>SubtleMessage</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")
+	log_admin("SubtlePM([source]): [key_name(usr)] -> [key_name(M)] : [msg]")
+	message_admins("<span class='notice'><b>SubtleMessage([source])</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")
+
+	if(source != "Voice in head")
+		world.send2bridge(
+			type = list(BRIDGE_ADMINCOM),
+			attachment_title = "[source == "CentCom" ? ":regional_indicator_c:" : ":regional_indicator_s:"] **[key_name(usr)]** replied to **[key_name(M)]** via Subtle Message",
+			attachment_msg = msg,
+			attachment_color = BRIDGE_COLOR_ADMINCOM,
+		)
+
 	feedback_add_details("admin_verb","SMS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_mentor_check_new_players()	//Allows mentors / admins to determine who the newer players are.

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -53,11 +53,11 @@
 		to_chat(src, "Only administrators may use this command.")
 		return
 
-	var/source = tgui_alert(src, "Choose message source:", "Subtle Message to [M.key]", list("Voice in head", "CentCom", "Syndicate"))
+	var/source = tgui_alert(src, "Выберите источник сообщения:", "Subtle Message для [M.key]", list("Голос в голове", "ЦК", "Синдикат", "Custom"))
 	if(!source)
 		return
 
-	if(source == "CentCom")
+	if(source == "ЦК")
 		if(isliving(M))
 			var/mob/living/L = M
 			if(!L.CanObtainCentcommMessage())
@@ -67,7 +67,7 @@
 			to_chat(src, "CentCom messages can only be sent to living mobs.")
 			return
 
-	if(source == "Syndicate")
+	if(source == "Синдикат")
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(!istype(H.l_ear, /obj/item/device/radio/headset) && !istype(H.r_ear, /obj/item/device/radio/headset))
@@ -75,6 +75,22 @@
 				return
 		else
 			to_chat(src, "Syndicate messages can only be sent to humans.")
+			return
+
+	var/custom_color = "green"
+	var/custom_sender = ""
+	if(source == "Custom")
+		var/col_choice = tgui_alert(src, "Выберите цвет имени:", "Цвет", list("Зелёный", "Синий", "ХОНК", "Серый"))
+		if(!col_choice)
+			return
+		switch(col_choice)
+			if("Зелёный") custom_color = "green"
+			if("Синий") custom_color = "#3366ff" // a nice readable blue
+			if("ХОНК") custom_color = "#ff1493" // deep pink, readable
+			if("Серый") custom_color = "gray"
+
+		custom_sender = sanitize(input("Введите имя отправителя:", text("Отправитель для [M.key]")) as text)
+		if(!custom_sender)
 			return
 
 	var/msg = sanitize(input("Message:", text("Subtle PM to [M.key]")) as text)
@@ -85,20 +101,22 @@
 		if (usr.client)
 			if(usr.client.holder)
 				switch(source)
-					if("Voice in head")
+					if("Голос в голове")
 						to_chat(M, "<b>Вы слышите голос в своей голове... <i>[msg]</i></b>")
-					if("CentCom")
-						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='orange'>Центрального Командования</font></b>. Передаю: <b>\"[msg]\"</b> Конец связи.\"")
-					if("Syndicate")
+					if("ЦК")
+						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"На связи <b><font color='blue'>Центральное Командование</font></b>. Прослушайте внимательно следующую информацию: <b>\"[msg]\"</b> Конец связи.\"")
+					if("Синдикат")
 						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='red'><i>Синдиката</i></font></b>. Слушайте внимательно, агент: <b>\"[msg]\"</b> Конец связи.\"")
+					if("Custom")
+						to_chat(M, "Вы слышите треск в гарнитуре, после чего раздаётся голос: \"Ожидайте сообщение от <b><font color='[custom_color]'>[custom_sender]</font></b>. Сообщение: <b>\"[msg]\"</b> Конец связи.\"")
 
 	log_admin("SubtlePM([source]): [key_name(usr)] -> [key_name(M)] : [msg]")
 	message_admins("<span class='notice'><b>SubtleMessage([source])</b>: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]</span>")
 
-	if(source != "Voice in head")
+	if(source != "Голос в голове" && source != "Custom")
 		world.send2bridge(
 			type = list(BRIDGE_ADMINCOM),
-			attachment_title = "[source == "CentCom" ? ":regional_indicator_c:" : ":regional_indicator_s:"] **[key_name(usr)]** replied to **[key_name(M)]** via Subtle Message",
+			attachment_title = "[source == "ЦК" ? ":regional_indicator_c:" : ":regional_indicator_s:"] **[key_name(usr)]** replied to **[key_name(M)]** via Subtle Message",
 			attachment_msg = msg,
 			attachment_color = BRIDGE_COLOR_ADMINCOM,
 		)
@@ -176,24 +194,14 @@
 	if(!M)
 		return
 
-	var/style = tgui_alert(src, "Choose narration style:", "Direct Narrate to [M.key]", list("Narration", "Feeling", "Vision"))
-	if(!style)
-		return
-
 	var/msg = sanitize(input("Message:", text("Enter the text you wish to appear to your target:")) as text)
 
 	if( !msg )
 		return
 
-	switch(style)
-		if("Narration")
-			to_chat(M, "<big><b><span class='notice'><i>[msg]</i></span></b></big>")
-		if("Feeling")
-			to_chat(M, "<big><b><span class='notice'><i>Вы чувствуете... [msg]</i></span></b></big>")
-		if("Vision")
-			to_chat(M, "<big><b><span class='notice'><i>Вы замечаете... [msg]</i></span></b></big>")
-	log_admin("DirectNarrate([style]): [key_name(usr)] to [key_name(M)]: [msg]")
-	message_admins("<span class='notice'><b>DirectNarrate([style])</b>: [key_name(usr)] to [key_name(M)]: [msg]<BR></span>")
+	to_chat(M, "<big><b><span class='notice'><i>[msg]</i></span></b></big>")
+	log_admin("DirectNarrate: [key_name(usr)] to [key_name(M)]: [msg]")
+	message_admins("<span class='notice'><b>DirectNarrate</b>: [key_name(usr)] to [key_name(M)]: [msg]<BR></span>")
 	feedback_add_details("admin_verb","DIRN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_godmode(mob/living/M as mob in mob_list)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
сделал direct message пожирнее а то его в текущем виде пропустить легче лёгкого
было
<img width="620" height="36" alt="image" src="https://github.com/user-attachments/assets/2bf9bb3b-ff68-4b9a-8524-8d69c41aeebe" />
стало
<img width="809" height="41" alt="image" src="https://github.com/user-attachments/assets/8e768cb4-2e46-487d-95a0-26f72e2806d5" />

и самое главное добавил опцию шёпота от имени ЦК/Синдиката через subtle message, до этого такие сообщения админ мог отправить только после взаимодействия игроком с консолью коммуникаций
<img width="904" height="34" alt="Screenshot 2026-04-14 015530" src="https://github.com/user-attachments/assets/fc60dbf3-716a-40ec-9d8b-edda433753db" />
<img width="907" height="34" alt="image" src="https://github.com/user-attachments/assets/164f3027-dabb-4f62-a468-fa1c8dbaf725" />
<img width="887" height="31" alt="image" src="https://github.com/user-attachments/assets/1e939cde-b808-405a-9f1d-0ef5329c074a" />

## Почему и что этот ПР улучшит
больше опций для рпшки для игроков от админов
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - tweak: Direct Narrate стал чуть жирнее, Subtle Message добавлены новые опции для админского шёпота
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
