### PR TITLE
Добавление задержки на активацию импланта подчинения

### DIFF
--- a/code/game/objects/items/weapons/implants/misc.dm
+++ b/code/game/objects/items/weapons/implants/misc.dm
@@ -154,7 +154,7 @@
 	desc = "Делает ваше стадо послушным."
 	hud_id = IMPOBED_HUD
 	hud_icon_state = "hud_imp_obedience"
-
+	COOLDOWN_DECLARE(shock_cooldown)
 	implant_data = {"
 <b>Характеристики импланта:</b><BR>
 <b>Наименование:</b> Внушитель послушания сотрудника типа \"Гарант прибыли\" NanoTrasen<BR>

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -40,11 +40,14 @@
 		to_chat(target, "<span class='userdanger'>COVER BLOWN!!! THEY KNOW ABOUT US!!!</span>")
 		qdel(src)
 		return
-	if(!isimplantedobedience(H))
+	var/obj/item/weapon/implant/obedience/obed_implant = isimplantedobedience(H)
+	if(!obed_implant || !COOLDOWN_FINISHED(obed_implant, shock_cooldown))
+		to_chat(user, "Nothing has happened. Maybe you need to wait for the implant to recharge?")
 		return
+	COOLDOWN_START(obed_implant, shock_cooldown, 1.5 SECOND)
 	H.Stun(5)
 	H.apply_effect(5, WEAKEN)
-	H.apply_effect(20, AGONY)
+	H.apply_effect(10, AGONY)
 	to_chat(H, "<span class='danger'You feel something beep inside of you and a wave of electricity pierces your body!</span>")
 	var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 	sparks.set_up(3, 0, get_turf(H))

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -44,7 +44,7 @@
 	if(!obed_implant || !COOLDOWN_FINISHED(obed_implant, shock_cooldown))
 		to_chat(user, "Nothing has happened. Maybe you need to wait for the implant to recharge?")
 		return
-	COOLDOWN_START(obed_implant, shock_cooldown, 1.5 SECOND)
+	COOLDOWN_START(obed_implant, shock_cooldown, 6 SECOND)
 	H.Stun(5)
 	H.apply_effect(5, WEAKEN)
 	H.apply_effect(10, AGONY)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавление задержки на активацию импланта подчинения (использование плетки всё ещё привязано к импланту, поэтому одновременно можно ударить двух и более человек, но на каждом из них впоследствии будет задержка на срабатывание)
## Почему и что этот ПР улучшит
Это уберёт бесконечный заклик плеткой по человеку с имлантом, давая хоть какой-нибудь шанс на развитие ситуации 
## Авторство
Помощь в написании кода @4310V343k
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
-->
:cl: Exclusive084
 - tweak: Дебаф от цепи командования капитана и ГСБ стал длиться меньше. Теперь нельзя часто активировать имплант подчинения одному и тому же человеку

