### PR TITLE
fix MMI brain toss

### DIFF
--- a/code/modules/surgery/braincore.dm
+++ b/code/modules/surgery/braincore.dm
@@ -110,7 +110,6 @@
 	IO.status |= ORGAN_CUT_AWAY
 	IO.remove(target)
 	IO.loc = get_turf(target)
-	IO.transfer_identity(target)
 	target.death()//You want them to die after the brain was transferred, so not to trigger client death() twice.
 
 /datum/surgery_step/brain/saw_spine/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Должно фиксить то, что у нас сейчас выкидывает игрока из ММИ если поместить его мозг туда. Двойной вызов трансфер идентифай создавал второй мозг внутри изъятого мозга без майнда, который и помещался внутрь ММИ.
## Почему и что этот ПР улучшит
closes #14686
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:

- bugfix: Теперь при  установке мозга в ММИ, игрока не будет выпихивать из ММИ. При извлечении мозга теперь не создается пустой дубликат мозга внутри мозга.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
