### PR TITLE
Добавлена новая негативная особенность "Hangover"  (Похмелье)

### DIFF
--- a/code/datums/qualities/negativeish.dm
+++ b/code/datums/qualities/negativeish.dm
@@ -274,3 +274,18 @@ var/global/list/allergen_reagents_list
 
 /datum/quality/negativeish/dyslalia/add_effect(mob/living/carbon/human/H, latespawn)
 	ADD_TRAIT(H, TRAIT_DYSLALIA, QUALITY_TRAIT)
+
+/datum/quality/negativeish/hangover
+	name = "Hangover"
+	desc = "Вчерашняя вечеринка не прошла бесследно. Вы проснулись с алкогольным опьянением, и только бутылка воды в руках даёт надежду на опохмеление"
+	requirement = "Нет."
+	pools = list(QUALITY_POOL_NEGATIVEISH)
+
+/datum/quality/negativeish/hangover/add_effect(mob/living/carbon/human/H, latespawn)
+	var/static/list/booze_types = list(
+		"beer", "vodka", "whiskey", "wine", "rum",
+		"tequila", "patron", "gin", "champagne", "sake", "cider"
+	)
+	var/drink = pick(booze_types)
+	H.reagents.add_reagent(drink, rand(90, 120))
+	H.put_in_hands(new /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle)

--- a/code/datums/qualities/negativeish.dm
+++ b/code/datums/qualities/negativeish.dm
@@ -279,7 +279,6 @@ var/global/list/allergen_reagents_list
 	name = "Hangover"
 	desc = "Вчерашняя вечеринка не прошла бесследно. Вы проснулись с алкогольным опьянением, и только бутылка воды в руках даёт надежду на опохмеление"
 	requirement = "Нет."
-	pools = list(QUALITY_POOL_NEGATIVEISH)
 
 /datum/quality/negativeish/hangover/add_effect(mob/living/carbon/human/H, latespawn)
 	var/static/list/booze_types = list(


### PR DESCRIPTION
## Описание изменений
Добавлена новая негативная особенность "Hangover" (Похмелье).  
При выборе этой особенности сотрудник в начале смены уже имеет случайный алкоголь в крови (пиво, водка, виски и т.д.) и держит в руке бутылку воды.  

## Почему и что этот ПР улучшит
Разнообразие негативных особок

## Авторство
Riverz

## Чеинжлог
:cl:Riverz
 - tweak: Добавлена негативная особенность "Hangover" - персонаж появляется с похмелья, случайным алкоголем в крови и бутылкой воды в руке.