### PR TITLE
Убираем серый фильтр у обезьян после перезахода

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1192,6 +1192,8 @@
 		set_EyesVision("greyscale")
 		return FALSE
 
+	set_EyesVision(null)
+
 	sight = initial(sight)
 	var/new_lighting_alpha = initial(lighting_alpha)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -101,7 +101,6 @@
 		return FALSE
 
 	see_in_dark = 8
-	set_EyesVision(null)
 
 	if(nightvision)
 		set_lighting_alpha(LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если играть за обезьяну (вроде ещё Яна) и перезайти в игру, серый фильтр от потери сознания не сбрасывался и оставался навсегда.
Если на момент реконнекта обезьяна без сознания, greyscale применялся к новому клиенту. Когда затем в Life() моб приходил в себя, blinded сбрасывался в null, update_sight() шёл по нормальной ветке, но не вызывался set_EyesVision(null).
## Почему и что этот ПР улучшит
Вроде баг не репортили, но теперь его нет.
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: при игре за обезьян, Яна и некоторых других мобов перезаход оставлял на экране неубираемый серый фильтр.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
