### PR TITLE
Чиним боргам возможность вытащить балон с анестезией

### DIFF
--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -119,7 +119,7 @@
 	if(.)
 		return
 
-	if(user.is_busy() || issilicon(user))
+	if(user.is_busy() || isAI(user))
 		return
 	if(holding && do_after(user, 20, target = src))
 		user.put_in_hands(holding)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Около 2 лет был баг с тем что играющие на медборгах не могли заменить балон в ИВЛ, при этом вставить его могли. Теперь смогут спокойно вытаскивать и менять его.
## Почему и что этот ПР улучшит
Фикс бага и исправление ошибки допущеной ранее.
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl: Azzy.Dreemurr
 - bugfix: Борги вновь могут спокойно вытаскивать из ИВЛ Балон с анестезией