### PR TITLE
homunculus fix

### DIFF
--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -319,7 +319,7 @@
 		return FALSE
 	playsound(AOG, 'sound/magic/manifest.ogg', VOL_EFFECTS_MASTER)
 	for(var/i in 1 to divine_power)
-		if(candidates.len < divine_power)
+		if(i > candidates.len)
 			return TRUE
 
 		var/mob/M = pick(candidates)

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -319,7 +319,7 @@
 		return FALSE
 	playsound(AOG, 'sound/magic/manifest.ogg', VOL_EFFECTS_MASTER)
 	for(var/i in 1 to divine_power)
-		if(i > candidates.len)
+		if(!candidates.len)
 			return TRUE
 
 		var/mob/M = pick(candidates)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
У культа есть ритуал призыва гомункула. При старте среди гостов ищутся желающие на роль. Ритуал можно прокачать - чем сильнее, тем больше за раз появляется гомункулов. Однако если у нас ритуал прокачан до 2, а кандидат 1, то не заспавнится ни одного. В итоге практичней ритуал вовсе не прокачивать.
## Почему и что этот ПР улучшит

## Авторство


## Чеинжлог

:cl:
 - bugfix: Призыв гомункула работает на высоких уровнях как положено.