### PR TITLE
Опечатка в коде флешбенгов

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -114,8 +114,8 @@
 				if(!banglet && !(istype(src , /obj/item/weapon/grenade/clusterbuster)))
 					if(IO.damage >= IO.min_broken_damage)
 						to_chat(M, "<span class='warning'>Вы ничего не видите!</span>")
-			if(H.species.name == SHADOWLING) // BBQ from shadowling ~Zve
-				H.adjustFireLoss(rand(15, 25))
+		if(H.species.name == SHADOWLING) // BBQ from shadowling ~Zve
+			H.adjustFireLoss(rand(15, 25))
 	if(M.ear_damage >= 15)
 		to_chat(M, "<span class='warning'>Вы чувствуете сильный звон в ушах!</span>")
 		if(!banglet && !(istype(src , /obj/item/weapon/grenade/clusterbuster)))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я ещё в ревью апдейта органов писал, что проверка на наличие глаз к урону по шэдоулингам отношения никакого не имеет, но был по какой-то причине проигнорирован.
## Почему и что этот ПР улучшит
В каком-то супер редком исключительном случае не будет бага.
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: Шедоулинг с вырезанными глазами не получал урон от светошумовых гранат.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
