### PR TITLE
Lord singulo

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -260,6 +260,9 @@
 	if(target && prob(60))
 		movement_dir = get_dir(src,target) //moves to a singulo beacon, if there is one
 
+	else if(prob(round(length(orbiters) * 2.5))) //These ghosts are griefers
+		movement_dir = get_dir(src, get_turf(length(global.living_list) ? pick(global.living_list) : get_turf(src)))
+
 	step(src, movement_dir)
 
 /obj/singularity/proc/check_turfs_in(direction = 0, step = 0)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -92,6 +92,10 @@ var/global/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmosp
 	var/first_move = dir
 	for(var/i in 0 to move_amount)
 		var/move_dir = pick(alldirs + first_move) //give the first move direction a bit of favoring.
+
+		if(prob(round((length(orbiters) - length(orbiting_balls)) * 1.5))) //These ghosts are griefers
+			move_dir = get_dir(src, get_turf(length(global.living_list) ? pick(global.living_list) : get_turf(src)))
+
 		var/turf/T = get_step(src, move_dir)
 		if(can_move(T))
 			loc = T


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Есть забавный миф, что призраки толкают сингу или теслу. Так вот теперь он получает воплощение.

В общем-то идея проста: за каждого орбитящего сингулярность призрака, имеется 2.5% шанс пойти в сторону живого. У теслы шанс 1.5%, т.к. быстро перемещается.
## Почему и что этот ПР улучшит
Если синга сбежала и аж 20 человек сидят в гостах, и хотят закончить раунд, то пускай у них будет небольшое развлечение. Раунду уже не поможешь. Масс грифф? Масс грифф, но в раунде погибло МИНИМУМ 20 человек, а скорее всего много больше. Так давайте закончим раунд с размахом.

Собственно, ПР реально стремный, поэтому если народ будет против - закрою.
## Авторство

## Чеинжлог

:cl:
 - balance: Призраки наводят лорда Сингуло на живых
