### PR TITLE
Rever электрофикацию только антаг ИИ/боргов и т.п.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -241,6 +241,8 @@
 #define COMSIG_ITEM_ALTCLICKWITH "item_altclickwith"
 /// from base of mob/CtrlShiftClickOn(): (atom/target, mob/user)
 #define COMSIG_ITEM_CTRLSHIFTCLICKWITH "item_ctrlshiftclickwith"
+/// from base of mob/AltShiftClickOn(): (atom/target, mob/user)
+#define COMSIG_ITEM_ALTSHIFTCLICKWITH "item_altshiftclickwith"
 /// from base of mob/MiddleClickOn(): (atom/target, mob/user)
 #define COMSIG_ITEM_MIDDLECLICKWITH "item_middleclickwith"
 	#define COMSIG_ITEM_CANCEL_CLICKWITH 1
@@ -328,6 +330,8 @@
 #define COMSIG_LIVING_CLICK_CTRL "living_click_ctrl"
 /// from base of mob/CtrlShiftClickOn(): (atom/target)
 #define COMSIG_LIVING_CLICK_CTRL_SHIFT "living_click_ctrl_shift"
+/// from base of mob/CtrlShiftClickOn(): (atom/target)
+#define COMSIG_LIVING_CLICK_ALT_SHIFT "living_alt_ctrl_shift"
 /// from slime CtrlClickOn(): (/mob)
 #define COMSIG_XENO_SLIME_CLICK_CTRL "xeno_slime_click_ctrl"
 /// from slime ShiftClickOn(): (/mob)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -40,6 +40,9 @@
 	if(modifiers[SHIFT_CLICK] && modifiers[CTRL_CLICK])
 		CtrlShiftClickOn(A)
 		return
+	if(modifiers[SHIFT_CLICK] && modifiers[ALT_CLICK])
+		AltShiftClickOn(A)
+		return
 	if(modifiers[MIDDLE_CLICK])
 		MiddleClickOn(A)
 		return
@@ -96,6 +99,8 @@
 	A.AIShiftClick(src)
 /mob/living/silicon/ai/CtrlClickOn(atom/A)
 	A.AICtrlClick(src)
+/mob/living/silicon/ai/AltShiftClickOn(atom/A)
+	A.AIAltShiftClick(src)
 /mob/living/silicon/ai/AltClickOn(atom/A)
 	if(active_module)
 		if(!active_module.AIAltClickHandle(A))
@@ -156,14 +161,16 @@
 		return
 	if(!issilicon(M))
 		return
-	var/mob/living/silicon/S = M
-	if(S.is_antag())
-		if(!secondsElectrified) //Needs rework. See more in PR #14556
-			electrify(M)
-		else
-			unelectrify(M)
-		return
+	if(!secondsElectrified) //Needs rework. See more in PR #14556
+		electrify(M)
+	else
+		unelectrify(M)
+	return
 
+/atom/proc/AIAltShiftClick()
+	return
+
+/obj/machinery/door/airlock/AIAltShiftClick(mob/M)
 	if(emergency)
 		enable_emergency_access(M)
 	else

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -369,6 +369,24 @@
 	return
 
 /*
+	Alt+Shift click
+	Unused except for AI
+*/
+/mob/proc/AltShiftClickOn(atom/A)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_CLICK_ALT_SHIFT, A) & COMPONENT_CANCEL_CLICK)
+		return
+
+	var/obj/item/I = get_active_hand()
+	if(I && next_move <= world.time && !incapacitated() && (SEND_SIGNAL(I, COMSIG_ITEM_ALTSHIFTCLICKWITH, A, src) & COMSIG_ITEM_CANCEL_CLICKWITH))
+		return
+
+	A.AltShiftClick(src)
+	return
+
+/atom/proc/AltShiftClick(mob/user)
+	return
+
+/*
 	Misc helpers
 
 	Laser Eyes: as the name implies, handles this since nothing else does currently

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -27,6 +27,9 @@
 	if(modifiers[SHIFT_CLICK] && modifiers[CTRL_CLICK])
 		CtrlShiftClickOn(A)
 		return
+	if(modifiers[SHIFT_CLICK] && modifiers[ALT_CLICK])
+		AltShiftClickOn(A)
+		return
 	if(modifiers[MIDDLE_CLICK])
 		MiddleClickOn(A)
 		return
@@ -112,6 +115,9 @@
 /mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
 	A.BorgCtrlShiftClick(src)
 
+/mob/living/silicon/robot/AltShiftClickOn(atom/A)
+	A.BorgAltShiftClick(src)
+
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
 	A.BorgShiftClick(src)
 
@@ -158,6 +164,13 @@
 
 /obj/machinery/turretid/BorgAltClick(mob/M) //turret lethal on/off. Forwards to AI code.
 	AIAltClick(M)
+
+/atom/proc/BorgAltShiftClick(mob/living/silicon/robot/user)
+	AltShiftClick(user)
+	return
+
+/obj/machinery/door/airlock/BorgAltShiftClick(mob/M) // Emergency mode doors on/off. Forwards to AI code.
+	AIAltShiftClick(M)
 
 /*
 	As with AI, these are not used in click code,

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -948,6 +948,3 @@ var/global/list/ai_verbs_default = list(
 		pixel_y = 8
 	else
 		pixel_y = 0
-
-/mob/living/silicon/ai/is_antag()
-	return laws?.zeroth

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1212,5 +1212,3 @@
 				F.attackby(B, src)
 				break
 
-/mob/living/silicon/robot/is_antag()
-	return emagged || laws?.zeroth

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -201,6 +201,3 @@
 
 /mob/living/silicon/vomit(punched = FALSE, masked = FALSE, vomit_type = DEFAULT_VOMIT, stun = TRUE, force = FALSE)
 	return
-
-/mob/living/silicon/proc/is_antag()
-	return FALSE


### PR DESCRIPTION


<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
#14556 частичный откат изменения связанного с электрификацией только антаг ИИ/боргов и т.д. в виду спорности ПРа
Но не откат самого рефактора
## Почему и что этот ПР улучшит
Причина данного ПРа:
Откат спорных изменений без обсуждения на форуме и то что мейнтейнер абсолютно проигнорировал обсуждения и реакцию людей в ПРе и администрацию касательно данного вопроса

## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl: Azzy.Dreemurr
 - del: Откат спорного изменения связанного с электрификации у ИИ/боргов
