### PR TITLE
Слепота накладывается мобам в трубах при перезаходе

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -7,7 +7,10 @@
 
 	//Vents
 	if(ventcrawler)
-		to_chat(src, "<span class='notice'>You can ventcrawl! Use alt+click on vents to quickly travel about the station.</span>")
+		to_chat(src, "<span class='notice'>You can ventcrawl! Use alt+click on vents to quickly travel around the station.</span>")
+	if(is_ventcrawling && istype(loc, /obj/machinery/atmospherics)) //attach us back into the pipes
+		remove_ventcrawl()
+		add_ventcrawl(loc)
 
 	noob_notify(src)
 

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -31,13 +31,6 @@ var/global/list/ventcrawl_machinery = list(
 		return FALSE
 	return ventcrawl_carry()
 
-/mob/living/LateLogin()
-	. = ..()
-	//login during ventcrawl
-	if(is_ventcrawling && istype(loc, /obj/machinery/atmospherics)) //attach us back into the pipes
-		remove_ventcrawl()
-		add_ventcrawl(loc)
-
 /mob/living/carbon/slime/can_ventcrawl()
 	if(Victim)
 		to_chat(src, "<span class='warning'>You cannot ventcrawl while feeding.</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Баг с наложением слепоты при перезаходе был вызван двойным определением /mob/living/LateLogin(). Одно из них это какой-то огрызок кода в code\modules\ventcrawl\ventcrawl.dm. При этом ventcrawl в dme файле расположен позже, поэтому основной LateLogin() затирался. Думаю, что это могло и к другим багам приводить, но я фиксил непосредственно упомянутый и знаю только про него.  
Совместил два прока в один, вроде всё чётко теперь.
## Почему и что этот ПР улучшит
fixes #8450 
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: мобам в трубах не накладывалась слепота при перезаходе в игру
 - bugfix: дрону синдиката в трубе не возвращалась слепота при повторном взятии под управление
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
