### PR TITLE
Фикс текста связанный с NanoTrasen representatives на Special Department

### DIFF
--- a/code/defines/obj/datacore.dm
+++ b/code/defines/obj/datacore.dm
@@ -160,7 +160,7 @@ using /obj/effect/datacore/proc/manifest_inject( )
 	// Formating keyword -> Description
 	var/list/departments_list = list(\
 		"heads" = "Heads",\
-		"centcom" = "NanoTrasen representatives",\
+		"centcom" = "Special Department",\
 		"sec" = "Security",\
 		"eng" = "Engineering",\
 		"med" = "Medical",\


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ранее когда фиксили баны, переименовывали данное название: 
<img width="368" height="23" alt="image" src="https://github.com/user-attachments/assets/c82cd3b4-1bca-414f-898c-180a177b245d" />
Оказалось, я недочистил до конца и в манифесте до сих пор было это. Теперь не будет.

## Почему и что этот ПР улучшит
Завершаю то что было в данном ПРе
https://github.com/TauCetiStation/TauCetiClassic/pull/14530
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl: Azzy.Dreemurr
 - spellcheck: Исправлена ошибка в манифесте где было написано NanoTrasen representatives при АВД и БЩ. Теперь в манифесте будет отображаться Special Department