### PR TITLE
превью лоадаута и квирков на манекене в окне персонажа

### DIFF
--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -102,6 +102,60 @@
 	if(S)
 		S.after_job_equip(mannequin, previewJob, TRUE)
 
+	// The mannequin is reused across slot switches, so clear display traits before reapplying.
+	REMOVE_TRAIT(mannequin, TRAIT_FAT, INNATE_TRAIT)
+	if((QUIRK_FATNESS in all_quirks))
+		ADD_TRAIT(mannequin, TRAIT_FAT, INNATE_TRAIT)
+	mannequin.update_body()
+	mannequin.update_inv_w_uniform()
+	mannequin.update_inv_wear_suit()
+
+	var/obj/item/clothing/preview_uniform = istype(mannequin.w_uniform, /obj/item/clothing) ? mannequin.w_uniform : null
+	var/obj/item/clothing/preview_suit = istype(mannequin.wear_suit, /obj/item/clothing) ? mannequin.wear_suit : null
+	if(gear && gear.len)
+		for(var/thing in gear)
+			var/datum/gear/G = gear_datums[thing]
+			if(!G)
+				continue
+			if(G.whitelisted && G.whitelisted != species)
+				continue
+			var/metadata = get_gear_metadata(G)
+			var/obj/item/spawned_item = G.spawn_item(mannequin, metadata)
+			if(!spawned_item)
+				continue
+			if(istype(spawned_item, /obj/item/clothing/accessory))
+				// Clothing accessories attach to worn clothing, not to a body slot
+				if(preview_uniform && preview_uniform.can_attach_accessory(spawned_item))
+					preview_uniform.attach_accessory(spawned_item, mannequin)
+				else if(preview_suit && preview_suit.can_attach_accessory(spawned_item))
+					preview_suit.attach_accessory(spawned_item, mannequin)
+				else
+					qdel(spawned_item)
+			else
+				var/target_slot = _preview_slot_from_flags(spawned_item.slot_flags)
+				if(target_slot)
+					mannequin.replace_in_slot(target_slot, spawned_item)
+				else if(!mannequin.equip_to_appropriate_slot(spawned_item))
+					qdel(spawned_item)
+
+	mannequin.update_inv_back()
 	COMPILE_OVERLAYS(mannequin)
 	parent.show_character_previews(new /mutable_appearance(mannequin))
 	unset_busy_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
+
+/// Maps an item's slot_flags bitmask to the corresponding equip slot constant.
+/// Returns null if the flags don't map to a single clear body slot (e.g. pockets).
+/proc/_preview_slot_from_flags(slot_flags)
+	if(slot_flags & SLOT_FLAGS_BACK)     return SLOT_BACK
+	if(slot_flags & SLOT_FLAGS_OCLOTHING) return SLOT_WEAR_SUIT
+	if(slot_flags & SLOT_FLAGS_ICLOTHING) return SLOT_W_UNIFORM
+	if(slot_flags & SLOT_FLAGS_GLOVES)   return SLOT_GLOVES
+	if(slot_flags & SLOT_FLAGS_EYES)     return SLOT_GLASSES
+	if(slot_flags & SLOT_FLAGS_EARS)     return SLOT_L_EAR
+	if(slot_flags & SLOT_FLAGS_MASK)     return SLOT_WEAR_MASK
+	if(slot_flags & SLOT_FLAGS_HEAD)     return SLOT_HEAD
+	if(slot_flags & SLOT_FLAGS_FEET)     return SLOT_SHOES
+	if(slot_flags & SLOT_FLAGS_ID)       return SLOT_WEAR_ID
+	if(slot_flags & SLOT_FLAGS_BELT)     return SLOT_BELT
+	if(slot_flags & SLOT_FLAGS_NECK)     return SLOT_NECK
+	return null

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -143,8 +143,6 @@
 	parent.show_character_previews(new /mutable_appearance(mannequin))
 	unset_busy_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
 
-/// Maps an item's slot_flags bitmask to the corresponding equip slot constant.
-/// Returns null if the flags don't map to a single clear body slot (e.g. pockets).
 /proc/_preview_slot_from_flags(slot_flags)
 	if(slot_flags & SLOT_FLAGS_BACK)     return SLOT_BACK
 	if(slot_flags & SLOT_FLAGS_OCLOTHING) return SLOT_WEAR_SUIT

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -40,3 +40,12 @@
 		busy_right_hand = FALSE
 	if(!busy_left_hand && !busy_right_hand)
 		busy_with_action = FALSE
+
+/// Clears `slot` (dropping and deleting whatever is there) then equips `new_item`, if given.
+/mob/living/carbon/human/proc/replace_in_slot(slot, obj/item/new_item)
+	var/obj/item/existing = get_equipped_item(slot)
+	if(existing)
+		drop_from_inventory(existing)
+		qdel(existing)
+	if(new_item)
+		equip_to_slot_or_del(new_item, slot)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -41,7 +41,6 @@
 	if(!busy_left_hand && !busy_right_hand)
 		busy_with_action = FALSE
 
-/// Clears `slot` (dropping and deleting whatever is there) then equips `new_item`, if given.
 /mob/living/carbon/human/proc/replace_in_slot(slot, obj/item/new_item)
 	var/obj/item/existing = get_equipped_item(slot)
 	if(existing)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
манекен в окне выбора персонажа теперь отображает надетые эффекты и предметы из лоадаута
<img width="303" height="833" alt="Screenshot 2026-04-17 164356" src="https://github.com/user-attachments/assets/7279adb8-dd78-40b6-a168-57ec608cbf41" />
база для #14738 
вынесено отдельным пром для ревью, можно мержить отдельно от #14738 
## Почему и что этот ПР улучшит
всё видно что надеваешь прикольно
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
 - tweak: Манекен в окне выбора персонажа теперь отображает надетые эффекты и предметы из лоадаута.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:

 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
