### PR TITLE
теперь у скелетов мага удаляются импланты и появляются нотесы

### DIFF
--- a/code/game/gamemodes/modes_gameplays/wizard/artefact.dm
+++ b/code/game/gamemodes/modes_gameplays/wizard/artefact.dm
@@ -44,8 +44,10 @@
 	M.makeSkeleton()
 	M.revive()
 	spooky_scaries |= M
-	to_chat(M, "<span class='userdanger'>You have been revived by </span><B>[user.real_name]!</B>")
-	to_chat(M, "<span class='userdanger'>[user.real_name] your master now, assist them even if it costs you your new life!</span>")
+	to_chat(M, "<h2><span class='userdanger'>You have been revived by </span>[user.real_name]!</h2>")
+	M.mind.store_memory("<B>You have been revived by [user.real_name]!</B>")
+	to_chat(M, "<h2><span class='userdanger'>[user.real_name] your master now, assist them even if it costs you your new life!</span></h2>")
+	M.mind.store_memory("<B>[user.real_name] your master, assist them even if it costs you your new life!</B>")
 	equip_roman_skeleton(M)
 	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
 
@@ -64,6 +66,8 @@
 	listclearnulls(spooky_scaries)
 
 /obj/item/device/necromantic_stone/proc/equip_roman_skeleton(mob/living/carbon/human/H)
+	for(var/obj/item/weapon/implant/I in H.implants)
+		qdel(I)
 	for(var/obj/item/I in H)
 		H.remove_from_mob(I)
 	H.sec_hud_set_implants()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
см. название
ещё сделал текст чуть более заметным
<img width="761" height="119" alt="image" src="https://github.com/user-attachments/assets/2dab2c8e-ccb3-4664-81f4-c6dc79abdbfc" />
<img width="374" height="286" alt="image" src="https://github.com/user-attachments/assets/802d4747-3ae7-4701-8b5e-933a76eff1af" />

## Почему и что этот ПР улучшит
fix #14691
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: У скелета магов оставались импланты.
- add: Добавлен нотес при превращении в скелета-трелла мага.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
