### PR TITLE
Функция Drop() корректно сбрасывает рольку

### DIFF
--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -130,8 +130,7 @@
 	if(!faction)
 		SSticker.mode.orphaned_roles.Remove(src)
 
-	if(antag)
-		RemoveFromRole(antag, msg_admins)
+	RemoveFromRole(antag, msg_admins)
 
 	qdel(src)
 

--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -124,14 +124,14 @@
 
 // Drops the antag mind from the parent role, informs the gamemode the mind now doesn't have a role, and deletes the role datum.
 /datum/role/proc/Drop(msg_admins = TRUE)
-	if(antag)
-		RemoveFromRole(antag, msg_admins)
-
 	if(faction && (src in faction.members))
 		faction.remove_role(src)
 
 	if(!faction)
 		SSticker.mode.orphaned_roles.Remove(src)
+
+	if(antag)
+		RemoveFromRole(antag, msg_admins)
 
 	qdel(src)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Был рантайм, потому что RemoveFromRole() занулляет переменную /antag (текущий минд игрока). А затем чистились фракционные худы куклы, находимой по mind. 

> Ещё с ПР-ом на фикс чего-то там про аль аппирансы культа появился рантайм который происходит каждый раз когда гостаешься из репликатора, но я не разбирался чем вызвано ([#14579 (changes)](https://github.com/TauCetiStation/TauCetiClassic/pull/14579/changes#diff-6905899837b35ea2da50e395593d1a4fcb920f6c6e12cb4469bbc01e3a0970a8R168) вот тут вот)

## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
