### PR TITLE
Небольшой рефактор on_mob_life

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -187,7 +187,7 @@ var/global/const/INGEST = 2
 	for(var/datum/reagent/R as anything in reagent_list)
 		var/remove_amount = R.custom_metabolism * M.mob_metabolism_mod.Get()
 		if(remove_amount > 0) // i think it should be always true, there is no reagents with 0 metabolism and zero metabolism mobs should not reach this code
-			R.on_mob_life(M)
+			R.on_mob_life(M, remove_amount)
 			remove_reagent(R.id, remove_amount)
 	update_total()
 

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -40,9 +40,9 @@ About the Holder:
 			If the specified amount is greater than what is available, it will use
 			the amount of the reagent that is available. If no reagent exists, returns null.
 
-		metabolize(mob/M)
+		metabolize(mob/living/M)
 			This proc is called by the mobs life proc. It simply calls on_mob_life for
-			all contained reagents. You shouldnt have to use this one directly.
+			all contained reagents, and then removes their metabolized amount. You shouldnt have to use this one directly.
 
 		handle_reactions()
 			This proc check all recipes and, on a match, uses them.
@@ -144,14 +144,11 @@ About Reagents:
 			with a turf. You'll want to put stuff like extra
 			slippery floors for lube or something in here.
 
-		on_mob_life(var/mob/M)
-			This proc is called everytime the mobs life proc executes.
-			This is the place where you put damage for toxins ,
-			drowsyness for sleep toxins etc etc.
-			You'll want to call the parents proc by using ..() .
-			If you don't, the chemical will stay in the mob forever -
-			unless you write your own piece of code to slowly remove it.
-			(Should be pretty easy, 1 line of code)
+		on_mob_life(mob/living/M)
+			This proc is called during the mob's metabolism tick (metabolize() in holder).
+			By default, it handles general digestion check, overdoses, and ingestion allergies.
+			Periodic effects of specific reagents should be implemented in on_general_digest(M)
+			or species-specific digest procs (on_diona_digest, on_skrell_digest, etc.).
 
 	Important variables:
 

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -145,7 +145,7 @@ About Reagents:
 			with a turf. You'll want to put stuff like extra
 			slippery floors for lube or something in here.
 
-		on_mob_life(mob/living/M)
+		on_mob_life(mob/living/M, remove_amount)
 			This proc is called during the mob's metabolism tick (metabolize() in holder).
 			By default, it handles general digestion check, overdoses, and ingestion allergies.
 			Periodic effects of specific reagents should be implemented in on_general_digest(M)

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -1,6 +1,8 @@
 /*
 NOTE: IF YOU UPDATE THE REAGENT-SYSTEM, ALSO UPDATE THIS README.
 NOTE 2: NO ONE UPDATES THIS, IT MAY BE OUTDATED
+NOTE 3: metabolize AND on_mob_life IS UP TO DATE. PLEASE REMEMBER TO ADD AND UPDATE ANY CHANGES HERE.
+
 
 Structure: ///////////////////          //////////////////////////
 		   // Mob or object // -------> // Reagents var (datum) // 	    Is a reference to the datum that holds the reagents.

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -1,6 +1,7 @@
 /*
 NOTE: IF YOU UPDATE THE REAGENT-SYSTEM, ALSO UPDATE THIS README.
 NOTE 2: NO ONE UPDATES THIS, IT MAY BE OUTDATED
+NOTE 3: metabolize AND on_mob_life IS UP TO DATE. PLEASE REMEMBER TO ADD AND UPDATE ANY CHANGES HERE.
 
 Structure: ///////////////////          //////////////////////////
 		   // Mob or object // -------> // Reagents var (datum) // 	    Is a reference to the datum that holds the reagents.

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -128,8 +128,9 @@
 
 	if(allergen && allergen[ALLERGY_INGESTION] && ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.trigger_allergy(id, custom_metabolism * H.mob_metabolism_mod.Get())
-		return FALSE
+		if(H.allergies && H.allergies[id])
+			H.trigger_allergy(id, custom_metabolism * H.mob_metabolism_mod.Get())
+			return FALSE
 
 	return TRUE
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -113,7 +113,7 @@
 	SEND_SIGNAL(src, COMSIG_REAGENT_REACTION_TURF, T, volume)
 	return
 
-/datum/reagent/proc/on_mob_life(mob/living/M)
+/datum/reagent/proc/on_mob_life(mob/living/M, remove_amount)
 	if(!M || !holder)
 		return
 
@@ -125,7 +125,7 @@
 
 	if(allergen && allergen[ALLERGY_INGESTION] && ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.trigger_allergy(id, custom_metabolism * H.mob_metabolism_mod.Get())
+		H.trigger_allergy(id, remove_amount)
 
 /datum/reagent/proc/on_move(mob/M)
 	return

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -116,23 +116,16 @@
 /datum/reagent/proc/on_mob_life(mob/living/M)
 	if(!M || !holder)
 		return
-	//Noticed runtime errors from pacid trying to damage ghosts, this should fix. --NEO
-	// hey, so, how is your ghost runtime doing? ~Luduk
-	if(!isliving(M))
-		return
+
 	if(!on_general_digest(M)) // You can't overdose on what you can't digest
-		return FALSE
+		return
 
 	if((overdose > 0) && (volume >= overdose))//Overdosing, wooo
 		M.adjustToxLoss(overdose_dam)
 
 	if(allergen && allergen[ALLERGY_INGESTION] && ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.allergies && H.allergies[id])
-			H.trigger_allergy(id, custom_metabolism * H.mob_metabolism_mod.Get())
-			return FALSE
-
-	return TRUE
+		H.trigger_allergy(id, custom_metabolism * H.mob_metabolism_mod.Get())
 
 /datum/reagent/proc/on_move(mob/M)
 	return

--- a/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
@@ -298,8 +298,9 @@
 	custom_metabolism = 0.005
 	var/alert_time = 0
 
-/datum/reagent/nicotine/on_mob_life(mob/living/M)
-	if(!..())
+/datum/reagent/nicotine/on_general_digest(mob/living/M)
+	. = ..()
+	if(!.)
 		return
 	if(!holder.has_reagent("alkysine"))
 		if(volume >= 0.85)
@@ -324,7 +325,6 @@
 				M.losebreath = max(M.losebreath + 1, 2)
 	if(holder.has_reagent("anti_toxin"))
 		holder.remove_reagent("nicotine", 0.065)
-	return TRUE
 
 /datum/reagent/nicotine/on_diona_digest(mob/living/M)
 	return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
1. Из прока убрана проверка `if(!isliving(M))`, это древнее легаси, у гостов on_mob_life не может быть вызван, потому что госты не mob/living/. Код 14 летней давности если что https://github.com/TauCetiStation/TauCetiClassic/blame/25eb0470d27ae2da648dd53d1e4c49568ccccb8a/code/modules/reagents/Chemistry-Reagents.dm
2. Убрал возврат FALSE у раннего выхода после `if(!on_general_digest(M))`: в текущей реализации прока нам не нужны возвратные значения, потому что мы не валидируем его результат в `/datum/reagents/proc/metabolize(mob/living/M)`. И, кажется, в этом нет смысла: единственная причина валидировать, которую я вижу, это решать, изымать ли реагент, если моб его не метаболизирует. Мне кажется, что изымать все равно надо. Но если важно уметь заливать полный бак дионе, чтобы она бегала и не опустошалась, то смысл появляется
3. Остальные возвраты убраны по той же причине: нам не нужно проверять, что вернул on_mob_life
4. Обновил документацию в ридми у on_mob_life и у metabolize
5. **UPD:** Передаём в on_mob_life значение `R.custom_metabolism * M.mob_metabolism_mod.Get()`, чтобы не считать его снова при вызове аллергии (каждый metabolize у каждого реагента в каждом мобе). У nicotine пришлось заменить в связи с этим оверрайд on_mob_life на on_general_digest 

~~Ещё, кажется, будет хорошо передавать из [метаболизма](https://github.com/TauCetiStation/TauCetiClassic/blob/b5c2130ebbf0d4c3c1916fa071853514c764d7de/code/modules/reagents/Chemistry-Holder.dm#L188) в [on_mob_life](https://github.com/TauCetiStation/TauCetiClassic/blob/b5c2130ebbf0d4c3c1916fa071853514c764d7de/code/modules/reagents/Chemistry-Reagents.dm#L131) переменную `remove_amount = = R.custom_metabolism * M.mob_metabolism_mod.Get()`, чтобы не считать её заново в `H.trigger_allergy(id, custom_metabolism * H.mob_metabolism_mod.Get())`, но это я пока не стал делать, т.к нужно будет трогать никотин, который оверрадит on_mob_life~~
## Почему и что этот ПР улучшит
Меньше наследия предков для будущих поколений, никто не будет путаться, почему после вызова аллергии должен быть возврат FALSE
## Авторство
я
<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
