### PR TITLE
кулдаун оружие генокрада

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
@@ -11,9 +11,7 @@
 	var/weapon_name_simple
 
 /obj/effect/proc_holder/changeling/weapon/can_sting(mob/user, mob/target)
-	if(world.time < user.next_move)
-		return FALSE
-	return ..()
+	return world.time >= user.next_move
 
 /obj/effect/proc_holder/changeling/weapon/try_to_sting(mob/user, mob/target)
 	if(istype(user.get_active_hand(),weapon_type))

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
@@ -11,7 +11,7 @@
 	var/weapon_name_simple
 
 /obj/effect/proc_holder/changeling/weapon/can_sting(mob/user, mob/target)
-	return world.time >= user.next_move
+	return world.time >= user.next_move && ..()
 
 /obj/effect/proc_holder/changeling/weapon/try_to_sting(mob/user, mob/target)
 	if(istype(user.get_active_hand(),weapon_type))

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
@@ -9,10 +9,15 @@
 
 	var/weapon_type
 	var/weapon_name_simple
+	var/form_cooldown = 2 SECONDS
+	var/last_form_time = 0
 
 /obj/effect/proc_holder/changeling/weapon/try_to_sting(mob/user, mob/target)
 	if(istype(user.get_active_hand(),weapon_type))
 		user.drop_from_inventory(user.get_active_hand()) // cuz changeling weapons are unremovable with standart procedure with canremove = 0, but we still need it
+		return
+	if(world.time < last_form_time + form_cooldown)
+		to_chat(user, "<span class='warning'>We need a moment before reshaping our [weapon_name_simple].</span>")
 		return
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
@@ -32,6 +37,7 @@
 		return FALSE
 	var/obj/item/W = new weapon_type(user)
 	user.put_in_active_hand(W)
+	last_form_time = world.time
 	return W
 
 //Parent to space suits and armor.

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
@@ -13,11 +13,12 @@
 	var/last_form_time = 0
 
 /obj/effect/proc_holder/changeling/weapon/try_to_sting(mob/user, mob/target)
-	if(istype(user.get_active_hand(),weapon_type))
-		user.drop_from_inventory(user.get_active_hand()) // cuz changeling weapons are unremovable with standart procedure with canremove = 0, but we still need it
-		return
 	if(world.time < last_form_time + form_cooldown)
 		to_chat(user, "<span class='warning'>We need a moment before reshaping our [weapon_name_simple].</span>")
+		return
+	if(istype(user.get_active_hand(),weapon_type))
+		last_form_time = world.time
+		user.drop_from_inventory(user.get_active_hand()) // cuz changeling weapons are unremovable with standart procedure with canremove = 0, but we still need it
 		return
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
@@ -10,10 +10,12 @@
 	var/weapon_type
 	var/weapon_name_simple
 
-/obj/effect/proc_holder/changeling/weapon/try_to_sting(mob/user, mob/target)
+/obj/effect/proc_holder/changeling/weapon/can_sting(mob/user, mob/target)
 	if(world.time < user.next_move)
-		return
-	user.SetNextMove(CLICK_CD_MELEE)
+		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/changeling/weapon/try_to_sting(mob/user, mob/target)
 	if(istype(user.get_active_hand(),weapon_type))
 		user.drop_from_inventory(user.get_active_hand()) // cuz changeling weapons are unremovable with standart procedure with canremove = 0, but we still need it
 		return
@@ -35,6 +37,7 @@
 		return FALSE
 	var/obj/item/W = new weapon_type(user)
 	user.put_in_active_hand(W)
+	user.SetNextMove(CLICK_CD_MELEE)
 	return W
 
 //Parent to space suits and armor.

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
@@ -9,15 +9,12 @@
 
 	var/weapon_type
 	var/weapon_name_simple
-	var/form_cooldown = 2 SECONDS
-	var/last_form_time = 0
 
 /obj/effect/proc_holder/changeling/weapon/try_to_sting(mob/user, mob/target)
-	if(world.time < last_form_time + form_cooldown)
-		to_chat(user, "<span class='warning'>We need a moment before reshaping our [weapon_name_simple].</span>")
+	if(world.time < user.next_move)
 		return
+	user.SetNextMove(CLICK_CD_MELEE)
 	if(istype(user.get_active_hand(),weapon_type))
-		last_form_time = world.time
 		user.drop_from_inventory(user.get_active_hand()) // cuz changeling weapons are unremovable with standart procedure with canremove = 0, but we still need it
 		return
 	if(iscarbon(user))
@@ -38,7 +35,6 @@
 		return FALSE
 	var/obj/item/W = new weapon_type(user)
 	user.put_in_active_hand(W)
-	last_form_time = world.time
 	return W
 
 //Parent to space suits and armor.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
добавляет задержку перед тем как убрать обратно молоток/меч/хлыст чтобы не перекликать два раза и не обосраться в критический момент
## Почему и что этот ПР улучшит
я проиграл в игре и чтобы больше не проигрывать я пришёл на гитхаб
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
 - tweak: Добавляет задержку когда убираешь ручное оружие генокрада.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:

 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
