### PR TITLE
Фикс зависания консолей вирусологии

### DIFF
--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -48,6 +48,7 @@
 	data["antibodies"] = null
 	data["pathogens"] = null
 	data["is_antibody_sample"] = null
+	data["busy"] = null
 
 	if (curing)
 		data["busy"] = "Isolating antibodies..."

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -52,6 +52,7 @@
 	data["dish_inserted"] = !!dish
 	data["affected_species"] = null
 	data["can_splice"] = FALSE
+	data["busy"] = null
 
 	if (memorybank)
 		data["buffer"] = list("name" = (analysed ? memorybank.effect.name : "Unknown Symptom"))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Не занулял параметр busy в tgui_data, из-за чего консоль могла зависнуть в заблокированном состоянии, пока игрок не откроет интерфейс заново.
## Почему и что этот ПР улучшит

## Авторство
Спасибо reminedme за подсказку и Mercurialaste за репорт
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: Консоли вирусолога зависали в состоянии выполнения задачи до перезапуска интерфейса
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
