### PR TITLE
капитан и сб больше не могут быть раундстарт культ

### DIFF
--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -51,7 +51,7 @@
 /datum/role/New(datum/mind/M, datum/faction/fac, override = FALSE, laterole = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 
-	if(M && !AssignToRole(M, override, laterole))
+	if(M && !AssignToRole(M, override, laterole = laterole))
 		Drop()
 		return
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
капитан и сб больше не могут быть раундстарт культ
https://github.com/TauCetiStation/TauCetiClassic/blob/c1d30b76cfac939ded74849cf3d1e8827323ba90/code/game/gamemodes/role.dm#L54
https://github.com/TauCetiStation/TauCetiClassic/blob/c1d30b76cfac939ded74849cf3d1e8827323ba90/code/game/gamemodes/role.dm#L75
здесь третьим параметром передаётся laterole, в AssignToRole на третей позиции msg_admins, поэтому msg_admins = laterole, а сам laterole по дефолту от AssignToRole оставался TRUE, из-за чего CanBeAssigned посмотрит на laterole = TRUE и даст роль культиста капитану раундстартом (сам капитан кстати с этой ролью ниче не может делать, ни руны чертить, ни чат культов видеть)
исправлено передачей laterole именованным аргументом
## Почему и что этот ПР улучшит
багафикс
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Капитан и СБ больше не могут становится раундстарт культистами.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment


 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
