### PR TITLE
Update protected jobs for Blueshield implant

### DIFF
--- a/code/__DEFINES/tags/jobs.dm
+++ b/code/__DEFINES/tags/jobs.dm
@@ -85,5 +85,3 @@
 
 #define JOB_BLUESHIELD "Blueshield Officer"
 #define JOB_LAWYER "Internal Affairs Agent"
-#define JOB_ERT_LEADER "ERT Leader"
-#define JOB_ERT_MEMBER "ERT Member"

--- a/code/__DEFINES/tags/jobs.dm
+++ b/code/__DEFINES/tags/jobs.dm
@@ -85,3 +85,5 @@
 
 #define JOB_BLUESHIELD "Blueshield Officer"
 #define JOB_LAWYER "Internal Affairs Agent"
+#define JOB_ERT_LEADER "ERT Leader"
+#define JOB_ERT_MEMBER "ERT Member"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -37,6 +37,7 @@
 
 	var/assigned_role
 	var/special_role
+	var/is_ert_leader = FALSE
 
 	var/holy_role = NONE
 

--- a/code/datums/spawners_menu/spawners_responder.dm
+++ b/code/datums/spawners_menu/spawners_responder.dm
@@ -49,14 +49,10 @@
 	M.mind.original = M
 	M.mind.assigned_role = "MODE"
 	M.mind.special_role = "Response Team"
+	M.mind.is_ert_leader = is_leader
 	if(!(M.mind in SSticker.minds))
 		SSticker.minds += M.mind//Adds them to regular mind list.
 	M.loc = get_turf(spawnloc)
-
-	if(is_leader)
-		M.job = JOB_ERT_LEADER
-	else
-		M.job = JOB_ERT_MEMBER
 
 	if(is_leader && leader_outfit)
 		M.equipOutfit(leader_outfit)

--- a/code/datums/spawners_menu/spawners_responder.dm
+++ b/code/datums/spawners_menu/spawners_responder.dm
@@ -53,6 +53,11 @@
 		SSticker.minds += M.mind//Adds them to regular mind list.
 	M.loc = get_turf(spawnloc)
 
+	if(is_leader)
+		M.job = JOB_ERT_LEADER
+	else
+		M.job = JOB_ERT_MEMBER
+
 	if(is_leader && leader_outfit)
 		M.equipOutfit(leader_outfit)
 	else

--- a/code/game/objects/items/weapons/implants/misc.dm
+++ b/code/game/objects/items/weapons/implants/misc.dm
@@ -186,7 +186,7 @@
 Правда, эти приборы никогда на станцию не доставляются."}
 
 /obj/item/weapon/implant/blueshield/atom_init()
-	protected_jobs = SSjob.departments_occupations[DEP_COMMAND] + JOB_LAWYER
+	protected_jobs = SSjob.departments_occupations[DEP_COMMAND] + JOB_LAWYER + JOB_ERT_LEADER
 	. = ..()
 
 /obj/item/weapon/implant/blueshield/inject(mob/living/carbon/C, def_zone)

--- a/code/game/objects/items/weapons/implants/misc.dm
+++ b/code/game/objects/items/weapons/implants/misc.dm
@@ -186,7 +186,7 @@
 Правда, эти приборы никогда на станцию не доставляются."}
 
 /obj/item/weapon/implant/blueshield/atom_init()
-	protected_jobs = SSjob.departments_occupations[DEP_COMMAND] + JOB_LAWYER + JOB_ERT_LEADER
+	protected_jobs = SSjob.departments_occupations[DEP_COMMAND] + JOB_LAWYER
 	. = ..()
 
 /obj/item/weapon/implant/blueshield/inject(mob/living/carbon/C, def_zone)
@@ -199,9 +199,12 @@
 	. = ..()
 
 /obj/item/weapon/implant/blueshield/proc/on_examine(mob/user, mob/M)
-	if(M.mind && (M.mind.assigned_role in protected_jobs))
+	if(is_protected_mob(M))
 		penalty_stack = 0
 		COOLDOWN_RESET(src, penalty_cooldown)
+
+/obj/item/weapon/implant/blueshield/proc/is_protected_mob(mob/M)
+	return M.mind && ((M.mind.assigned_role in protected_jobs) || M.mind.is_ert_leader)
 
 /obj/item/weapon/implant/blueshield/process()
 	if(!implanted_mob)
@@ -217,7 +220,7 @@
 	// todo: store crew in jobs/departments datums
 	var/list/to_protect = list()
 	for(var/mob/living/carbon/human/player as anything in human_list)
-		if(player.mind && (player.mind.assigned_role in protected_jobs))
+		if(is_protected_mob(player))
 			to_protect += player.mind
 
 	if(!length(to_protect))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Добавил лидера ЕРТ в защищаемые роли для импланта по просьбе @volas 

Related to [TauCetiStaton/Rules#98](https://github.com/TauCetiStation/Rules/pull/98)

## Почему и что этот ПР улучшит

Изменено по решению жалобы, добавлено уточнение про то, что должны защищаться все высокопоставленные представители НТ

https://forum.taucetistation.org/t/zhaloba-azzy-dreemurr/45911/15

## Авторство

@L4rever 
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
- balance: Синий щит теперь обязан защищать и лидера ОБР тоже

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
