### PR TITLE
revert "Магбутсы защищают от репульса"

### DIFF
--- a/code/datums/spells/repulse.dm
+++ b/code/datums/spells/repulse.dm
@@ -23,13 +23,6 @@
 		if(AM == user || AM.anchored)
 			continue
 
-		if(ishuman(AM)) // AIR_FLOW_PROTECT defends a human from repulse
-			var/mob/living/carbon/human/H = AM
-			if(H.shoes && (H.shoes.flags & AIR_FLOW_PROTECT))
-				continue
-			if(H.wear_suit && (H.wear_suit.flags & AIR_FLOW_PROTECT))
-				continue
-
 		throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(AM, user)))
 		distfromcaster = get_dist(user, AM)
 		if(distfromcaster == 0)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -15,8 +15,6 @@
 	name = "Toggle Magboots"
 
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
-	if(user.is_busy() || !do_after(user, 0.8 SECONDS, target = src))
-		return
 	if(magpulse)
 		flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
 		slowdown = SHOES_SLOWDOWN


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
откат #13999
флаг AIR_FLOW_PROTECT теперь не защищает от репульса мага

убрал магбутсам вне рига секундный дуафтер
## Почему и что этот ПР улучшит
мне не нравится тот пр потому что ради добавления одного способа защиты от репульса мага усложнили жизнь куче игроков которые предпочитают носить магбуты на ногах чтобы не отправляться в крайне длительный стан от ветерка + удара об стенку

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- del: Магбуты не защищают от репульса.
- del: Магбутсы не в риге мгновенно переключатся.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
