### PR TITLE
ОБОПу добавлена кобура и удобные магазины с патронами

### DIFF
--- a/code/game/gamemodes/modes_gameplays/families/outfit.dm
+++ b/code/game/gamemodes/modes_gameplays/families/outfit.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	var/obj/item/clothing/under/U = H.w_uniform
 	if(istype(U))
-		var/obj/item/clothing/accessory/holster/armpit/holster = new /obj/item/clothing/accessory/holster/armpit(U)
+		var/obj/item/clothing/accessory/holster/armpit/holster = new (U)
 		LAZYADD(U.accessories, holster)
 		holster.on_attached(U, H, TRUE)
 

--- a/code/game/gamemodes/modes_gameplays/families/outfit.dm
+++ b/code/game/gamemodes/modes_gameplays/families/outfit.dm
@@ -24,13 +24,21 @@
 
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/colt/rubber = 3,
-		/obj/item/ammo_box/c45 = 2,
+		/obj/item/ammo_box/magazine/colt = 2,
 		/obj/item/weapon/gun/projectile/automatic/pistol/colt1911 = 1,
 	)
 
 	implants = list(
 		/obj/item/weapon/implant/mind_protect/loyalty,
 	)
+
+/datum/outfit/families_police/beatcop/post_equip(mob/living/carbon/human/H)
+	. = ..()
+	var/obj/item/clothing/under/U = H.w_uniform
+	if(istype(U))
+		var/obj/item/clothing/accessory/holster/armpit/holster = new /obj/item/clothing/accessory/holster/armpit(U)
+		LAZYADD(U.accessories, holster)
+		holster.on_attached(U, H, TRUE)
 
 /datum/outfit/families_police/beatcop/armored
 	name = "Families: Вооруженный Офицер"
@@ -39,8 +47,9 @@
 	suit_store = /obj/item/weapon/gun/projectile/shotgun/dungeon
 	backpack_contents = list(
 		/obj/item/weapon/storage/box/teargas = 1,
-		/obj/item/weapon/storage/box/shotgun/buckshot = 1,
-		/obj/item/ammo_box/magazine/colt/rubber = 3,
+		/obj/item/ammo_box/eight_shells/buckshot = 2,
+		/obj/item/ammo_box/magazine/colt/rubber = 1,
+		/obj/item/ammo_box/magazine/colt = 2,
 		/obj/item/weapon/gun/projectile/automatic/pistol/colt1911 = 1,
 	)
 
@@ -54,9 +63,10 @@
 	backpack_contents = list(
 		/obj/item/weapon/storage/box/handcuffs = 1,
 		/obj/item/weapon/storage/box/teargas = 1,
-		/obj/item/weapon/storage/box/shotgun/buckshot = 1,
+		/obj/item/ammo_box/eight_shells/buckshot = 2,
 		/obj/item/weapon/gun/projectile/automatic/pistol/colt1911 = 1,
-		/obj/item/ammo_box/magazine/colt/rubber = 3,
+		/obj/item/ammo_box/magazine/colt/rubber = 1,
+		/obj/item/ammo_box/magazine/colt = 2,
 	)
 
 /datum/outfit/families_police/beatcop/fbi


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь у каждого офицера обоп есть кобура на униформе
Также выдал вместо обычной коробки в которой по одной пульке лежат патроны для дробовика, нормальные коробки как из автолата
Ну и по мелочи добавил боевые патроны на кольт
## Почему и что этот ПР улучшит
Теперь офицерам ОБОП не нужно бегать по станции и искать кобуру чтобы засунуть тазер/кольт итд
Ну а также ручками заряжать каждый патрон в дробовик
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->
Riverz
## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
:cl:Riverz
 - tweak: ОБОПу добавлена кобура и удобные магазины с патронами