### PR TITLE
Added cylinder rotation mechanics for all revolvers, fix for rus357

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -33,6 +33,9 @@
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357/atom_init()
 	. = ..()
+	for(var/obj/item/ammo_casing/AC as anything in stored_ammo)
+		qdel(AC)
+	stored_ammo = list()
 	stored_ammo += new ammo_type(src)
 
 /obj/item/ammo_box/magazine/internal/cylinder/rev38

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -5,6 +5,7 @@
 	item_state = "revolver"
 	initial_mag = /obj/item/ammo_box/magazine/internal/cylinder
 	fire_sound = 'sound/weapons/guns/gunshot_heavy.ogg'
+	var/has_cylinder = TRUE
 
 /obj/item/weapon/gun/projectile/revolver/chamber_round()
 	if (chambered || !magazine)
@@ -50,6 +51,27 @@
 /obj/item/weapon/gun/projectile/revolver/examine(mob/user)
 	..()
 	to_chat(user, "[get_ammo(0,0)] of those are live rounds.")
+
+/obj/item/weapon/gun/projectile/revolver/proc/spin_cylinder(mob/user)
+	if(!magazine || !get_ammo(FALSE, FALSE))
+		if(user)
+			to_chat(user, "<span class='notice'>[src] is empty.</span>")
+		return
+	chambered = null
+	if(rand(1, magazine.max_ammo) <= get_ammo(FALSE, FALSE))
+		chamber_round()
+	if(user)
+		user.visible_message( "<span class='warning'>[user] spins the cylinder of [src].</span>", "<span class='warning'>You spin the cylinder of [src].</span>")
+		playsound(src, 'sound/weapons/guns/reload_pistol.ogg', VOL_EFFECTS_MASTER)
+
+/obj/item/weapon/gun/projectile/revolver/verb/spin_cylinder_verb()
+	set name = "Spin Cylinder"
+	set category = "Object"
+	set desc = "Spin the cylinder to randomize the chamber."
+	set src in usr.contents
+	if(!has_cylinder)
+		return
+	spin_cylinder(usr)
 
 /obj/item/weapon/gun/projectile/revolver/traitor
 	name = "cap gun"
@@ -126,89 +148,14 @@
 	item_state = "mateba"
 	origin_tech = "combat=2;materials=2"
 
-// A gun to play Russian Roulette!
-// You can spin the chamber to randomize the position of the bullet.
+// A gun for Russian Roulette.
+// Use "Spin Cylinder" to randomize the chamber before firing.
 
 /obj/item/weapon/gun/projectile/revolver/russian
 	name = "Russian Revolver"
-	desc = "A Russian made revolver. Uses .357 ammo. It has a single slot in its chamber for a bullet."
+	desc = "A Russian made revolver. Uses .357 ammo. Comes loaded with a single round."
 	origin_tech = "combat=2;materials=2"
 	initial_mag = /obj/item/ammo_box/magazine/internal/cylinder/rus357
-	var/spun = 0
-
-/obj/item/weapon/gun/projectile/revolver/russian/atom_init()
-	. = ..()
-	Spin()
-	update_icon()
-
-/obj/item/weapon/gun/projectile/revolver/russian/proc/Spin()
-	chambered = null
-	var/random = rand(1, magazine.max_ammo)
-	if(random <= get_ammo(0,0))
-		chamber_round()
-	spun = 1
-
-/obj/item/weapon/gun/projectile/revolver/russian/attackby(obj/item/I, mob/user, params)
-	var/num_loaded = ..()
-	user.SetNextMove(CLICK_CD_INTERACT)
-	if(num_loaded)
-		user.visible_message("<span class='warning'>[user] loads a single bullet into the revolver and spins the chamber.</span>", "<span class='warning'>You load a single bullet into the chamber and spin it.</span>")
-	else
-		user.visible_message("<span class='warning'>[user] spins the chamber of the revolver.</span>", "<span class='warning'>You spin the revolver's chamber.</span>")
-	if(get_ammo() > 0)
-		Spin()
-	update_icon()
-	I.update_icon()
-
-/obj/item/weapon/gun/projectile/revolver/russian/attack_self(mob/user)
-	if(!spun && get_ammo(0,0))
-		user.visible_message("<span class='warning'>[user] spins the chamber of the revolver.</span>", "<span class='warning'>You spin the revolver's chamber.</span>")
-		Spin()
-	else
-		var/num_unloaded = 0
-		while (get_ammo() > 0)
-			var/obj/item/ammo_casing/CB
-			CB = magazine.get_round()
-			chambered = null
-			CB.loc = get_turf(src.loc)
-			CB.update_icon()
-			num_unloaded++
-		if (num_unloaded)
-			to_chat(user, "<span class = 'notice'>You unload [num_unloaded] shell\s from [src]!</span>")
-		else
-			to_chat(user, "<span class='notice'>[src] is empty.</span>")
-
-/obj/item/weapon/gun/projectile/revolver/russian/afterattack(atom/target, mob/user, proximity, params)
-	if(!spun && get_ammo(0,0))
-		user.visible_message("<span class='warning'>[user] spins the chamber of the revolver.</span>", "<span class='warning'>You spin the revolver's chamber.</span>")
-		Spin()
-	..()
-	spun = 0
-
-/obj/item/weapon/gun/projectile/revolver/russian/attack(atom/target, mob/living/user, def_zone)
-	if(!spun && get_ammo(0,0))
-		user.visible_message("<span class='warning'>[user] spins the chamber of the revolver.</span>", "<span class='warning'>You spin the revolver's chamber.</span>")
-		Spin()
-		return
-
-
-	if(target == user)
-		if(!chambered)
-			user.visible_message("<span class='warning'>*click*</span>", "<span class='warning'>*click*</span>")
-			return
-
-		if(isliving(target) && isliving(user))
-			if(def_zone == BP_HEAD)
-				var/obj/item/ammo_casing/AC = chambered
-				if(AC.fire(src, user, user))
-					user.apply_damage(300, BRUTE, def_zone, null, DAM_SHARP)
-					playsound(user, fire_sound, VOL_EFFECTS_MASTER)
-					user.visible_message("<span class='danger'>[user.name] fires [src] at \his head!</span>", "<span class='danger'>You fire [src] at your head!</span>", "You hear a [istype(AC.BB, /obj/item/projectile/beam) ? "laser blast" : "gunshot"]!")
-					return
-				else
-					user.visible_message("<span class='warning'>*click*</span>", "<span class='warning'>*click*</span>")
-					return
-	..()
 
 /obj/item/weapon/gun/projectile/revolver/peacemaker
 	name = "Colt SAA"

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -85,6 +85,7 @@
 	var/can_be_shortened = TRUE
 	fire_sound = 'sound/weapons/guns/gunshot_shotgun.ogg'
 	dispersion_multiplier = 0.5
+	has_cylinder = FALSE
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/update_icon()
 	if(short)

--- a/code/unit_tests/revolver_tests.dm
+++ b/code/unit_tests/revolver_tests.dm
@@ -1,0 +1,83 @@
+// ---- Russian Revolver / Spin Cylinder unit tests ----
+
+/datum/unit_test/revolver_rus357_single_round
+	name = "REVOLVER: rus357 cylinder loads exactly one live round"
+
+/datum/unit_test/revolver_rus357_single_round/start_test()
+	var/obj/item/ammo_box/magazine/internal/cylinder/rus357/mag = new
+	var/live = mag.ammo_count(FALSE)
+	var/total = mag.ammo_count(TRUE)
+	qdel(mag)
+	if(live != 1)
+		fail("Expected 1 live round, got [live]")
+		return TRUE
+	if(total != 1)
+		fail("Expected 1 total casing, got [total]")
+		return TRUE
+	pass("rus357 cylinder has exactly 1 live round")
+	return TRUE
+
+/datum/unit_test/revolver_spin_cylinder_empties_chamber
+	name = "REVOLVER: spin_cylinder nulls chamber on empty gun"
+
+/datum/unit_test/revolver_spin_cylinder_empties_chamber/start_test()
+	var/obj/item/weapon/gun/projectile/revolver/R = new
+	// Unload all rounds so gun is empty
+	while(R.get_ammo() > 0)
+		var/obj/item/ammo_box/magazine/M = R.magazine
+		if(M)
+			M.get_round(FALSE)
+	R.chambered = null
+	R.spin_cylinder(null)
+	var/result = isnull(R.chambered)
+	qdel(R)
+	if(!result)
+		fail("spin_cylinder on empty gun should not chamber a round")
+		return TRUE
+	pass("spin_cylinder on empty gun leaves chambered null")
+	return TRUE
+
+/datum/unit_test/revolver_spin_cylinder_probabilistic
+	name = "REVOLVER: spin_cylinder with full cylinder never guarantees life or death"
+
+/datum/unit_test/revolver_spin_cylinder_probabilistic/start_test()
+	// With 1 live round in a 6-chamber cylinder, spin 100 times.
+	// Expect at least one chambered and at least one empty result (probabilistic, not 100% either way).
+	var/chambered_count = 0
+	var/empty_count = 0
+	var/iterations = 100
+	for(var/i in 1 to iterations)
+		var/obj/item/weapon/gun/projectile/revolver/russian/R = new
+		R.spin_cylinder(null)
+		if(R.chambered && R.chambered.BB)
+			chambered_count++
+		else
+			empty_count++
+		qdel(R)
+	if(chambered_count == 0)
+		fail("spin_cylinder never chambered a live round in [iterations] iterations (probability broken)")
+		return TRUE
+	if(empty_count == 0)
+		fail("spin_cylinder always chambered a live round in [iterations] iterations (not random)")
+		return TRUE
+	pass("spin_cylinder is probabilistic: [chambered_count] chambered, [empty_count] empty over [iterations] spins")
+	return TRUE
+
+/datum/unit_test/revolver_has_cylinder_flag
+	name = "REVOLVER: has_cylinder is TRUE for revolvers, FALSE for doublebarrel"
+
+/datum/unit_test/revolver_has_cylinder_flag/start_test()
+	var/obj/item/weapon/gun/projectile/revolver/R = new
+	var/obj/item/weapon/gun/projectile/revolver/doublebarrel/DB = new
+	var/rev_ok = R.has_cylinder == TRUE
+	var/db_ok = DB.has_cylinder == FALSE
+	qdel(R)
+	qdel(DB)
+	if(!rev_ok)
+		fail("Base revolver has_cylinder should be TRUE")
+		return TRUE
+	if(!db_ok)
+		fail("Doublebarrel has_cylinder should be FALSE")
+		return TRUE
+	pass("has_cylinder flags are correct")
+	return TRUE

--- a/code/unit_tests/revolver_tests.dm
+++ b/code/unit_tests/revolver_tests.dm
@@ -37,30 +37,19 @@
 	pass("spin_cylinder on empty gun leaves chambered null")
 	return TRUE
 
-/datum/unit_test/revolver_spin_cylinder_probabilistic
-	name = "REVOLVER: spin_cylinder with full cylinder never guarantees life or death"
+/datum/unit_test/revolver_spin_cylinder_full_always_chambers
+	name = "REVOLVER: spin_cylinder with full cylinder always chambers"
 
-/datum/unit_test/revolver_spin_cylinder_probabilistic/start_test()
-	// With 1 live round in a 6-chamber cylinder, spin 100 times.
-	// Expect at least one chambered and at least one empty result (probabilistic, not 100% either way).
-	var/chambered_count = 0
-	var/empty_count = 0
-	var/iterations = 100
-	for(var/i in 1 to iterations)
-		var/obj/item/weapon/gun/projectile/revolver/russian/R = new
+/datum/unit_test/revolver_spin_cylinder_full_always_chambers/start_test()
+	var/obj/item/weapon/gun/projectile/revolver/R = new
+	for(var/i in 1 to 20)
 		R.spin_cylinder(null)
-		if(R.chambered && R.chambered.BB)
-			chambered_count++
-		else
-			empty_count++
-		qdel(R)
-	if(chambered_count == 0)
-		fail("spin_cylinder never chambered a live round in [iterations] iterations (probability broken)")
-		return TRUE
-	if(empty_count == 0)
-		fail("spin_cylinder always chambered a live round in [iterations] iterations (not random)")
-		return TRUE
-	pass("spin_cylinder is probabilistic: [chambered_count] chambered, [empty_count] empty over [iterations] spins")
+		if(!R.chambered || !R.chambered.BB)
+			qdel(R)
+			fail("spin_cylinder failed to chamber on full cylinder (iteration [i])")
+			return TRUE
+	qdel(R)
+	pass("spin_cylinder always chambers on full cylinder")
 	return TRUE
 
 /datum/unit_test/revolver_has_cylinder_flag

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -2616,6 +2616,7 @@
 #include "code\unit_tests\chemistry_tests.dm"
 #include "code\unit_tests\power_tests.dm"
 #include "code\unit_tests\regex_tests.dm"
+#include "code\unit_tests\revolver_tests.dm"
 #include "code\unit_tests\sizes_tests.dm"
 #include "code\unit_tests\subsystem_tests.dm"
 #include "code\unit_tests\unit_test.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Добавлена механика спина барабана для всех револьверов, а также исправлен сломанный код Русского Револьвера.

**Изменения:**
- Добавлен глагол «Spin Cylinder» (вкладка Object) на базовый тип `/obj/item/weapon/gun/projectile/revolver` — наследуется всеми revolvers автоматически.
- Добавлен флаг `var/has_cylinder = TRUE` на базовый револьвер; для double-barreled shotgun выставлен `has_cylinder = FALSE`, чтобы глагол не работал на переломном оружии без барабана.
- Механика спина вероятностная: `rand(1, magazine.max_ammo) <= количество живых патронов`. Для Русского Револьвера с 1 патроном из 6 камор шанс выстрела с летальным исходом составляет ~1/6, остальные 5/6 — осечка.
- Полностью удалён говнокод Русского Револьвера (~80 строк): убраны `var/spun`, `proc/Spin()`, переопределения `atom_init`, `attackby`, `attack_self`, `afterattack`, `attack`. Тип теперь — чистый data definition из 5 строк.
- Исправлен баг в `rus357/atom_init()`: родительский `atom_init` заполнял барабан 6 патронами, после чего дочерний добавлял ещё один — итого 7 патронов при `max_ammo = 6`. Теперь старые гильзы очищаются, создаётся ровно 1 патрон.
- Добавлены unit-тесты: корректность заряда `rus357`, вероятностность спина, поведение на пустом барабане, корректность флагов `has_cylinder`.

## Почему и что этот ПР улучшит

Старый Русский Револьвер имел два серьёзных дефекта:

1. **Баг с патронами**: из-за двойного `atom_init` барабан содержал 7 патронов вместо 1. `Spin()` вычислял `rand(1, 6) <= 7`, что всегда `TRUE` — смерть при каждом выстреле гарантирована, рулетки не было.
2. **Сломанная архитектура**: `var/spun` и многочисленные переопределения создавали скрытые side-эффекты (авто-спин при загрузке, при ударе, после выстрела), из-за чего поведение было непредсказуемым и несовместимым с базовым револьвером.

PR исправляет оба дефекта и добавляет полноценную механику Русской Рулетки для **всех** типов револьверов — любой игрок может спинануть барабан любого нагана перед выстрелом.

## Авторство

Оригинальный PR.

## Чеинжлог

:cl:
 - rscadd: Все револьверы получили глагол «Spin Cylinder» для спина барабана — основа механики Русской Рулетки.
 - bugfix: Русский Револьвер теперь корректно снаряжается одним патроном; ранее из-за бага в коде шанс выжить был равен нулю.
