### PR TITLE
fixes replicator buttons

### DIFF
--- a/code/modules/replicators/replicators.dm
+++ b/code/modules/replicators/replicators.dm
@@ -321,7 +321,7 @@ ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/hostile/replicator, alive_replicato
 	var/datum/faction/replicators/FR = get_or_create_replicators_faction()
 
 	if(!mind.GetRole(REPLICATOR))
-		add_faction_member(FR, src, TRUE)
+		add_faction_member(FR, src, recruit=TRUE, post_setup=TRUE)
 
 	var/datum/replicator_array_info/RAI = FR.ckey2info[ckey]
 	if(RAI)


### PR DESCRIPTION
## Описание изменений

Я не смог разобраться когда и как это сломали, но с какого-то момента при заходе за реплика PostSetup его рольки перестал вызываться. Чуть больше подробностей в ишуе.

Фиксит то что репликаторы спавнятся без кнопок, но всё ещё есть ситуации где эти кнопки почему-то дублицируются при гостании и заходе заново за реплика :/

Ещё с ПР-ом на фикс чего-то там про аль аппирансы культа появился рантайм который происходит каждый раз когда гостаешься из репликатора, но я не разбирался чем вызвано (https://github.com/TauCetiStation/TauCetiClassic/pull/14579/changes#diff-6905899837b35ea2da50e395593d1a4fcb920f6c6e12cb4469bbc01e3a0970a8R168 вот тут вот)

## Почему и что этот ПР улучшит

fixes #14789
