### PR TITLE
фикс оверлея бинта

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -148,9 +148,9 @@
 				W.germ_level += min(germ_level, 3)
 			break
 
-			BP.update_damages()
-			H.update_bandage()
-			return TRUE
+		BP.update_damages()
+		H.update_bandage()
+		return TRUE
 	return ..()
 
 /obj/item/stack/medical/bruise_pack/update_icon()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
код для отображения бинтов стоял после брейка в цикле, ошибка табуляции
## Почему и что этот ПР улучшит
багфикс
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
 - bugfix: Оверлей бинтов правильно отображается на персонаже.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:

 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
