### PR TITLE
фикс хамелеон очков

### DIFF
--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -439,21 +439,24 @@
 	var/newtype = clothing_choices[picked]
 	var/obj/item/clothing/A = new newtype
 
-	desc = null
-	permeability_coefficient = 0.90
-
-	if(A.icon_custom)
-		icon = A.icon_custom
-		icon_custom = A.icon_custom
+	// initial(): a new'd item's atom_init mangles its icon_state to the "_w" world sprite in nullspace
+	var/d_icon_custom = initial(A.icon_custom)
+	if(d_icon_custom)
+		icon = d_icon_custom
+		icon_custom = d_icon_custom
 	else
-		icon = A.icon
+		icon = initial(A.icon)
 		icon_custom = null
-	desc = A.desc
-	name = A.name
-	icon_state = A.icon_state
-	item_state = A.item_state
-	flags_inv = A.flags_inv
+	desc = initial(A.desc)
+	name = initial(A.name)
+	icon_state = initial(A.icon_state)
+	item_state = initial(A.item_state)
+	flags_inv = initial(A.flags_inv)
+	qdel(A)
 	update_inv_mob()
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		H.update_inv_glasses()
 
 //*****************
 //**Chameleon Gun**

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -457,10 +457,9 @@
 	name = initial(A.name)
 	item_state = initial(A.item_state)
 	var/inv_state = initial(A.item_state_inventory) ? initial(A.item_state_inventory) : initial(A.icon_state)
-	var/world_state = initial(A.item_state_world)
 	icon_state = inv_state
 	item_state_inventory = inv_state
-	item_state_world = (world_state && icon_exists(icon, world_state)) ? world_state : null
+	item_state_world = initial(A.item_state_world)
 	flags_inv = initial(A.flags_inv)
 	qdel(A)
 	update_world_icon()

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -407,6 +407,7 @@
 	name = "optical meson scanner"
 	icon_state = "meson"
 	item_state = "glasses"
+	item_state_world = "meson_w"
 	desc = "It looks like a plain set of mesons, but on closer inspection, it seems to have a small dial inside."
 	origin_tech = "syndicate=3"
 	var/list/clothing_choices = list()
@@ -421,8 +422,13 @@
 /obj/item/clothing/glasses/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "optical meson scanner"
 	desc = "It's a set of mesons."
+	icon = initial(icon)
+	icon_custom = null
 	icon_state = "meson"
 	item_state = "glasses"
+	item_state_inventory = initial(item_state_inventory)
+	item_state_world = initial(item_state_world)
+	update_world_icon()
 	update_icon()
 	update_inv_mob()
 
@@ -459,9 +465,6 @@
 	qdel(A)
 	update_world_icon()
 	update_inv_mob()
-	if(ishuman(loc))
-		var/mob/living/carbon/human/H = loc
-		H.update_inv_glasses()
 
 //*****************
 //**Chameleon Gun**

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -449,10 +449,15 @@
 		icon_custom = null
 	desc = initial(A.desc)
 	name = initial(A.name)
-	icon_state = initial(A.icon_state)
 	item_state = initial(A.item_state)
+	var/inv_state = initial(A.item_state_inventory) ? initial(A.item_state_inventory) : initial(A.icon_state)
+	var/world_state = initial(A.item_state_world)
+	icon_state = inv_state
+	item_state_inventory = inv_state
+	item_state_world = (world_state && icon_exists(icon, world_state)) ? world_state : null
 	flags_inv = initial(A.flags_inv)
 	qdel(A)
+	update_world_icon()
 	update_inv_mob()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
спрайт брался по icon_state, код копировал icon_state в временном образце и из него уже в напольный спрайт (например meson в meson_w), очки брали стейт напольного спрайта, очевидно для персонажа такого спрайта нет, поэтому они просто были невидимы на кукле, фикс берёт изначальный icon_state
## Почему и что этот ПР улучшит
багификс
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Хамелеон очки правильно отображаются когда меняешь их вид.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
