### PR TITLE
rcd update

### DIFF
--- a/code/__DEFINES/rcd.dm
+++ b/code/__DEFINES/rcd.dm
@@ -1,5 +1,5 @@
 #define RCD_MODE_FLOOR_WALLS "Floor & Walls"
-#define RCD_MODE_AIRLOCK     "Airlock"
+#define RCD_MODE_AIRLOCK_ASSEMBLY     "Airlock Assembly"
 #define RCD_MODE_DECONSTRUCT "Deconstruct"
 
 #define RCD_MODE_PNEUMATIC 	"Pneumatic Tube"

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -381,16 +381,15 @@
 					chassis.use_power(energy_drain*2)
 		if(2)
 			if(isfloorturf(target))
-				occupant_message("Building Airlock...")
+				occupant_message("Building Airlock Assembly...")
 				set_ready_state(0)
 				if(do_after_cooldown(target))
 					if(disabled) return
 					chassis.spark_system.start()
-					var/obj/machinery/door/airlock/T = new /obj/machinery/door/airlock(target)
-					T.autoclose = 1
-					playsound(target, 'sound/items/Deconstruct.ogg', VOL_EFFECTS_MASTER)
-					playsound(target, 'sound/effects/sparks2.ogg', VOL_EFFECTS_MASTER)
-					chassis.use_power(energy_drain*2)
+					var/obj/structure/door_assembly/da = new /obj/structure/door_assembly(target)
+					da.anchored = TRUE
+					da.state = ASSEMBLY_WIRED
+					da.update_state()
 	return
 
 

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -386,10 +386,10 @@
 				if(do_after_cooldown(target))
 					if(disabled) return
 					chassis.spark_system.start()
-					var/obj/structure/door_assembly/da = new /obj/structure/door_assembly(target)
-					da.anchored = TRUE
-					da.state = ASSEMBLY_WIRED
-					da.update_state()
+					var/obj/structure/door_assembly/DA = new /obj/structure/door_assembly(target)
+					DA.anchored = TRUE
+					DA.state = ASSEMBLY_WIRED
+					DA.update_state()
 	return
 
 

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -180,10 +180,10 @@ RCD
 				if(!use_tool(target, user, 3 SECONDS, amount = 20))
 					return
 				activate()
-				var/obj/structure/door_assembly/da = new /obj/structure/door_assembly(target)
-				da.anchored = TRUE
-				da.state = ASSEMBLY_WIRED
-				da.update_state()
+				var/obj/structure/door_assembly/DA = new /obj/structure/door_assembly(target)
+				DA.anchored = TRUE
+				DA.state = ASSEMBLY_WIRED
+				DA.update_state()
 				return TRUE
 
 		if(RCD_MODE_DECONSTRUCT)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -24,7 +24,7 @@ RCD
 	var/max_matter = 100
 	var/working = 0
 	var/mode = RCD_MODE_FLOOR_WALLS
-	var/list/available_modes = list(RCD_MODE_FLOOR_WALLS, RCD_MODE_AIRLOCK, RCD_MODE_DECONSTRUCT)
+	var/list/available_modes = list(RCD_MODE_FLOOR_WALLS, RCD_MODE_AIRLOCK_ASSEMBLY, RCD_MODE_DECONSTRUCT)
 	var/canRwall = 0
 	var/disabled = 0
 
@@ -48,7 +48,7 @@ RCD
 	switch(mode)
 		if(RCD_MODE_FLOOR_WALLS)  mode_overlay = "floornwall"
 		if(RCD_MODE_DECONSTRUCT)  mode_overlay = "deconstruct"
-		if(RCD_MODE_AIRLOCK)      mode_overlay = "airlock"
+		if(RCD_MODE_AIRLOCK_ASSEMBLY)      mode_overlay = "airlock assembly"
 		else                      mode_overlay = "floornwall"
 	add_overlay(image(icon, "sel_[mode_overlay][overlay_suffix]"))
 
@@ -97,7 +97,7 @@ RCD
 		return
 
 	var/static/radial_floor_wall = image(icon = 'icons/turf/floors.dmi', icon_state = "plating")
-	var/static/radial_airlock = image(icon = 'icons/obj/doors/airlocks/station/public.dmi', icon_state = "full")
+	var/static/radial_airlock = image(icon = 'icons/obj/doors/airlocks/station/public.dmi', icon_state = "construction")
 	var/static/radial_pipe = image(icon = 'icons/obj/pipes/disposal.dmi', icon_state = "conpipe-s")
 	var/static/radial_deconstruct = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_trash")
 
@@ -105,8 +105,8 @@ RCD
 
 	if(RCD_MODE_FLOOR_WALLS in available_modes)
 		options[RCD_MODE_FLOOR_WALLS] = radial_floor_wall
-	if(RCD_MODE_AIRLOCK in available_modes)
-		options[RCD_MODE_AIRLOCK] = radial_airlock
+	if(RCD_MODE_AIRLOCK_ASSEMBLY in available_modes)
+		options[RCD_MODE_AIRLOCK_ASSEMBLY] = radial_airlock
 	if(RCD_MODE_DECONSTRUCT in available_modes)
 		options[RCD_MODE_DECONSTRUCT] = radial_deconstruct
 	if(RCD_MODE_PNEUMATIC in available_modes)
@@ -170,17 +170,20 @@ RCD
 				F.ChangeTurf(/turf/simulated/wall)
 				return TRUE
 
-		if(RCD_MODE_AIRLOCK)
+		if(RCD_MODE_AIRLOCK_ASSEMBLY)
 			if(isfloorturf(target))
 				if(!canBuildOnTurf(target))
-					to_chat(user, "<span class='warning'>You can't build airlock here.</span>")
+					to_chat(user, "<span class='warning'>You can't build airlock assembly here.</span>")
 					return FALSE
 
-				to_chat(user, "<span class='notice'>Building Airlock...</span>")
-				if(!use_tool(target, user, 5 SECONDS, amount = 20))
+				to_chat(user, "<span class='notice'>Building Airlock Assembly...</span>")
+				if(!use_tool(target, user, 3 SECONDS, amount = 20))
 					return
 				activate()
-				new /obj/machinery/door/airlock(target)
+				var/obj/structure/door_assembly/da = new /obj/structure/door_assembly(target)
+				da.anchored = TRUE
+				da.state = ASSEMBLY_WIRED
+				da.update_state()
 				return TRUE
 
 		if(RCD_MODE_DECONSTRUCT)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Немного ускорил работу РЦД в режиму постройки "шлюзов"
Вместо шлюзов РЦД теперь строит раму шлюза, прикрученую к полу и с проводами внутри.
(Да, РЦД меха, тоже)
## Почему и что этот ПР улучшит
Удобство для инженеров.

Вместо: Поставил шлюз без доступа -> разобрал его -> поставил стекло\доступ -> собрал обратно
Сейчас: Поставил раму для шлюза -> поставил стекло\доступ -> собрал

(Ну и РЦД меха теперь не сможет ставить 10000 шлюзов в 1 тайл)
(рцд боргов тоже)
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- tweak: РЦД в режиме "шлюзов" работает немного быстрее и вместо шлюзов строит рамы для шлюзов.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
