### PR TITLE
Zombie patch

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -419,7 +419,10 @@
 #define COMSIG_CARBON_BUMPED_AIRLOCK_OPEN "carbon_bumped_airlock_open"
 /// Return to stop the door opening on bump.
 	#define STOP_BUMP (1<<0)
-
+/// Called from carbon losing a limb /obj/item/bodypart/proc/drop_limb(obj/item/bodypart/lost_limb)
+#define COMSIG_CARBON_REMOVE_LIMB "carbon_post_remove_limb"
+///from base of /obj/item/bodypart/proc/try_attach_limb(): (new_limb, special)
+#define COMSIG_CARBON_ATTACH_LIMB "carbon_post_attach_limb"
 /// Called from update_health_hud, whenever a bodypart is being updated on the health doll
 #define COMSIG_BODYPART_UPDATING_HEALTH_HUD "bodypart_updating_health_hud"
 	/// Return to override that bodypart's health hud with your own icon

--- a/code/datums/components/mutant_hands.dm
+++ b/code/datums/components/mutant_hands.dm
@@ -1,0 +1,119 @@
+/**
+ * ## Mutant hands component
+ *
+ * This component applies to humans, and forces them to hold
+ * a certain typepath item in every hand no matter what*.
+ *
+ * For example, zombies being forced to hold "zombie claws" - disallowing them from holding items
+ * but giving them powerful weapons to infect people
+ *
+ * It is suggested that the item path supplied has NODROP (and likely DROPDEL),
+ * but nothing's preventing you from not having that.
+ *
+ * If they lose or gain hands, new mutant hands will be created immediately.
+ *
+ * Does not override nodrop items that already exist in hand slots.
+ * However if those nodrop items are lost, will immediately create a new mutant hand.
+ */
+/datum/component/mutant_hands
+	// First come, first serve
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// The item typepath that we insert into the parent's hands
+	var/obj/item/mutant_hand_path = /obj/item/weapon/melee/zombie_hand
+
+/datum/component/mutant_hands/Initialize(obj/item/mutant_hand_path = /obj/item/weapon/melee/zombie_hand)
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/mutant_hands/RegisterWithParent()
+	// Give them a hand before registering ANYTHING just so it's clean
+	INVOKE_ASYNC(src, PROC_REF(apply_mutant_hands))
+
+	RegisterSignals(parent, list(COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB), PROC_REF(try_reapply_hands))
+	RegisterSignal(parent, COMSIG_MOB_EQUIPPED, PROC_REF(mob_equipped_item))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(mob_dropped_item))
+
+/datum/component/mutant_hands/UnregisterFromParent()
+	UnregisterSignal(parent, list(
+		COMSIG_CARBON_ATTACH_LIMB,
+		COMSIG_CARBON_REMOVE_LIMB,
+		COMSIG_MOB_EQUIPPED,
+		COMSIG_ITEM_DROPPED,
+	))
+
+	// Remove all their hands after unregistering everything so they don't return
+	INVOKE_ASYNC(src, PROC_REF(remove_mutant_hands))
+
+/**
+ * Tries to give the parent mob mutant hands.
+ *
+ * * If a hand slot is empty, places the mutanthand type into their hand.
+ * * If a hand slot is filled with a nodrop item, it will do nothing.
+ * * If a hand slot is filled with a non-nodrop item, drops the item to the ground.
+ * * If a hand slot is filled with a hand already, does nothing.
+ */
+/datum/component/mutant_hands/proc/apply_mutant_hands()
+	var/mob/living/carbon/human/H = parent
+	H.drop_l_hand()
+	H.drop_r_hand()
+	H.equip_to_slot_or_del(new mutant_hand_path, SLOT_L_HAND)
+	H.equip_to_slot_or_del(new mutant_hand_path, SLOT_R_HAND)
+
+/**
+ * Removes all mutant idems from the parent's hand slots
+ */
+/datum/component/mutant_hands/proc/remove_mutant_hands()
+	var/mob/living/carbon/human/H = parent
+
+	if(istype(H.l_hand, mutant_hand_path))
+		qdel(H.l_hand)
+
+	if(istype(H.r_hand, mutant_hand_path))
+		qdel(H.r_hand)
+
+/**
+ * Signal proc for any signals that may result in the number of hands of the parent mob changing
+ *
+ * Always try to re-insert mutanthands if we gain or lose hands
+ */
+/datum/component/mutant_hands/proc/try_reapply_hands(datum/source)
+	SIGNAL_HANDLER
+
+	if(QDELING(src) || QDELING(parent))
+		return
+
+	INVOKE_ASYNC(src, PROC_REF(apply_mutant_hands))
+
+/**
+ * Signal proc for [COMSIG_MOB_EQUIPPED_ITEM]
+ *
+ * This is a failsafe - the mob managed to pick up something that isn't a mutant hand
+ */
+/datum/component/mutant_hands/proc/mob_equipped_item(mob/living/carbon/human/source, obj/item/thing, slot)
+	SIGNAL_HANDLER
+
+	if(!(slot & (SLOT_L_HAND | SLOT_R_HAND))) // Who cares
+		return
+
+	if(istype(thing, mutant_hand_path)) // This is definitely meant to be here
+		return
+
+	if(thing.flags & (NODROP | ABSTRACT)) // This is meant to be here
+		return
+
+	// We equipped something to hands that wasn't a mutant hand, and wasn't abstract!
+	// This means they're meant to have a mutant hand. So help them out.
+	INVOKE_ASYNC(src, PROC_REF(apply_mutant_hands))
+
+/**
+ * Signal proc for [COMSIG_MOB_UNEQUIPPED_ITEM]
+ *
+ * This is another failsafe - the mob dropped something, maybe from their hands, so try to re-equip
+ */
+/datum/component/mutant_hands/proc/mob_dropped_item(mob/living/carbon/human/source, obj/item/thing)
+	SIGNAL_HANDLER
+
+	if(QDELING(src) || QDELING(parent))
+		return
+
+	INVOKE_ASYNC(src, PROC_REF(apply_mutant_hands))

--- a/code/datums/elements/mutations/zombie.dm
+++ b/code/datums/elements/mutations/zombie.dm
@@ -36,8 +36,7 @@
 		H.drop_l_hand()
 		H.drop_r_hand()
 
-		H.equip_to_slot_or_del(new /obj/item/weapon/melee/zombie_hand, SLOT_L_HAND)
-		H.equip_to_slot_or_del(new /obj/item/weapon/melee/zombie_hand/right, SLOT_R_HAND)
+		H.AddComponent(/datum/component/mutant_hands)
 
 		var/obj/item/organ/external/head/O = H.bodyparts_by_name[BP_HEAD]
 		if(O)
@@ -60,12 +59,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		H.add_status_flags(MOB_STATUS_FLAGS_DEFAULT)
-
-		if(istype(H.l_hand, /obj/item/weapon/melee/zombie_hand))
-			qdel(H.l_hand)
-
-		if(istype(H.r_hand, /obj/item/weapon/melee/zombie_hand))
-			qdel(H.r_hand)
+		qdel(H.GetComponent(/datum/component/mutant_hands))
 
 		var/obj/item/organ/external/head/O = H.bodyparts_by_name[BP_HEAD]
 		if(O)

--- a/code/datums/spawners_menu/spawners_living.dm
+++ b/code/datums/spawners_menu/spawners_living.dm
@@ -221,6 +221,6 @@
 /datum/spawner/living/zombie
 	name = "Зомби"
 	desc = "Тебя ведет голод. Распространяй смерть, хаос и болезнь. Убивай живых и помогай своим не-живым собратьям."
-	time_for_registration = null
-	register_only = FALSE
 	cooldown = 10 SECONDS
+	ranks = list(ROLE_GHOSTLY)
+	time_for_registration = 10 SECONDS

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -122,8 +122,8 @@
 		if(prob(10) && owner.health)
 			if(!carbon_owner || !carbon_owner.hal_crit)
 				owner.emote("snore")
-	owner.drop_from_inventory(owner.l_hand)
-	owner.drop_from_inventory(owner.r_hand)
+	owner.drop_l_hand()
+	owner.drop_r_hand()
 
 /atom/movable/screen/alert/status_effect/asleep
 	name = "Сон"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -70,8 +70,8 @@
 		return
 	owner.weakened = TRUE
 	ADD_TRAIT(owner, TRAIT_INCAPACITATED, id)
-	owner.drop_from_inventory(owner.l_hand)
-	owner.drop_from_inventory(owner.r_hand)
+	owner.drop_l_hand()
+	owner.drop_r_hand()
 
 /datum/status_effect/incapacitating/weakened/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, id)

--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -639,15 +639,6 @@
 	cost = 2
 	uplink_types = list(UPLINK_TYPE_NUCLEAR)
 
-/datum/uplink_item/stealthy_weapons/romerol_kit
-	name = "Romerol"
-	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. \
-			On death, these nodules take control of the dead body, causing limited revivification, \
-			along with slurred speech, aggression, and the ability to infect others with this agent."
-	item = /obj/item/weapon/storage/box/syndie_kit/romerol
-	cost = 80
-	uplink_types = list(UPLINK_TYPE_NUCLEAR)
-
 // STEALTHY TOOLS
 
 /datum/uplink_item/stealthy_tools

--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -645,7 +645,7 @@
 			On death, these nodules take control of the dead body, causing limited revivification, \
 			along with slurred speech, aggression, and the ability to infect others with this agent."
 	item = /obj/item/weapon/storage/box/syndie_kit/romerol
-	cost = 50
+	cost = 80
 	uplink_types = list(UPLINK_TYPE_NUCLEAR)
 
 // STEALTHY TOOLS

--- a/code/game/gamemodes/factions/zombies.dm
+++ b/code/game/gamemodes/factions/zombies.dm
@@ -6,16 +6,16 @@
 
 	logo_state = "zombie-logo"
 
-	var/last_check = 0
+	COOLDOWN_DECLARE(last_check)
 
 /datum/faction/zombie/forgeObjectives()
 	. = ..()
 	AppendObjective(/datum/objective/turn_into_zombie)
 
 /datum/faction/zombie/check_win()
-	if(last_check > world.time)
+	if(COOLDOWN_FINISHED(src, last_check))
 		return FALSE
-	last_check = world.time + 1 MINUTE
+	COOLDOWN_START(src, last_check, 1 MINUTE)
 	if(round(length(members) / check_crew()) >= 0.8)
 		if(SSshuttle.location || SSshuttle.direction) //If traveling or docked somewhere other than idle at command, don't call.
 			return FALSE

--- a/code/game/gamemodes/factions/zombies.dm
+++ b/code/game/gamemodes/factions/zombies.dm
@@ -16,7 +16,7 @@
 	if(last_check > world.time)
 		return FALSE
 	last_check = world.time + 30 SECONDS
-	if(round(length(members) / check_crew() >= 0.8))
+	if(round(length(members) / check_crew()) >= 0.8)
 		SSshuttle.incall(0.5)
 		SSshuttle.announce_emer_called.message = "Карантин прорван, дальнейшая локализация угрозы не представляется возможной. Выжившему персоналу предписано прибыть на эвакуацию и удерживать оборону. Эвакуационный шаттл прибудет через несколько минут."
 		SSshuttle.announce_emer_called.play()

--- a/code/game/gamemodes/factions/zombies.dm
+++ b/code/game/gamemodes/factions/zombies.dm
@@ -17,5 +17,7 @@
 		return FALSE
 	last_check = world.time + 30 SECONDS
 	if(round(length(members) / check_crew() >= 0.8))
-		return TRUE
-	return FALSE
+		SSshuttle.incall(0.5)
+		SSshuttle.announce_emer_called.message = "Карантин прорван, дальнейшая локализация угрозы не представляется возможной. Выжившему персоналу предписано прибыть на эвакуацию и удерживать оборону. Эвакуационный шаттл прибудет через несколько минут."
+		SSshuttle.announce_emer_called.play()
+

--- a/code/game/gamemodes/factions/zombies.dm
+++ b/code/game/gamemodes/factions/zombies.dm
@@ -15,7 +15,7 @@
 /datum/faction/zombie/check_win()
 	if(last_check > world.time)
 		return FALSE
-	last_check = world.time + 30 SECONDS
+	last_check = world.time + 1 MINUTE
 	if(round(length(members) / check_crew()) >= 0.8)
 		if(SSshuttle.location || SSshuttle.direction) //If traveling or docked somewhere other than idle at command, don't call.
 			return

--- a/code/game/gamemodes/factions/zombies.dm
+++ b/code/game/gamemodes/factions/zombies.dm
@@ -17,6 +17,8 @@
 		return FALSE
 	last_check = world.time + 30 SECONDS
 	if(round(length(members) / check_crew()) >= 0.8)
+		if(SSshuttle.location || SSshuttle.direction) //If traveling or docked somewhere other than idle at command, don't call.
+			return
 		SSshuttle.incall(0.5)
 		SSshuttle.announce_emer_called.message = "Карантин прорван, дальнейшая локализация угрозы не представляется возможной. Выжившему персоналу предписано прибыть на эвакуацию и удерживать оборону. Эвакуационный шаттл прибудет через несколько минут."
 		SSshuttle.announce_emer_called.play()

--- a/code/game/gamemodes/factions/zombies.dm
+++ b/code/game/gamemodes/factions/zombies.dm
@@ -1,4 +1,4 @@
-/datum/faction/zombie // for events
+/datum/faction/zombie
 	name = F_ZOMBIES
 	ID = F_ZOMBIES
 
@@ -6,6 +6,16 @@
 
 	logo_state = "zombie-logo"
 
+	var/last_check = 0
+
 /datum/faction/zombie/forgeObjectives()
 	. = ..()
 	AppendObjective(/datum/objective/turn_into_zombie)
+
+/datum/faction/zombie/check_win()
+	if(last_check > world.time)
+		return FALSE
+	last_check = world.time + 30 SECONDS
+	if(round(length(members) / check_crew() >= 0.8))
+		return TRUE
+	return FALSE

--- a/code/game/gamemodes/factions/zombies.dm
+++ b/code/game/gamemodes/factions/zombies.dm
@@ -18,7 +18,7 @@
 	last_check = world.time + 1 MINUTE
 	if(round(length(members) / check_crew()) >= 0.8)
 		if(SSshuttle.location || SSshuttle.direction) //If traveling or docked somewhere other than idle at command, don't call.
-			return
+			return FALSE
 		SSshuttle.incall(0.5)
 		SSshuttle.announce_emer_called.message = "Карантин прорван, дальнейшая локализация угрозы не представляется возможной. Выжившему персоналу предписано прибыть на эвакуацию и удерживать оборону. Эвакуационный шаттл прибудет через несколько минут."
 		SSshuttle.announce_emer_called.play()

--- a/code/game/gamemodes/objectives/turn_into_zombie.dm
+++ b/code/game/gamemodes/objectives/turn_into_zombie.dm
@@ -1,14 +1,11 @@
 /datum/objective/turn_into_zombie
-	explanation_text = "Превратите всех людей на станции в зомби."
+	explanation_text = "Превратите большую часть людей на станции в зомби."
 
 /datum/objective/turn_into_zombie/check_completion()
 	if(!faction)
 		return OBJECTIVE_LOSS
 	if(!faction.members.len)
 		return OBJECTIVE_LOSS
-	for(var/mob/living/carbon/human/H as anything in human_list)
-		if(!H || !H.mind || !is_station_level(H.z))
-			continue
-		if(!H.mind.GetRoleByType(faction.initroletype) || !H.mind.GetRoleByType(faction.roletype))
-			return OBJECTIVE_LOSS
-	return OBJECTIVE_WIN
+	if(length(faction.members) / faction.check_crew() >= 0.6)
+		return OBJECTIVE_WIN
+	return OBJECTIVE_LOSS

--- a/code/game/machinery/computer/intruder_station.dm
+++ b/code/game/machinery/computer/intruder_station.dm
@@ -175,3 +175,17 @@
 	desc = "Can be attached to Drop Pod to reach exemplary accuracy and allow to return to the base."
 	item = /obj/item/device/camera_bug
 	cost = 2
+
+/datum/intruder_tools/romerol
+	name = "Romerol"
+	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. \
+			On death, these nodules take control of the dead body, causing limited revivification, \
+			along with slurred speech, aggression, and the ability to infect others with this agent."
+	item = /obj/item/weapon/storage/box/syndie_kit/romerol
+	cost = 80
+
+/datum/intruder_tools/romerol/buy(obj/machinery/computer/intruder_station/console, mob/living/user)
+	if(!war_device_activated)
+		to_chat(user, "<span class='notice'>Эта опция доступна только при объявлении войны!</span>")
+		return
+	. = ..()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -198,7 +198,6 @@
 	new /obj/item/weapon/reagent_containers/glass/beaker/vial/romerol(src)
 	new /obj/item/weapon/reagent_containers/syringe(src)
 	new /obj/item/weapon/reagent_containers/dropper(src)
-	new /obj/item/weapon/reagent_containers/hypospray/combat/zombie(src)
 
 	var/garanted_item = pick(/obj/item/weapon/reagent_containers/hypospray/autoinjector/romerol, /obj/item/weapon/grenade/chem_grenade/romerol, /obj/item/weapon/implanter/zombie)
 	new garanted_item (src)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -139,12 +139,10 @@
 			var/free_body = TRUE
 			for(var/mob/dead/observer/ghost in player_list)
 				if(ghost.mind == mind && ghost.can_reenter_corpse)
-					free_body = FALSE
 					var/answer = tgui_alert(ghost,"You are about to turn into a zombie. Do you want to return to body?","I'm a zombie!", list("Yes","No"), 10 SECONDS)
 					if(answer == "Yes")
 						ghost.reenter_corpse()
-					else if(!client)
-						create_spawner(/datum/spawner/living/zombie, src)
+						free_body = FALSE
 					break
 			if(free_body && !client)
 				create_spawner(/datum/spawner/living/zombie, src)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -143,9 +143,10 @@
 					var/answer = tgui_alert(ghost,"You are about to turn into a zombie. Do you want to return to body?","I'm a zombie!", list("Yes","No"), 10 SECONDS)
 					if(answer == "Yes")
 						ghost.reenter_corpse()
-					else
+					else if(!client)
 						create_spawner(/datum/spawner/living/zombie, src)
-			if(free_body)
+					break
+			if(free_body && !client)
 				create_spawner(/datum/spawner/living/zombie, src)
 
 		visible_message("<span class='danger'>[src]'s body starts to move!</span>")

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -18,8 +18,10 @@
 
 	attack_verb = list("bitten and scratched", "scratched")
 
-/obj/item/weapon/melee/zombie_hand/right
-	icon_state = "bloodhand_right"
+/obj/item/weapon/melee/zombie_hand/equipped(mob/user, slot)
+	. = ..()
+	if(slot == SLOT_R_HAND)
+		icon_state = "bloodhand_right"
 
 /obj/item/weapon/melee/zombie_hand/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)
@@ -133,8 +135,8 @@
 /mob/living/carbon/human/proc/prerevive_zombie()
 	var/obj/item/organ/external/BP = bodyparts_by_name[BP_HEAD]
 	if(organs_by_name[O_BRAIN] && BP && !(BP.is_stump))
-		var/free_body = TRUE
 		if(!key && mind)
+			var/free_body = TRUE
 			for(var/mob/dead/observer/ghost in player_list)
 				if(ghost.mind == mind && ghost.can_reenter_corpse)
 					free_body = FALSE
@@ -143,8 +145,8 @@
 						ghost.reenter_corpse()
 					else
 						create_spawner(/datum/spawner/living/zombie, src)
-		if(free_body)
-			create_spawner(/datum/spawner/living/zombie, src)
+			if(free_body)
+				create_spawner(/datum/spawner/living/zombie, src)
 
 		visible_message("<span class='danger'>[src]'s body starts to move!</span>")
 		addtimer(CALLBACK(src, PROC_REF(revive_zombie)), 40)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -124,7 +124,7 @@
 /mob/living/carbon/human/proc/handle_infected_death() //Death of human
 	if(!can_zombified())
 		return
-	preprerevive_zombie(300)
+	preprerevive_zombie(600)
 
 /mob/living/carbon/human/proc/preprerevive_zombie(delay)
 	addtimer(CALLBACK(src, PROC_REF(prerevive_zombie)), delay)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -423,13 +423,6 @@ var/global/list/zombie_list = list()
 		var/mob/living/carbon/human/H = M
 		H.infect_zombie_virus(null, TRUE, TRUE)
 
-/obj/item/weapon/reagent_containers/hypospray/combat/zombie
-	name = "biowarfare hypospray"
-	desc = "A modified air-needle autoinjector, used by operatives to quickly make warcrimes in the field. This one is left unlabelled."
-	volume = 15
-	list_reagents = list("romerol" = 15)
-	amount_per_transfer_from_this = 5
-
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/romerol
 	name = "Z-virus"
 	desc = "Makes warcrimes"

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -426,8 +426,8 @@ var/global/list/zombie_list = list()
 /obj/item/weapon/reagent_containers/hypospray/combat/zombie
 	name = "biowarfare hypospray"
 	desc = "A modified air-needle autoinjector, used by operatives to quickly make warcrimes in the field. This one is left unlabelled."
-	volume = 50
-	list_reagents = list("romerol" = 50)
+	volume = 15
+	list_reagents = list("romerol" = 15)
 	amount_per_transfer_from_this = 5
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/romerol

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -195,6 +195,8 @@
 	if(surgically)
 		check_rejection()
 
+	SEND_SIGNAL(H, COMSIG_CARBON_ATTACH_LIMB)
+
 /obj/item/organ/external/proc/mod_skin_color(original_color)
 	// sorted in priority, maybe some day someone will experiment with colors mixing
 	if(is_slime)
@@ -636,6 +638,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 				owner.remove_from_mob(owner.shoes)
 			else
 				qdel(owner.shoes)
+
+	SEND_SIGNAL(owner, COMSIG_CARBON_REMOVE_LIMB)
+
 	if(pumped)
 		owner.mob_metabolism_mod.RemoveMods(src)
 

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -359,6 +359,7 @@
 #include "code\datums\components\mechanic_description.dm"
 #include "code\datums\components\mood.dm"
 #include "code\datums\components\multi_carry.dm"
+#include "code\datums\components\mutant_hands.dm"
 #include "code\datums\components\seethrough.dm"
 #include "code\datums\components\serial_number.dm"
 #include "code\datums\components\silence.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Зомби получили компоненту, которая создает им новые клешни в случае факапов с оными. Потерять ручки все ещё можно, но вот взять в руки уже не выйдет.

Поправил спавнеры

Зомби побеждают, если их более 60% от живых, а также заканчивают раунд, если их более 80%. Позволит не софт лочить раунд, а также причина нюкерам не сидеть на жопе ровно при выпуске ромерола.

Гипоспрей вырезан из-за стелс-прокидов.

Ромерол только в войну 

**АХТУНГ!** Исправлен баг с флагом NO_DROP. Статус эффекты слабости и сна не проверяли на NO_DROP перед сбросом предметов из рук. Может что-то задеть, но по идее оно станет работать именно так, как задумывалось изначально.

Через ТМ.
## Почему и что этот ПР улучшит
Я накодил баги. Теперь пора их поправить :)
## Авторство
Компонента с ТГ по большей части
## Чеинжлог

:cl:
 - balance: Зомби могут победить, если живых останется менее 20%
 - bugfix: Статус эффекты слабости и сна проверяют предметы на флаг NO_DROP
 - bugfix: У зомби поправлены спавнеры
