### PR TITLE
СПУ навсегда оставался слепым после хирургической замены головы

### DIFF
--- a/code/modules/surgery/limbs.dm
+++ b/code/modules/surgery/limbs.dm
@@ -158,9 +158,7 @@
 			return
 		BP = new L.bodypart_type()
 		target.remove_from_mob(tool)
-		qdel(tool)
-
-	if(isbodypart(tool))
+	else if(isbodypart(tool))
 		BP = tool
 
 	if(!BP)
@@ -171,6 +169,9 @@
 
 	user.remove_from_mob(tool)
 	BP.insert_organ(target, surgically = TRUE)
+
+	if(istype(tool, /obj/item/robot_parts))
+		qdel(tool)
 	target.update_body(BP.body_zone)
 	target.updatehealth()
 	target.UpdateDamageIcon(BP)

--- a/code/modules/surgery/limbs.dm
+++ b/code/modules/surgery/limbs.dm
@@ -157,9 +157,6 @@
 		if(!L.can_attach())
 			return
 		BP = new L.bodypart_type()
-		if(L.part == HEAD && !target.has_organ(O_EYES))
-			var/obj/item/organ/internal/eyes/ipc/cameras = new(null)
-			cameras.insert_organ(target)
 		target.remove_from_mob(tool)
 		qdel(tool)
 
@@ -181,6 +178,9 @@
 
 	if(istype(BP, /obj/item/organ/external/head))
 		var/obj/item/organ/external/head/B = BP
+		if(istype(BP, /obj/item/organ/external/head/robot) && !target.has_organ(O_EYES))
+			var/obj/item/organ/internal/eyes/ipc/cameras = new(null)
+			cameras.insert_organ(target)
 		if (B.brainmob && B.brainmob.mind)
 			B.brainmob.mind.transfer_to(target)
 			target.dna = B.brainmob.dna


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Условие создания камер (глаз) для СПУ содержало опечатку: `L.part == HEAD`, где `L.part` равно `BP_HEAD` (строка `"head"`), а `HEAD` — битфлаг одежды `(1<<0)`. Сравнение `"head" == 1` всегда ложно, камеры никогда не создавались.

- Создание камер перенесено **после** `BP.insert_organ()`, чтобы голова уже была в `bodyparts_by_name` и камеры корректно привязывались через `parent`
- Условие заменено на `istype(BP, /obj/item/organ/external/head/robot) && !target.has_organ(O_EYES)` , чтобы случайно не напихать камер хуману

## Почему и что этот ПР улучшит
-fixes #14728 
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: СПУ навсегда оставался слепым после хирургической замены головы
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
