### PR TITLE
Карго имеют свою сеть камер.

### DIFF
--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -43,8 +43,9 @@ var/global/const/CAMERA_WIRE_NOTHING2 = 32
 				C.cancelCameraAlarm()
 
 		if(CAMERA_WIRE_AI)
-			C.hidden = !mended
-			cameranet.updateVisibility(C, 0)
+			if(C.hidden == mended)
+				C.hidden = !mended
+				cameranet.updateVisibility(C, 0)
 
 /datum/wires/camera/update_pulsed(index)
 	var/obj/machinery/camera/C = holder

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -2,7 +2,7 @@ var/global/const/CAMERA_WIRE_FOCUS    = 1
 var/global/const/CAMERA_WIRE_POWER    = 2
 var/global/const/CAMERA_WIRE_LIGHT    = 4
 var/global/const/CAMERA_WIRE_ALARM    = 8
-var/global/const/CAMERA_WIRE_NOTHING1 = 16
+var/global/const/CAMERA_WIRE_AI       = 16
 var/global/const/CAMERA_WIRE_NOTHING2 = 32
 
 /datum/wires/camera
@@ -16,6 +16,7 @@ var/global/const/CAMERA_WIRE_NOTHING2 = 32
 	. += "[(C.can_use(check_paint = FALSE) ? "The power link light is on." : "The power link light is off.")]"
 	. += "[(C.light_disabled ? "The camera light is off." : "The camera light is on.")]"
 	. += "[(C.alarm_on ? "The alarm light is on." : "The alarm light is off.")]"
+	. += "[(C.hidden ? "The cyan light is off." : "The cyan light is blinking.")]"
 
 /datum/wires/camera/can_use()
 	var/obj/machinery/camera/C = holder
@@ -41,6 +42,10 @@ var/global/const/CAMERA_WIRE_NOTHING2 = 32
 			else
 				C.cancelCameraAlarm()
 
+		if(CAMERA_WIRE_AI)
+			C.hidden = !mended
+			cameranet.updateVisibility(C, 0)
+
 /datum/wires/camera/update_pulsed(index)
 	var/obj/machinery/camera/C = holder
 
@@ -59,4 +64,4 @@ var/global/const/CAMERA_WIRE_NOTHING2 = 32
 			C.audible_message("[bicon(C)] *beep*")
 
 /datum/wires/camera/proc/is_deconstructable()
-	return is_index_cut(CAMERA_WIRE_POWER) && is_index_cut(CAMERA_WIRE_FOCUS) && is_index_cut(CAMERA_WIRE_LIGHT) && is_index_cut(CAMERA_WIRE_NOTHING1) && is_index_cut(CAMERA_WIRE_NOTHING2)
+	return is_index_cut(CAMERA_WIRE_POWER) && is_index_cut(CAMERA_WIRE_FOCUS) && is_index_cut(CAMERA_WIRE_LIGHT) && is_index_cut(CAMERA_WIRE_AI) && is_index_cut(CAMERA_WIRE_NOTHING2)

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -78,6 +78,9 @@
 		if(!c)
 			continue
 
+		if(c.hidden)
+			continue
+
 		var/restricted = 0
 		for(var/N in c.network)
 			if(N in RESTRICTED_CAMERA_NETWORKS)
@@ -152,7 +155,7 @@
 		if(restricted)
 			continue
 
-		if(c.can_use())
+		if(c.can_use() && !c.hidden)
 			cameras += c
 
 	for(var/turf/t in range(10, locate(x + 8, y + 8, z)))
@@ -165,6 +168,9 @@
 			continue
 
 		if(!c.can_use())
+			continue
+
+		if(c.hidden)
 			continue
 
 		for(var/turf/t in c.can_see())

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -6808,7 +6808,9 @@
 "alk" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay South";
-	dir = 5
+	dir = 5;
+	network = list("CARGO");
+	hidden = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -14037,10 +14039,15 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/eva)
 "axK" = (
-/obj/machinery/computer/security/mining,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 24
+	},
+/obj/structure/filingcabinet{
+	req_access = list(41)
+	},
+/obj/item/weapon/paper/depacc{
+	department_name = "Cargo"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -16410,18 +16417,10 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aCa" = (
-/obj/structure/filingcabinet{
-	req_access = list(41)
-	},
-/obj/item/weapon/paper/depacc{
-	department_name = "Cargo"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/item/portrait/captain{
-	pixel_x = 32
-	},
+/obj/structure/closet/secure_closet/quartermaster,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brown"
@@ -23078,13 +23077,14 @@
 "aOI" = (
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
-	dir = 8
-	},
-/obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/item/weapon/flora/pottedplant/ficus,
+/obj/item/portrait/captain{
+	pixel_x = 32
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -24948,7 +24948,9 @@
 /area/station/security/checkpoint)
 "aSa" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Bay Warehouse"
+	c_tag = "Cargo Bay Warehouse";
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/structure/rack,
 /obj/random/science/circuit,
@@ -27558,7 +27560,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Lobby";
-	dir = 8
+	dir = 8;
+	network = list("CARGO");
+	hidden = 1
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -29360,7 +29364,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -27
 	},
-/obj/structure/closet/secure_closet/quartermaster,
+/obj/structure/table,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"
@@ -29408,6 +29412,10 @@
 /obj/item/weapon/coin/silver{
 	pixel_x = -8;
 	pixel_y = -2
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor{
 	icon_state = "brown"
@@ -32825,7 +32833,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining office";
-	dir = 6
+	dir = 6;
+	network = list("CARGO");
+	hidden = 1
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -34980,6 +34990,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/computer/security/mining{
+	network = list("CARGO", "MINE");
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -36295,7 +36309,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Office";
-	dir = 8
+	dir = 8;
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/machinery/computer/vending{
 	dir = 8
@@ -43367,7 +43383,9 @@
 "byv" = (
 /obj/machinery/camera{
 	c_tag = "Recycler Office";
-	dir = 1
+	dir = 1;
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54838,7 +54856,9 @@
 "bTT" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay East";
-	dir = 1
+	dir = 1;
+	network = list("CARGO");
+	hidden = 1
 	},
 /turf/simulated/floor{
 	icon_state = "brown"
@@ -71903,7 +71923,9 @@
 "eZS" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
-	dir = 4
+	dir = 4;
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -72112,7 +72134,9 @@
 "fqb" = (
 /obj/machinery/camera{
 	c_tag = "Recycler External North";
-	dir = 8
+	dir = 8;
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -72288,7 +72312,9 @@
 /area/station/hallway/secondary/exit)
 "fAb" = (
 /obj/machinery/camera{
-	c_tag = "Recycler External South"
+	c_tag = "Recycler External South";
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/structure/fence/metal{
 	color = "yellow";
@@ -75299,7 +75325,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Recycler Office";
-	dir = 10
+	dir = 10;
+	network = list("CARGO");
+	hidden = 1
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -76349,7 +76377,9 @@
 "jyb" = (
 /obj/machinery/camera{
 	c_tag = "Disposals";
-	dir = 8
+	dir = 8;
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -87887,7 +87917,9 @@
 /area/station/engineering/engine)
 "xoX" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Bay West"
+	c_tag = "Cargo Bay West";
+	network = list("CARGO");
+	hidden = 1
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "loadingarea"


### PR DESCRIPTION
## Описание изменений
Камеры в карго теперь отображаются на консоли камер карго и не отображаются на консоли камер брига.
Также камеры карго недоступны для просмотра ИИ по умолчанию, но можно потыркать бирюзовый провод и включить просмотр ИИ.

## Почему и что этот ПР улучшит
СБ придётся посылать офицерика следить за каргонцами, а не просто удалённо смотреть че там заказали. Аналогично с ИИ и борготой.

## Авторство
AndreyGysev

## Чеинжлог
:cl: AndreyGysev
 - tweak: Камеры в карго теперь имеют свою сеть, не подключенную к сети станции и недоступны для просмотра из брига или для ИИ, но доступны для просмотра с консоли камер карго.