### PR TITLE
 Картавость и шепелявость не влияют на язык жестов

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -137,7 +137,7 @@
 
 	message = accent_sounds(message, speaking)
 
-	if(HAS_TRAIT(src, TRAIT_DYSLALIA))
+	if(HAS_TRAIT(src, TRAIT_DYSLALIA) && !(speaking && (speaking.flags & SIGNLANG)))
 		message = message_with_dyslalia(message)
 
 	if(!speaking)


### PR DESCRIPTION


<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Fix #14659 
Особка дефекта речи "слая судьба" больше не распространяется на язык жестов.
## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->
Pufikc
## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl: Pufikc
 - bugfix: Особка дефекта речи "слая судьба" больше не распространяется на язык жестов.