### PR TITLE
Беды с башкой СПУ эпизод 2

### DIFF
--- a/code/modules/surgery/organs/external/robotic.dm
+++ b/code/modules/surgery/organs/external/robotic.dm
@@ -83,6 +83,7 @@
 
 /obj/item/organ/external/head/robot
 	name = "robotic head"
+	vital = FALSE
 
 	icon = 'icons/mob/human/robotic.dmi'
 	icon_state = "head_m"

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -179,6 +179,9 @@
 			S = H.species
 		set_species(S) // species should always be set, we use previous one if we surgically installed
 		set_preferences(H) // cache owner preferences, can be freely updated if needed
+	else if(!species) // surgically installed but species wasn't set (e.g., new from robot_parts)
+		set_species(H.species)
+		set_preferences(H)
 
 	owner.bodyparts += src
 	owner.bodyparts_by_name[body_zone] = src


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
- **Фикс null species при хирургической установке конечностей** — новые органы из `robot_parts` теперь получают `species` от пациента, а не остаются `null`, что вызывало runtime на `null.alpha_color_mask` и `null.eyes_static_layer` в `generate_appearances()`.
- **Фикс смерти IPC при повторной ампутации головы** — `/obj/item/organ/external/head/robot` теперь имеет `vital = FALSE`, как и IPC-голова. Раньше унаследованное `vital = TRUE` от базовой головы вызывало `death()` при отсечении робо-головы, хотя мозг IPC находится в груди.

## Почему и что этот ПР улучшит
-fixes #14596 
-fixes #14727 
## Авторство
Я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl: TEXHAPb
 - bugfix: При повторной ампутации головы после замены СПУ умирал
 - bugfix: СПУ при хирургической замене получал голову без экрана
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
