### PR TITLE
фикс экшен кнопки у баллонов

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -45,8 +45,14 @@
 	name = "Toggle internals"
 
 /datum/action/item_action/hands_free/toggle_internals/Activate()
-	var/obj/item/weapon/tank/T = target
-	T.toggle_internals()
+	var/obj/item/weapon/tank/tank = target
+	tank.toggle_internals()
+
+/datum/action/item_action/hands_free/toggle_internals/Remove(mob/T)
+	var/obj/item/weapon/tank/tank = target
+	owner.internal = null
+	tank.update_actions_icons(owner)
+	..()
 
 /obj/item/weapon/tank/examine(mob/user)
 	..()
@@ -202,12 +208,16 @@
 	internal_switch = world.time + 16
 	update_actions_icons(C)
 
-/obj/item/weapon/tank/proc/update_actions_icons(mob/living/carbon/T)
-	for(var/datum/action/item_action/hands_free/toggle_internals/TI in T.actions)
-		if(T.internal == src)
-			TI.background_icon_state = "bg_active"
+
+/obj/item/weapon/tank/proc/update_actions_icons(mob/living/carbon/C, turn_off = FALSE)
+	for(var/datum/action/item_action/hands_free/toggle_internals/TI in C.actions)
+		if((TI.target == src) && (C.internal == src) && !turn_off)
+			TI.active = TRUE
+			TI.UpdateButtonIcon()
 		else
-			TI.background_icon_state = "bg_default"
+			TI.active = FALSE
+			TI.UpdateButtonIcon()
+	C.update_action_buttons()
 
 /obj/item/weapon/tank/remove_air(amount)
 	return air_contents.remove(amount)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -377,6 +377,7 @@ var/global/list/tourette_bad_words= list(
 		return null
 
 	if(!(HAS_TRAIT(src, TRAIT_EXTERNAL_VENTILATION) || (contents.Find(internal) && wear_mask && (wear_mask.flags & MASKINTERNALS))))
+		internal.update_actions_icons(src, TRUE)
 		internal = null
 		return null
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
иконка кнопки корректно обновляется при подключении и отключении (экшен кнопкой, при снятии маски и при удалении баллона из инвентаря) баллона
## Почему и что этот ПР улучшит
меньше багов
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- fix: Экшен-кнопка у баллона корректно обновляется при подключении и отключении баллона к дыхательной маске/противогазу.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
