### PR TITLE
Починка окон сваркой

### DIFF
--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -21,7 +21,7 @@
 	var/list/drops = list(/obj/item/weapon/shard)
 
 	// Full repair time (deciseconds) when integrity is at 0. Actual time scales with damage.
-	var/repair_time = 120
+	var/repair_time = 12 SECONDS
 
 	// If set to list(devastation, heavy, light), welding the window detonates it instead of repairing it (phoron glass).
 	var/list/weld_explosion = null

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -20,6 +20,12 @@
 
 	var/list/drops = list(/obj/item/weapon/shard)
 
+	// Full repair time (deciseconds) when integrity is at 0. Actual time scales with damage.
+	var/repair_time = 120
+
+	// If set to list(devastation, heavy, light), welding the window detonates it instead of repairing it (phoron glass).
+	var/list/weld_explosion = null
+
 /obj/structure/window/atom_init()
 	update_nearby_tiles()
 	return ..()
@@ -78,6 +84,28 @@
 	return !density
 
 /obj/structure/window/attackby(obj/item/W, mob/user)
+	if(iswelding(W))
+		if((flags & NODECONSTRUCT) || (resistance_flags & INDESTRUCTIBLE))
+			return ..()
+		var/obj/item/weapon/weldingtool/WT = W
+		if(weld_explosion)
+			if(WT.use(0, user))
+				phoron_weld_explode(arglist(weld_explosion))
+			return
+		if(get_integrity() >= max_integrity)
+			to_chat(user, "<span class='notice'>[src] уже в хорошем состоянии.</span>")
+			return
+		if(WT.use(0, user))
+			var/damage_fraction = 1 - (get_integrity() / max_integrity)
+			var/cur_repair_time = max(30, round(repair_time * damage_fraction))
+			to_chat(user, "<span class='notice'>Вы начинаете чинить [CASE(src, ACCUSATIVE_CASE)]...</span>")
+			if(WT.use_tool(src, user, cur_repair_time, volume = 50, quality = QUALITY_WELDING))
+				repair_damage(max_integrity)
+				integrity_failure = initial(integrity_failure)
+				update_icon()
+				to_chat(user, "<span class='notice'>Вы починили [CASE(src, ACCUSATIVE_CASE)].</span>")
+		return
+
 	if(istype(W, /obj/item/weapon/airlock_painter))
 		change_paintjob(W, user)
 		return
@@ -180,6 +208,12 @@
 
 /obj/structure/window/proc/change_color(new_color)
 	color = new_color
+
+/obj/structure/window/proc/phoron_weld_explode(dev = 0, heavy = 1, light = 2)
+	visible_message("<span class='userdanger'>Сварка поджигает фороновое стекло, и [src] взрывается!</span>")
+	var/turf/T = get_turf(src)
+	qdel(src)
+	explosion(T, dev, heavy, light, light + 1)
 
 /obj/structure/window/proc/change_paintjob(obj/item/weapon/airlock_painter/W, mob/user)
 	if(!istype(W))

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -26,9 +26,6 @@
 	// Welding fuel spent on a full repair from 0 integrity. Actual cost scales with damage.
 	var/repair_fuel = 5
 
-	// If set to list(devastation, heavy, light), welding the window detonates it instead of repairing it (phoron glass).
-	var/list/weld_explosion = null
-
 /obj/structure/window/atom_init()
 	update_nearby_tiles()
 	return ..()
@@ -91,9 +88,7 @@
 		if((flags & NODECONSTRUCT) || (resistance_flags & INDESTRUCTIBLE))
 			return ..()
 		var/obj/item/weapon/weldingtool/WT = W
-		if(weld_explosion)
-			if(WT.use(0, user))
-				phoron_weld_explode(arglist(weld_explosion))
+		if(weld_react(user, WT))
 			return
 		if(get_integrity() >= max_integrity)
 			to_chat(user, "<span class='notice'>[src] уже в хорошем состоянии.</span>")
@@ -213,7 +208,12 @@
 /obj/structure/window/proc/change_color(new_color)
 	color = new_color
 
-/obj/structure/window/proc/phoron_weld_explode(dev = 0, heavy = 1, light = 2)
+// Reaction to being welded. Base glass returns FALSE and gets repaired by the caller;
+// phoron glass overrides this to detonate and returns TRUE to skip the repair.
+/obj/structure/window/proc/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
+	return FALSE
+
+/obj/structure/window/proc/weld_explode(dev, heavy, light)
 	visible_message("<span class='userdanger'>Сварка поджигает фороновое стекло, и [src] взрывается!</span>")
 	var/turf/T = get_turf(src)
 	qdel(src)

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -23,6 +23,9 @@
 	// Full repair time (deciseconds) when integrity is at 0. Actual time scales with damage.
 	var/repair_time = 12 SECONDS
 
+	// Welding fuel spent on a full repair from 0 integrity. Actual cost scales with damage.
+	var/repair_fuel = 5
+
 	// If set to list(devastation, heavy, light), welding the window detonates it instead of repairing it (phoron glass).
 	var/list/weld_explosion = null
 
@@ -95,11 +98,12 @@
 		if(get_integrity() >= max_integrity)
 			to_chat(user, "<span class='notice'>[src] уже в хорошем состоянии.</span>")
 			return
-		if(WT.use(0, user))
-			var/damage_fraction = 1 - (get_integrity() / max_integrity)
-			var/cur_repair_time = max(30, round(repair_time * damage_fraction))
+		var/damage_fraction = 1 - (get_integrity() / max_integrity)
+		var/cur_repair_time = max(30, round(repair_time * damage_fraction))
+		var/cur_repair_fuel = max(1, round(repair_fuel * damage_fraction))
+		if(WT.tool_start_check(user, amount = cur_repair_fuel))
 			to_chat(user, "<span class='notice'>Вы начинаете чинить [CASE(src, ACCUSATIVE_CASE)]...</span>")
-			if(WT.use_tool(src, user, cur_repair_time, volume = 50, quality = QUALITY_WELDING))
+			if(WT.use_tool(src, user, cur_repair_time, amount = cur_repair_fuel, volume = 50, quality = QUALITY_WELDING))
 				repair_damage(max_integrity)
 				integrity_failure = initial(integrity_failure)
 				update_icon()

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -88,6 +88,8 @@
 		if((flags & NODECONSTRUCT) || (resistance_flags & INDESTRUCTIBLE))
 			return ..()
 		var/obj/item/weapon/weldingtool/WT = W
+		if(!WT.use(0, user)) // сварка должна быть включена (и тут же eyecheck)
+			return
 		if(weld_react(user, WT))
 			return
 		if(get_integrity() >= max_integrity)
@@ -97,12 +99,14 @@
 		var/cur_repair_time = max(30, round(repair_time * damage_fraction))
 		var/cur_repair_fuel = max(1, round(repair_fuel * damage_fraction))
 		if(WT.tool_start_check(user, amount = cur_repair_fuel))
-			to_chat(user, "<span class='notice'>Вы начинаете чинить [CASE(src, ACCUSATIVE_CASE)]...</span>")
+			user.visible_message("<span class='notice'>[user] начинает чинить [CASE(src, ACCUSATIVE_CASE)]...</span>", \
+								 "<span class='notice'>Вы начинаете чинить [CASE(src, ACCUSATIVE_CASE)]...</span>")
 			if(WT.use_tool(src, user, cur_repair_time, amount = cur_repair_fuel, volume = 50, quality = QUALITY_WELDING))
 				repair_damage(max_integrity)
 				integrity_failure = initial(integrity_failure)
 				update_icon()
-				to_chat(user, "<span class='notice'>Вы починили [CASE(src, ACCUSATIVE_CASE)].</span>")
+				user.visible_message("<span class='notice'>[user] чинит [CASE(src, ACCUSATIVE_CASE)].</span>", \
+									 "<span class='notice'>Вы починили [CASE(src, ACCUSATIVE_CASE)].</span>")
 		return
 
 	if(istype(W, /obj/item/weapon/airlock_painter))

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -217,7 +217,7 @@
 	armor = list(melee = 80, fire = 70, bomb = 25)
 	explosive_resistance = 0.5
 
-	repair_time = 280
+	repair_time = 28 SECONDS
 
 	disassemble_glass_type = /obj/item/stack/sheet/rglass
 

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -157,8 +157,7 @@
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
 /obj/structure/window/fulltile/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
-	if(WT.use(0, user))
-		weld_explode(0, 1, 2)
+	weld_explode(0, 1, 2)
 	return TRUE
 
 /**
@@ -246,8 +245,7 @@
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
 /obj/structure/window/fulltile/reinforced/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
-	if(WT.use(0, user))
-		weld_explode(1, 2, 3)
+	weld_explode(1, 2, 3)
 	return TRUE
 
 /**

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -29,7 +29,7 @@
 
 	armor = list(melee = 50, fire = 70)
 
-	repair_time = 180
+	repair_time = 18 SECONDS
 
 	var/disassemble_glass_type = /obj/item/stack/sheet/glass // any better ideas to handle drops and disassembles?
 

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -156,7 +156,10 @@
 
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
-	weld_explosion = list(0, 1, 2)
+/obj/structure/window/fulltile/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
+	if(WT.use(0, user))
+		weld_explode(0, 1, 2)
+	return TRUE
 
 /**
  * Fulltile tinted
@@ -242,7 +245,10 @@
 
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
-	weld_explosion = list(1, 2, 3)
+/obj/structure/window/fulltile/reinforced/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
+	if(WT.use(0, user))
+		weld_explode(1, 2, 3)
+	return TRUE
 
 /**
  * Fulltile reinforced tinted

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -29,6 +29,8 @@
 
 	armor = list(melee = 50, fire = 70)
 
+	repair_time = 180
+
 	var/disassemble_glass_type = /obj/item/stack/sheet/glass // any better ideas to handle drops and disassembles?
 
 /obj/structure/window/fulltile/atom_init(mapload, grill)
@@ -154,6 +156,8 @@
 
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
+	weld_explosion = list(0, 1, 2)
+
 /**
  * Fulltile tinted
  */
@@ -213,6 +217,8 @@
 	armor = list(melee = 80, fire = 70, bomb = 25)
 	explosive_resistance = 0.5
 
+	repair_time = 280
+
 	disassemble_glass_type = /obj/item/stack/sheet/rglass
 
 /**
@@ -235,6 +241,8 @@
 	disassemble_glass_type = /obj/item/stack/sheet/glass/phoronrglass
 
 	hit_particle_type = /particles/tool/digging/glass/phoron
+
+	weld_explosion = list(1, 2, 3)
 
 /**
  * Fulltile reinforced tinted

--- a/code/game/objects/structures/windows/window_thin.dm
+++ b/code/game/objects/structures/windows/window_thin.dm
@@ -167,7 +167,10 @@
 
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
-	weld_explosion = list(0, 0, 2)
+/obj/structure/window/thin/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
+	if(WT.use(0, user))
+		weld_explode(0, 0, 2)
+	return TRUE
 
 /obj/structure/window/thin/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > T0C + 32000)
@@ -203,7 +206,10 @@
 
 	max_integrity = 160
 
-	weld_explosion = list(0, 1, 2)
+/obj/structure/window/thin/reinforced/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
+	if(WT.use(0, user))
+		weld_explode(0, 1, 2)
+	return TRUE
 
 /obj/structure/window/fulltile/reinforced/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return

--- a/code/game/objects/structures/windows/window_thin.dm
+++ b/code/game/objects/structures/windows/window_thin.dm
@@ -187,7 +187,7 @@
 
 	max_integrity = 100
 
-	repair_time = 220
+	repair_time = 22 SECONDS
 
 /**
  * Fulltile reinforced phoron

--- a/code/game/objects/structures/windows/window_thin.dm
+++ b/code/game/objects/structures/windows/window_thin.dm
@@ -167,6 +167,8 @@
 
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
+	weld_explosion = list(0, 0, 2)
+
 /obj/structure/window/thin/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > T0C + 32000)
 		take_damage(round(exposed_volume / 1000), BURN, FIRE, FALSE)
@@ -185,6 +187,8 @@
 
 	max_integrity = 100
 
+	repair_time = 220
+
 /**
  * Fulltile reinforced phoron
  */
@@ -198,6 +202,8 @@
 	drops = list(/obj/item/stack/rods, /obj/item/weapon/shard/phoron)
 
 	max_integrity = 160
+
+	weld_explosion = list(0, 1, 2)
 
 /obj/structure/window/fulltile/reinforced/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return

--- a/code/game/objects/structures/windows/window_thin.dm
+++ b/code/game/objects/structures/windows/window_thin.dm
@@ -168,8 +168,7 @@
 	hit_particle_type = /particles/tool/digging/glass/phoron
 
 /obj/structure/window/thin/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
-	if(WT.use(0, user))
-		weld_explode(0, 0, 2)
+	weld_explode(0, 0, 2)
 	return TRUE
 
 /obj/structure/window/thin/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
@@ -207,8 +206,7 @@
 	max_integrity = 160
 
 /obj/structure/window/thin/reinforced/phoron/weld_react(mob/user, obj/item/weapon/weldingtool/WT)
-	if(WT.use(0, user))
-		weld_explode(0, 1, 2)
+	weld_explode(0, 1, 2)
 	return TRUE
 
 /obj/structure/window/fulltile/reinforced/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Повреждённые окна теперь можно чинить сварочным аппаратом; время ремонта зависит от степени повреждения. Фороновые окна при попытке сварки взрываются.
## Почему и что этот ПР улучшит
можно чинить окна, а не брать то же самое стекло, и вставлять его обратно и называть это "ремонтом", так же можно чинить окна, которые, например, ведут в космос, без продувания всего отсека
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
- add: Повреждённые окна теперь можно починить сварочным аппаратом; время ремонта зависит от степени повреждения.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
