### PR TITLE
люди могут дышать в зимнем лесу

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -82,9 +82,9 @@
 	var/heat_level_2 = BODYTEMP_HEAT_DAMAGE_LIMIT + 40	// Heat damage level 2 above this point.
 	var/heat_level_3 = BODYTEMP_HEAT_DAMAGE_LIMIT + 640	// Heat damage level 3 above this point.
 
-	var/breath_cold_level_1 = BODYTEMP_COLD_DAMAGE_LIMIT - 15
-	var/breath_cold_level_2 = BODYTEMP_COLD_DAMAGE_LIMIT - 30
-	var/breath_cold_level_3 = BODYTEMP_COLD_DAMAGE_LIMIT - 45
+	var/breath_cold_level_1 = BODYTEMP_COLD_DAMAGE_LIMIT - 40
+	var/breath_cold_level_2 = BODYTEMP_COLD_DAMAGE_LIMIT - 50
+	var/breath_cold_level_3 = BODYTEMP_COLD_DAMAGE_LIMIT - 85
 
 	var/body_temperature = BODYTEMP_NORMAL	//non-IS_SYNTHETIC species will try to stabilize at this temperature. (also affects temperature processing)
 	var/synth_temp_gain = 0					//IS_SYNTHETIC species will gain this much temperature every second
@@ -617,10 +617,6 @@
 	unarmed_type = /datum/unarmed_attack/claws
 	dietflags = DIET_OMNI
 	taste_sensitivity = TASTE_SENSITIVITY_SHARP
-
-	breath_cold_level_1 = BODYTEMP_COLD_DAMAGE_LIMIT - 40
-	breath_cold_level_2 = BODYTEMP_COLD_DAMAGE_LIMIT - 50
-	breath_cold_level_3 = BODYTEMP_COLD_DAMAGE_LIMIT - 60
 
 	cold_level_1 = BODYTEMP_COLD_DAMAGE_LIMIT - 20
 	cold_level_2 = BODYTEMP_COLD_DAMAGE_LIMIT - 40


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
см. название
## Почему и что этот ПР улучшит
жизнь игроков
когда-то давно в зимнем лесу можно было спокойно дышать, но вот в один момент температуру понизили чтобы слаймов можно в лес выбрасывать и они умирали
температуру понизили, а возможность дышать при такой температуре не добавили
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- tweak: Люди могут дышать без маски и баллона в зимнем лесу.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
