### PR TITLE
Фикс бесконечного oxyloss после вдыхания фрактола + добавление механики "отходняка" после дыхания

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -283,6 +283,12 @@
 	if(holder.has_reagent("lexorin"))
 		holder.remove_reagent("lexorin", 2 * REM)
 
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/internal/lungs/L = H.organs_by_name[O_LUNGS]
+		if(L && L.fractol_addiction > 0)
+			L.fractol_addiction = max(0, L.fractol_addiction - 2 * REM) // 2x recovery speedup (+1/tick)
+
 /datum/reagent/dexalin/on_diona_digest(mob/living/M)
 	return FALSE
 
@@ -347,6 +353,12 @@
 
 	if(holder.has_reagent("lexorin"))
 		holder.remove_reagent("lexorin", 2 * REM)
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/internal/lungs/L = H.organs_by_name[O_LUNGS]
+		if(L && L.fractol_addiction > 0)
+			L.fractol_addiction = max(0, L.fractol_addiction - 6 * REM) // 4x recovery speedup (+3/tick)
 
 /datum/reagent/dexalinp/on_diona_digest(mob/living/M)
 	return FALSE

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -36,7 +36,8 @@
 	var/list/breath_gas = breath.gas
 	var/breath_total_moles = breath.total_moles
 
-	var/inhaling = breath_gas[breath_type]
+	var/inhale_type = breath_type
+	var/inhaling = breath_gas[inhale_type]
 	var/exhaling = breath_gas[exhale_type]
 	var/poison = breath_gas[poison_type]
 	var/sleeping_agent = breath_gas["sleeping_agent"]
@@ -54,7 +55,7 @@
 	var/druggy_inhaling = breath_gas[druggy_breath_type]
 	var/druggy_inhale_pp = druggy_inhaling ? (druggy_inhaling / breath_total_moles) * breath_pressure : 0
 
-	breath_type = inhale_pp >= druggy_inhale_pp ? breath_type : druggy_breath_type
+	inhale_type = inhale_pp >= druggy_inhale_pp ? inhale_type : druggy_breath_type
 	inhaling = inhale_pp >= druggy_inhale_pp ? inhaling : druggy_inhaling
 	inhale_pp = inhale_pp >= druggy_inhale_pp ? inhale_pp : druggy_inhale_pp
 
@@ -99,7 +100,7 @@
 		failed_inhale = TRUE
 		owner.inhale_alert = TRUE
 
-	breath.adjust_gas(breath_type, -inhaled_gas_used, update = FALSE) //update afterwards
+	breath.adjust_gas(inhale_type, -inhaled_gas_used, update = FALSE) //update afterwards
 
 	if(exhale_type)
 		breath.adjust_gas_temp(exhale_type, inhaled_gas_used, owner.bodytemperature, update = FALSE) //update afterwards

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -21,6 +21,7 @@
 	var/poison_type = "phoron"
 	var/last_successful_breath
 	var/breathing = FALSE
+	var/fractol_addiction = 0
 
 
 /obj/item/organ/internal/lungs/proc/handle_breath(datum/gas_mixture/breath, forced)
@@ -59,6 +60,11 @@
 	inhaling = inhale_pp >= druggy_inhale_pp ? inhaling : druggy_inhaling
 	inhale_pp = inhale_pp >= druggy_inhale_pp ? inhale_pp : druggy_inhale_pp
 
+	if(inhale_type == druggy_breath_type)
+		fractol_addiction++
+	else if(fractol_addiction > 0)
+		fractol_addiction--
+		inhale_type = druggy_breath_type
 
 	if(!owner)
 		return TRUE


### PR DESCRIPTION


<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
### Отходняк от фрактола
Логика простая: чем дольше дышишь фрактолом, тем дольше отходить (легкие будут думать, что они должны дышать не кислородом, а фрактолом), 1к1

Дексалин сокращает это время в 2 раза, дексалин плюс в 4 раза
### Баг
`lungs.dm`, строка 57 (до фикса) — переменная **объекта** `breath_type` перезаписывалась на `"fractol"`, если он преобладает в среде:
```dm
breath_type = inhale_pp >= druggy_inhale_pp ? breath_type : druggy_breath_type
```
На следующем тике в чистой от фрактола среде в строке 39 считывали газ по `breath_type` (уже `"fractol"`), получали `0` молей, и проверка `0 >= 0` снова оставляла `"fractol"`. Кислород навсегда отваливался.

### Фикс
Заменили на **локальную** переменную `inhale_type`, как это уже сделано у простых мобов в `carbon.dm:135`:
```dm
var/inhale_type = breath_type  // каждый тик берётся из оригинала
inhale_type = inhale_pp >= druggy_inhale_pp ? inhale_type : druggy_breath_type
```
Теперь `breath_type` не перезаписывается. На следующем тике `inhale_type` заново инициализируется из `breath_type` (`"oxygen"`), легкие нормально вдыхают кислород. Если моб всё еще находится в облаке фрактола, то лёгкие по-прежнему будут им дышать


## Почему и что этот ПР улучшит

## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
 - bugfix: Исправлено бесконечное удушье после вдыхания фрактола.
 - rscadd: Добавлена механика "отходняка" после вдыхания фрактола: легкие продолжают требовать газ некоторое время после выхода из облака, пропорциональное времени нахождения в нем.
 - rscadd: Дексалин и Дексалин Плюс ускоряют лечение отходняка от фрактола.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Исправлено бесконечное удушье после контакта с фрактолом.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
