### PR TITLE
Фикс ремапа и гладкой плитки

### DIFF
--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -53,7 +53,6 @@
 /turf/simulated/floor/smoothtile/make_plating()
 	ChangeTurf(/turf/simulated/floor/plating)
 
-
 /turf/simulated/floor/smoothtile/airless
 	icon = 'icons/turf/floors/smooth/floortile.dmi'
 	airless = TRUE

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -51,10 +51,8 @@
 	smooth = SMOOTH_TRUE
 
 /turf/simulated/floor/smoothtile/make_plating()
-	ChangeTurf(/turf/simulated/floor)
-	var/turf/simulated/floor/F = src
-	F.make_plating()
-	return
+	ChangeTurf(/turf/simulated/floor/plating)
+
 
 /turf/simulated/floor/smoothtile/airless
 	icon = 'icons/turf/floors/smooth/floortile.dmi'

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -50,6 +50,12 @@
 	icon_state = "center_8"
 	smooth = SMOOTH_TRUE
 
+/turf/simulated/floor/smoothtile/make_plating()
+	ChangeTurf(/turf/simulated/floor)
+	var/turf/simulated/floor/F = src
+	F.make_plating()
+	return
+
 /turf/simulated/floor/smoothtile/airless
 	icon = 'icons/turf/floors/smooth/floortile.dmi'
 	airless = TRUE

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -527,6 +527,9 @@
 /obj/machinery/camera{
 	c_tag = "Cryogenic Storage"
 	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -12661,7 +12664,6 @@
 	name = "apc top";
 	pixel_y = 28
 	},
-/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "avk" = (
@@ -16518,14 +16520,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aCp" = (
-/obj/effect/decal/turf_decal/white{
-	icon_state = "siding_corner";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "aCq" = (
@@ -16562,6 +16561,10 @@
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/eva)
 "aCv" = (
+/obj/effect/decal/turf_decal/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "aCw" = (
@@ -17118,20 +17121,6 @@
 	icon_state = "dark"
 	},
 /area/station/gateway)
-"aDE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/turf_decal/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/station/ai_monitored/eva)
 "aDF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -17176,16 +17165,13 @@
 	icon_state = "siding_line";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "aDK" = (
@@ -17199,10 +17185,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Dormitory"
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -17502,13 +17484,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -17995,16 +17975,11 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/obj/structure/fence/metal{
-	dir = 4;
-	color = "#b79044"
-	},
 /obj/machinery/suit_storage_unit/unathi{
 	filled = 1
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/eva)
@@ -18038,9 +18013,14 @@
 	},
 /area/station/security/main)
 "aFs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/obj/machinery/door/airlock/glass{
+	name = "Dormitory"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "aFt" = (
 /obj/machinery/door/airlock/glass{
@@ -18351,6 +18331,10 @@
 "aFX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/white{
+	icon_state = "siding_corner";
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
@@ -18729,14 +18713,11 @@
 	},
 /area/station/hallway/primary/central)
 "aGK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/station/civilian/dormitories)
+/area/station/hallway/primary/central)
 "aGL" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -19197,14 +19178,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aHE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
-/area/station/civilian/dormitories)
+/area/station/hallway/primary/central)
 "aHF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22011,16 +21993,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/rack,
-/obj/item/device/radio/off,
-/obj/item/device/radio/off,
-/obj/item/device/radio/off,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
 	icon_state = "warn"
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -32371,15 +32353,12 @@
 	},
 /area/station/rnd/hallway)
 "beU" = (
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/civilian/dormitories)
+/area/station/maintenance/dormitory)
 "beV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -43931,10 +43910,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
-"bzy" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dormitory)
 "bzz" = (
 /obj/item/weapon/flora/random,
 /obj/structure/fence/metal{
@@ -44852,8 +44827,9 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "bBe" = (
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/machinery/computer/cryopod{
+	density = 0;
+	pixel_y = 32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -48920,10 +48896,6 @@
 	dir = 4
 	},
 /obj/machinery/light/smart,
-/obj/machinery/computer/cryopod{
-	density = 0;
-	pixel_y = -32
-	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -52058,6 +52030,9 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -52066,11 +52041,13 @@
 "bNY" = (
 /obj/structure/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
@@ -52369,12 +52346,14 @@
 	},
 /area/station/civilian/dormitories)
 "bOD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
@@ -59211,13 +59190,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "chY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
-/area/station/civilian/dormitories)
+/area/station/hallway/primary/central)
 "chZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -62293,12 +62271,15 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "neutral"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/area/station/civilian/dormitories)
+/obj/machinery/disposal,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/hallway/primary/central)
 "cqo" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -70255,15 +70236,18 @@
 	},
 /area/station/hallway/secondary/entry)
 "diY" = (
-/obj/effect/decal/turf_decal/white{
-	icon_state = "siding_corner";
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	pixel_x = -27
 	},
+/obj/random/foods/food_trash,
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "bluecorner"
 	},
 /area/station/ai_monitored/eva)
 "djb" = (
@@ -70803,15 +70787,24 @@
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "dNk" = (
-/obj/effect/decal/turf_decal/white{
-	icon_state = "siding_line";
-	dir = 8
+/obj/structure/fence/metal{
+	dir = 4;
+	color = "#b79044"
 	},
-/obj/random/foods/food_trash,
-/obj/item/weapon/flora/random,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/obj/machinery/suit_storage_unit/unathi{
+	filled = 1
+	},
+/obj/structure/fence/metal{
+	color = "#b79044"
+	},
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/eva)
 "dNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70930,11 +70923,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
-"dTP" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
 "dUb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -71890,15 +71878,8 @@
 	},
 /area/station/hallway/primary/starboard)
 "eRs" = (
-/obj/structure/table/woodentable/fancy,
-/obj/random/foods/ramens,
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
+/turf/environment/space,
+/area/station/hallway/primary/central)
 "eSb" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -72079,15 +72060,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
-"feS" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
 "ffD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -72823,18 +72795,13 @@
 	},
 /area/station/ai_monitored/storage_secure)
 "fNI" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
-	},
 /obj/effect/decal/turf_decal/set_damaged,
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
+/obj/item/weapon/cigbutt{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/area/station/civilian/dormitories)
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "fOT" = (
 /obj/structure/grille,
 /obj/structure/window/thin/reinforced,
@@ -73495,17 +73462,11 @@
 	},
 /area/station/engineering/chiefs_office)
 "gAS" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
-	},
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "gBb" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/mask/gas/coloured,
@@ -74358,6 +74319,8 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/item/device/radio/off,
+/obj/item/device/radio/off,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/eva)
 "hmR" = (
@@ -74611,6 +74574,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "hyd" = (
@@ -74848,6 +74812,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "hLb" = (
@@ -75119,15 +75084,15 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "hXz" = (
+/obj/machinery/telescience_jammer,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_corner";
+	dir = 4
+	},
 /obj/effect/decal/turf_decal{
-	dir = 5;
+	dir = 1;
 	icon_state = "warn"
 	},
-/obj/structure/fence/metal{
-	dir = 4;
-	color = "#b79044"
-	},
-/obj/machinery/telescience_jammer,
 /obj/effect/decal/turf_decal/metal{
 	icon_state = "siding_corner";
 	dir = 4
@@ -75195,13 +75160,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	dir = 4;
-	name = "Unisex Restrooms"
-	},
-/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -75416,18 +75374,10 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "ijM" = (
-/obj/random/vending/cola,
-/obj/effect/decal/turf_decal/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
-	},
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "ikb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -77046,17 +76996,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jLK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/station/civilian/dormitories)
+/obj/effect/decal/turf_decal/set_damaged,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "jMb" = (
 /obj/item/clothing/gloves/insulated,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -82069,15 +82012,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"oGz" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/station/civilian/dormitories)
 "oGL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -82098,16 +82032,12 @@
 	},
 /area/station/civilian/kitchen)
 "oHi" = (
-/obj/machinery/door/airlock/glass{
-	name = "Dormitory"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/station/civilian/dormitories)
+/area/station/hallway/primary/central)
 "oHZ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -82265,24 +82195,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "oWh" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal/white{
-	icon_state = "siding_line";
-	dir = 9
+/obj/structure/fence/metal{
+	dir = 4;
+	color = "#b79044"
 	},
 /obj/structure/fence/metal{
 	dir = 1;
 	color = "#b79044"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/eva)
 "oXb" = (
 /obj/machinery/hydroponics/constructable,
@@ -82742,18 +82671,9 @@
 	},
 /area/station/medical/cmo)
 "pzF" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
-	},
-/obj/random/vending/snack,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "pAb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -85750,19 +85670,12 @@
 	},
 /area/station/civilian/chapel)
 "stV" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
-	},
-/obj/structure/fence/metal{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
 "sub" = (
@@ -86747,16 +86660,9 @@
 	},
 /area/station/medical/genetics)
 "tyN" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "tzb" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 4
@@ -88752,6 +88658,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -88809,15 +88719,15 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "wPm" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 6;
-	icon_state = "spline_fancy"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
 	},
-/obj/item/weapon/flora/random,
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
 	},
-/area/station/civilian/dormitories)
+/area/station/hallway/primary/central)
 "wPF" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "5,0"
@@ -88865,11 +88775,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "neutral"
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Unisex Restrooms"
 	},
-/area/station/civilian/dormitories)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/station/civilian/toilet)
 "wZc" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
@@ -88995,15 +88911,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "xqD" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 9;
-	icon_state = "spline_fancy"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/wood{
-	icon_state = "wood4"
-	},
-/area/station/civilian/dormitories)
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "xrW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89371,6 +89285,8 @@
 	c_tag = "EVA North";
 	dir = 6
 	},
+/obj/item/device/radio/off,
+/obj/item/device/radio/off,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/eva)
 "xTJ" = (
@@ -117912,7 +117828,7 @@ aJD
 aAp
 aBD
 aDJ
-aDE
+aDJ
 hKf
 hxY
 wJI
@@ -120994,13 +120910,13 @@ awT
 awT
 awT
 awT
-aef
-aeJ
-aef
 awT
-beU
-beU
-awT
+fNI
+tyN
+aef
+aef
+aMR
+aMR
 ktX
 bDW
 rlQ
@@ -121251,13 +121167,13 @@ bOP
 awT
 bQC
 bRg
-aef
+awT
 aeJ
-aef
+beU
 xqD
-gAS
-fNI
-chY
+aef
+eRs
+aGZ
 aMN
 aKx
 aRR
@@ -121508,13 +121424,13 @@ bOX
 awT
 bQD
 bRi
-aef
+awT
 aeJ
-aef
+jLK
 ijM
-dTP
+aef
 eRs
-chY
+aGZ
 aMN
 aKx
 iBb
@@ -121765,14 +121681,14 @@ bPh
 awT
 bQE
 bRj
-aef
+awT
+gAS
 aeJ
-aef
 pzF
-dTP
-tyN
-chY
-aMN
+aef
+aMR
+aMR
+wPm
 aKx
 aRR
 aGZ
@@ -122022,13 +121938,13 @@ bPq
 awT
 bQF
 awT
+awT
 aef
 bLR
 aef
-stV
-feS
-wPm
-awT
+aef
+aOe
+aMS
 idJ
 aKx
 aRR
@@ -122274,18 +122190,18 @@ aKN
 bIF
 bKV
 bMc
-azz
+stV
 bOC
 bNX
 bPy
 azz
 azz
 aFj
-aFt
-jLK
 azz
-aGK
+azz
 aFt
+aGK
+aGK
 aIR
 aKx
 aRR
@@ -122779,7 +122695,7 @@ cea
 arj
 arS
 cea
-bzy
+aeJ
 aeJ
 aBe
 awT
@@ -122797,7 +122713,7 @@ aEa
 aEa
 aEa
 wYU
-oGz
+aEa
 cqm
 chY
 dNB

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -520,13 +520,15 @@
 /turf/environment/space,
 /area/space)
 "aaX" = (
-/obj/machinery/cryopod,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /obj/machinery/camera{
 	c_tag = "Cryogenic Storage"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
+	icon_state = "white"
 	},
 /area/station/civilian/dormitories)
 "aaY" = (
@@ -15548,21 +15550,23 @@
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aAv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/station/civilian/dormitories)
 "aAw" = (
 /obj/machinery/alarm{
@@ -16220,22 +16224,13 @@
 	},
 /area/station/hallway/primary/fore)
 "aBM" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -50921,17 +50916,18 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "apc left";
+	pixel_x = -28
+	},
+/obj/structure/cable,
 /turf/environment/space,
 /turf/simulated/floor{
 	dir = 9;
@@ -52055,11 +52051,12 @@
 	},
 /area/station/medical/genetics)
 "bNX" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "apc left";
-	pixel_x = -28
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -30
+	},
+/obj/machinery/light/smart{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -52355,12 +52352,16 @@
 	pixel_x = 16;
 	pixel_y = -16
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -30
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light/smart{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -122268,17 +122269,17 @@ azs
 cea
 aBe
 awT
-aKN
+aaX
 aKN
 bIF
 bKV
 bMc
-bNX
-bOC
 azz
+bOC
+bNX
 bPy
 azz
-aAv
+azz
 aFj
 aFt
 jLK
@@ -122525,13 +122526,13 @@ cea
 cea
 aBe
 awT
-aaX
+azx
 azx
 bIN
 awT
 bMs
 bNY
-bOD
+aAv
 bOD
 bPI
 bQv


### PR DESCRIPTION
## Описание изменений
Гладкая плитка теперь ломается нормально.

Убрал кафе под дормами, сделал ещё более квадратное ВКД по образу Лексакрской попытки.


<img width="489" height="397" alt="image" src="https://github.com/user-attachments/assets/d9c96556-d9b3-4484-a5d8-c6cc96daac3e" />


<img width="604" height="387" alt="image" src="https://github.com/user-attachments/assets/05b6aeb5-955c-416e-a26a-c2f0340f4056" />



## Почему и что этот ПР улучшит
Исправлен баг с плиткой, теперь её можно нормально использовать, а то после добавления её ни разу не использовали и баг не обнаруживался.

Убраны спорные изменения карты.

## Авторство

## Чеинжлог
:cl:
 - bugfix: Исправлено снятие гладкой плитки
 - map: Убран кафетерий перед дормами
 - map: Слегка изменён отсек ВКД