### PR TITLE
Добавлен звук и анимация при ходьбе моба клоуна

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -21,7 +21,6 @@
 	melee_damage = 10
 	attacktext = "attacks"
 	attack_sound = list('sound/items/bikehorn.ogg')
-
 	min_oxy = 5
 	max_oxy = 0
 	min_tox = 0
@@ -32,14 +31,37 @@
 	max_n2 = 0
 	minbodytemp = 270
 	maxbodytemp = 370
-	heat_damage_per_tick = 15	//amount of damage applied if animal's body temperature is higher than maxbodytemp
-	cold_damage_per_tick = 10	//same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
+	heat_damage_per_tick = 15 //amount of damage applied if animal's body temperature is higher than maxbodytemp
+	cold_damage_per_tick = 10 //same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
 	unsuitable_atoms_damage = 10
-
 	animalistic = FALSE
 	has_head = TRUE
 	has_arm = TRUE
 	has_leg = TRUE
+
+/mob/living/simple_animal/hostile/retaliate/clown/atom_init()
+	. = ..()
+	AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_PIXELMOVE))
+
+/mob/living/simple_animal/hostile/retaliate/clown/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0)
+	. = ..()
+	if(.)
+		play_unique_footstep_sound()
+
+/mob/living/simple_animal/hostile/retaliate/clown/proc/play_unique_footstep_sound()
+	playsound(src, pick(SOUNDIN_CLOWNSTEP), VOL_EFFECTS_MASTER)
+
+/mob/living/simple_animal/hostile/retaliate/clown/Destroy()
+	var/datum/component/waddle/W = GetComponent(/datum/component/waddle)
+	if(W)
+		qdel(W)
+	return ..()
+
+/mob/living/simple_animal/hostile/retaliate/clown/death(gibbed)
+	var/datum/component/waddle/W = GetComponent(/datum/component/waddle)
+	if(W)
+		qdel(W)
+	return ..()
 
 /mob/living/simple_animal/hostile/clown //Here's CopyPasta!!
 	name = "Clown"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -52,15 +52,6 @@
 	if(. && stat == CONSCIOUS)
 		playsound(src, pick(SOUNDIN_CLOWNSTEP), VOL_EFFECTS_MASTER)
 
-/mob/living/simple_animal/hostile/retaliate/clown/death(gibbed)
-	qdel(GetComponent(/datum/component/waddle))
-	return ..()
-
-/mob/living/simple_animal/hostile/retaliate/clown/revive()
-	. = ..()
-	if(.)
-		AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_PIXELMOVE))
-
 /mob/living/simple_animal/hostile/clown //Here's CopyPasta!!
 	name = "Clown"
 	desc = "А вот и Клоуни!"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -5,6 +5,7 @@
 	icon_living = "clown"
 	icon_dead = "clown_dead"
 	icon_gib = "clown_gib"
+
 	speak_chance = 0
 	turns_per_move = 5
 	response_help = "pokes the"
@@ -14,6 +15,7 @@
 	emote_see = list("хонкает")
 	speak_chance = 1
 	stop_automated_movement_when_pulled = FALSE
+
 	maxHealth = 75
 	health = 75
 	speed = -1
@@ -21,6 +23,7 @@
 	melee_damage = 10
 	attacktext = "attacks"
 	attack_sound = list('sound/items/bikehorn.ogg')
+
 	min_oxy = 5
 	max_oxy = 0
 	min_tox = 0
@@ -34,6 +37,7 @@
 	heat_damage_per_tick = 15 //amount of damage applied if animal's body temperature is higher than maxbodytemp
 	cold_damage_per_tick = 10 //same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
 	unsuitable_atoms_damage = 10
+
 	animalistic = FALSE
 	has_head = TRUE
 	has_arm = TRUE
@@ -45,23 +49,17 @@
 
 /mob/living/simple_animal/hostile/retaliate/clown/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0)
 	. = ..()
-	if(.)
-		play_unique_footstep_sound()
-
-/mob/living/simple_animal/hostile/retaliate/clown/proc/play_unique_footstep_sound()
-	playsound(src, pick(SOUNDIN_CLOWNSTEP), VOL_EFFECTS_MASTER)
-
-/mob/living/simple_animal/hostile/retaliate/clown/Destroy()
-	var/datum/component/waddle/W = GetComponent(/datum/component/waddle)
-	if(W)
-		qdel(W)
-	return ..()
+	if(. && stat == CONSCIOUS)
+		playsound(src, pick(SOUNDIN_CLOWNSTEP), VOL_EFFECTS_MASTER)
 
 /mob/living/simple_animal/hostile/retaliate/clown/death(gibbed)
-	var/datum/component/waddle/W = GetComponent(/datum/component/waddle)
-	if(W)
-		qdel(W)
+	qdel(GetComponent(/datum/component/waddle))
 	return ..()
+
+/mob/living/simple_animal/hostile/retaliate/clown/revive()
+	. = ..()
+	if(.)
+		AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_PIXELMOVE))
 
 /mob/living/simple_animal/hostile/clown //Here's CopyPasta!!
 	name = "Clown"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавлен звук и анимация при ходьбе моба клоуну как у ботинок клоуна
(хочу добавить раунд старт ивент где будет этот клоун) поэтому добавил не много приколюх)
## Почему и что этот ПР улучшит
Клоун моб стал тру клоуном с крутым звуком и анимацией 
## Авторство
Riverz
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: Добавлен звук и анимация при ходьбе моба клоуна