### PR TITLE
mech alt turn

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -277,6 +277,10 @@
 	if(hasInternalDamage(MECHA_INT_CONTROL_LOST))
 		move_result = mechsteprand()
 	else if(strafe)
+		if(occupant?.client?.keys_held["Alt"])
+			if(direction != dir)
+				return mechturn(direction)
+			return FALSE
 		move_result	= mechstep(direction)
 	else if(direction == dir || direction == prev_move_dir)
 		move_result = mechstep(dir)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -85,13 +85,13 @@ menu "menu"
 		can-check = true
 		saved-params = "is-checked"
 	elem
-		name = "&Scaling Mode"
+		name = "Scaling Mode"
 		command = ""
 		saved-params = "is-checked"
 	elem "ps"
 		name = "&Point Sampling"
 		command = ".winset \"mapwindow.map.zoom-mode=normal\""
-		category = "&Scaling Mode"
+		category = "Scaling Mode"
 		is-checked = true
 		can-check = true
 		group = "scaling"
@@ -99,14 +99,14 @@ menu "menu"
 	elem "bl"
 		name = "&Bilinear"
 		command = ".winset \"mapwindow.map.zoom-mode=blur\""
-		category = "&Scaling Mode"
+		category = "Scaling Mode"
 		can-check = true
 		group = "scaling"
 		saved-params = "is-checked"
 	elem "nn"
 		name = "&Nearest Neighbor"
 		command = ".winset \"mapwindow.map.zoom-mode=distort\""
-		category = "&Scaling Mode"
+		category = "Scaling Mode"
 		can-check = true
 		group = "scaling"
 		saved-params = "is-checked"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
при зажатии кнопки L-ALT можно поворачиваться мехом, будучи в стрейфинг моде
убран хоткей ALT+S Scaling Mode теперь можно открыть только мышкой
## Почему и что этот ПР улучшит
QoL
## Авторство
спёр с [tgstation](https://github.com/tgstation/tgstation)
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - tweak: Добавлена возможность поворачиваться в мехах, при зажатии кнопки L-ALT.
 - del: Убрана мнемоника ALT+S, больше нельзя удобнейшим способом открывать пункт Scaling Mode в меню окна игры.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
