### PR TITLE
cult hood buff

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -108,7 +108,8 @@
 	flags = HEADCOVERSEYES
 	body_parts_covered = HEAD|EYES
 	render_flags = parent_type::render_flags | HIDE_ALL_HAIR
-	armor = list(melee = 30, bullet = 20, laser = 30,energy = 25, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 45, laser = 60,energy = 45, bomb = 30, bio = 0, rad = 0)
+	flashbang_protection = TRUE
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0

--- a/code/modules/religion/building_agent.dm
+++ b/code/modules/religion/building_agent.dm
@@ -219,6 +219,7 @@
 	name = "Набор Брони"
 	building_type = /obj/item/weapon/storage/backpack/cultpack/armor
 	favor_cost = 200
+	piety_cost = 10
 
 /datum/building_agent/tool/cult/blade
 	name = "Кровавая Месть"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
бафф капюшона культистов он теперь защищает от флешек (защищает уши, но не глаза) и имеет те же защитные статки что и космический шлем культистов
ещё из-за этого набор с робой+капюшоном стоит на 10 пиети больше (до этого стоил ноль)
## Почему и что этот ПР улучшит
культистам не придётся жертвовать стилем (в шлеме от спес сьюта и в робе они выглядят глупо) ради нормальной защиты головы
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- balance: Капюшон культистов защищает намного лучше, кроме того, он защищает от стана светошумовых гранат.
- balance: Набор с робой культистов стоит чуть дороже.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
