### PR TITLE
AI QOL hotkey + refactor

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -101,20 +101,27 @@
 		if(!active_module.AIAltClickHandle(A))
 			return
 	A.AIAltClick(src)
+/mob/living/silicon/ai/CtrlShiftClickOn(atom/A)
+	A.AICtrlShiftClick(src)
 
 /*
 	The following criminally helpful code is just the previous code cleaned up;
 	I have no idea why it was in atoms.dm instead of respective files.
 */
 
-/atom/proc/AICtrlShiftClick()
+/atom/proc/AICtrlShiftClick(mob/M)
 	return
 
-/obj/machinery/door/airlock/AICtrlShiftClick()
-	if(emagged)
+/obj/machinery/door/airlock/AICtrlShiftClick(mob/M)
+	if(!can_still_interact_with(M))
 		return
-	return
-
+	if(!issilicon(M))
+		return
+	if(!secondsMainPowerLost && !secondsBackupPowerLost)
+		loseMainPower()
+		loseBackupPower()
+	else
+		to_chat(M, "Питание уже отключено!")
 /atom/proc/AIShiftClick(mob/living/silicon/ai/user)
 	user.examinate(src)
 
@@ -168,7 +175,6 @@
 		enable_emergency_access(M)
 	else
 		disable_emergency_access(M)
-
 //
 // Override AdjacentQuick for AltClicking
 //

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -113,6 +113,7 @@
 	return
 
 /obj/machinery/door/airlock/AICtrlShiftClick(mob/M)
+
 	if(!can_still_interact_with(M))
 		return
 	if(!issilicon(M))
@@ -141,14 +142,14 @@
 	return
 
 
-/atom/proc/AICtrlClick()
+/atom/proc/AICtrlClick(mob/M)
 	return
 
-/obj/machinery/door/airlock/AICtrlClick() // Bolts doors
+/obj/machinery/door/airlock/AICtrlClick(mob/M) // Bolts doors
 	if(locked)
-		Topic("aiEnable=4", list("aiEnable"="4"), 1)// 1 meaning no window (consistency!)
+		AIUnbolt(M)
 	else
-		Topic("aiDisable=4", list("aiDisable"="4"), 1)
+		AIBolt(M)
 
 /obj/machinery/power/apc/AICtrlClick(mob/user) // turns off/on APCs.
 	if(user.incapacitated() || aidisabled)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -116,8 +116,6 @@
 
 	if(!can_still_interact_with(M))
 		return
-	if(!issilicon(M))
-		return
 	if(!secondsMainPowerLost && !secondsBackupPowerLost)
 		loseMainPower()
 		loseBackupPower()
@@ -146,6 +144,8 @@
 	return
 
 /obj/machinery/door/airlock/AICtrlClick(mob/M) // Bolts doors
+	if(!can_still_interact_with(M))
+		return
 	if(locked)
 		AIUnbolt(M)
 	else

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -120,7 +120,7 @@
 		loseMainPower()
 		loseBackupPower()
 	else
-		to_chat(M, "Питание уже отключено!")
+		to_chat(M, "<span class='notice'>Питание уже отключено!</span>")
 /atom/proc/AIShiftClick(mob/living/silicon/ai/user)
 	user.examinate(src)
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -127,8 +127,8 @@
 /atom/proc/BorgCtrlShiftClick(mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlShiftClick(user)
 
-/obj/machinery/door/airlock/BorgCtrlShiftClick()
-	AICtrlShiftClick()
+/obj/machinery/door/airlock/BorgCtrlShiftClick(mob/living/silicon/robot/user) // Cut power to doors. Forwards to AI code.
+	AICtrlShiftClick(user)
 
 /atom/proc/BorgShiftClick(mob/living/silicon/robot/user) //forward to human click if not overriden
 	ShiftClick(user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -234,13 +234,14 @@ var/global/list/airlock_overlays = list()
 	// Raise door bolts
 	if(isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
 		to_chat(user, "The door bolt drop wire is cut - you can't raise the door bolts.<br>\n")
-	else if(!locked)
+		return
+	if(!locked)
 		to_chat(user, "The door bolts are already up.<br>\n")
-	else
-		if(hasPower())
-			unbolt()
-		else
-			to_chat(user, "Cannot raise door bolts due to power failure.<br>\n")
+		return
+	if(!hasPower())
+		to_chat(user, "Cannot raise door bolts due to power failure.<br>\n")
+		return
+	unbolt()
 
 // shock user with probability prb (if all connections & power are working)
 // returns 1 if shocked, 0 otherwise

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -217,12 +217,30 @@ var/global/list/airlock_overlays = list()
 	playsound(src, door_bolt_down_sound, VOL_EFFECTS_MASTER, 40, FALSE, null, -4)
 	update_icon()
 
+/obj/machinery/door/airlock/proc/AIBolt(mob/user)
+	if(isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
+		to_chat(user, "You can't drop the door bolts - The door bolt dropping wire has been cut.")
+	else if(!locked)
+		bolt()
+
 /obj/machinery/door/airlock/proc/unbolt()
 	if(!locked)
 		return
 	locked = 0
 	playsound(src, door_bolt_up_sound, VOL_EFFECTS_MASTER, 40, FALSE, null, -4)
 	update_icon()
+
+/obj/machinery/door/airlock/proc/AIUnbolt(mob/user)
+	// Raise door bolts
+	if(isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
+		to_chat(user, "The door bolt drop wire is cut - you can't raise the door bolts.<br>\n")
+	else if(!locked)
+		to_chat(user, "The door bolts are already up.<br>\n")
+	else
+		if(hasPower())
+			unbolt()
+		else
+			to_chat(user, "Cannot raise door bolts due to power failure.<br>\n")
 
 // shock user with probability prb (if all connections & power are working)
 // returns 1 if shocked, 0 otherwise
@@ -730,10 +748,7 @@ var/global/list/airlock_overlays = list()
 
 				if(4)
 					// Drop door bolts
-					if(isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						to_chat(usr, "You can't drop the door bolts - The door bolt dropping wire has been cut.")
-					else if(!locked)
-						bolt()
+					AIBolt(usr)
 
 				if(5)
 					// Un-electrify door
@@ -794,15 +809,7 @@ var/global/list/airlock_overlays = list()
 
 				if(4)
 					// Raise door bolts
-					if(isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						to_chat(usr, "The door bolt drop wire is cut - you can't raise the door bolts.<br>\n")
-					else if(!locked)
-						to_chat(usr, "The door bolts are already up.<br>\n")
-					else
-						if(hasPower())
-							unbolt()
-						else
-							to_chat(usr, "Cannot raise door bolts due to power failure.<br>\n")
+					AIUnbolt(usr)
 
 				if(5)
 					// Electrify door for 30 seconds

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -220,7 +220,8 @@ var/global/list/airlock_overlays = list()
 /obj/machinery/door/airlock/proc/AIBolt(mob/user)
 	if(isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
 		to_chat(user, "You can't drop the door bolts - The door bolt dropping wire has been cut.")
-	else if(!locked)
+		return
+	if(!locked)
 		bolt()
 
 /obj/machinery/door/airlock/proc/unbolt()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -199,10 +199,12 @@ var/global/list/airlock_overlays = list()
 					cont = TRUE
 			spawnPowerRestoreRunning = FALSE
 			updateDialog()
+			update_icon()
 
 /obj/machinery/door/airlock/proc/loseBackupPower()
 	if(secondsBackupPowerLost < 60)
 		secondsBackupPowerLost = 60
+	update_icon()
 
 /obj/machinery/door/airlock/proc/regainBackupPower()
 	if(secondsBackupPowerLost > 0)
@@ -716,7 +718,6 @@ var/global/list/airlock_overlays = list()
 					// Disrupt main power
 					if(!secondsMainPowerLost)
 						loseMainPower()
-						update_icon()
 					else
 						to_chat(usr, "Main power is already offline.")
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Продолжаю свой тейк про то, что QOL фичи нельзя убирать и надо добавлять, потому поддерживаю в этом плане предложение @LudwigVonChesterfield — добавление на Ctrl+Shift+Click обесточивание двери. 

<img width="1070" height="64" alt="image" src="https://github.com/user-attachments/assets/d7d77fde-09f9-4811-9a8f-ed2c5686ebb0" />


Также провёл мини-рефактор болтирования дверей ИИшкой

## Почему и что этот ПР улучшит

QOL фича для ИИ, более чистый код
 
## Авторство

@L4rever 

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:

- tweak: ИИ может обесточивать двери на ctrl-shift-click
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
