### PR TITLE
Добавлено динамическое перекрашивание глаз в красный цвет при употреблении Bloody Mary

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
@@ -1299,19 +1299,17 @@
 	taste_message = "tomatoes with booze"
 
 /datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/M)
-	if(!iscarbon(M))
-		return ..()
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
 		return ..()
-	if(volume >= 31)
+	if(volume > 30)
 		if(!HAS_TRAIT(H, TRAIT_CULT_EYES))
 			ADD_TRAIT(H, TRAIT_CULT_EYES, "reagent")
-			H.regenerate_icons()
+			H.update_body()
 	else
 		if(HAS_TRAIT_FROM(H, TRAIT_CULT_EYES, "reagent"))
 			REMOVE_TRAIT(H, TRAIT_CULT_EYES, "reagent")
-			H.regenerate_icons()
+			H.update_body()
 	return ..()
 
 /datum/reagent/consumable/ethanol/brave_bull

--- a/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
@@ -1298,6 +1298,22 @@
 	boozepwr = 3
 	taste_message = "tomatoes with booze"
 
+/datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/M)
+	if(!iscarbon(M))
+		return ..()
+	var/mob/living/carbon/human/H = M
+	if(!istype(H))
+		return ..()
+	if(volume >= 31)
+		if(!HAS_TRAIT(H, TRAIT_CULT_EYES))
+			ADD_TRAIT(H, TRAIT_CULT_EYES, "reagent")
+			H.regenerate_icons()
+	else
+		if(HAS_TRAIT_FROM(H, TRAIT_CULT_EYES, "reagent"))
+			REMOVE_TRAIT(H, TRAIT_CULT_EYES, "reagent")
+			H.regenerate_icons()
+	return ..()
+
 /datum/reagent/consumable/ethanol/brave_bull
 	name = "Brave Bull"
 	id = "bravebull"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если в организме персонажа больше 30 унций  Bloody Mary, персонажу выдаётся трейт TRAIT_CULT_EYES и глаа персонажа становится красными

При падении объёма ниже 31 унции, глаза возвращаются к своему обычному цвету (если нет других источников красных глаз).
## Почему и что этот ПР улучшит
Больше прикольных свойств напиткам, меньше меты по культу
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: Добавлено динамическое перекрашивание глаз в красный цвет при употреблении Bloody Mary