### PR TITLE
Подтягиваем перевод зон для культа

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/rune_datum.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/rune_datum.dm
@@ -263,7 +263,7 @@
 
 	statue = new(rune_turf, holder)
 	var/religify_compelted = R.religify_area(area.type, CALLBACK(src, PROC_REF(capture_iteration)), null, TRUE)
-	religion.send_message_to_members("Захват [area] [religify_compelted ? "удался" : "провален"].", pick(religion.deity_names))
+	religion.send_message_to_members("Захват [CASE(area, GENITIVE_CASE)] [religify_compelted ? "удался" : "провален"].", pick(religion.deity_names))
 	message_admins("Capture of [area] [religify_compelted ? "successful" : "failed"].")
 	R.capturing_area = FALSE
 
@@ -272,7 +272,8 @@
 		return FALSE
 
 	if((100*i)/all_items.len % 25 == 0)
-		religion.send_message_to_members("Захват [get_area(holder)] завершен на [round((100*i)/all_items.len, 0.1)]%", font_size = 2)
+		var/area/A = get_area(holder) //for cases
+		religion.send_message_to_members("Захват [CASE(A, GENITIVE_CASE)] завершен на [round((100*i)/all_items.len, 0.1)]%", font_size = 2)
 
 	INVOKE_ASYNC(src, PROC_REF(capture_effect), i, all_items)
 	sleep(per_obj_cd)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фикс отсутствия перевода зон у культа

## Почему и что этот ПР улучшит
Было:
<img width="618" height="56" alt="image" src="https://github.com/user-attachments/assets/342674e8-66d2-4b1c-b1d8-3aca53db0022" />

Стало:
<img width="674" height="196" alt="image" src="https://github.com/user-attachments/assets/91f20c7d-b81e-4644-b53c-d83ecbd50b2e" />

## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl: Azzy.Dreemurr
 - spellcheck: Теперь у культа захваченные зоны пишутся на русском языке