### PR TITLE
human ex_act update

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -229,6 +229,7 @@
 	if(eyecheck() >= FLASHES_FULL_PROTECTION)
 		flash_eyes()
 
+	var/weapon_message = "Explosive Blast"
 	var/bomb_protection = getarmor(null, BOMB)
 	var/b_loss = null //brute damage
 	var/f_loss = null //burn (fire) damage
@@ -262,14 +263,13 @@
 
 	// focus most of the blast on one organ
 	var/obj/item/organ/external/BP = pick(bodyparts)
-	apply_damage(b_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = "Explosive blast")
-	apply_damage(f_loss * 0.9, BURN, BP, bomb_protection, used_weapon = "Explosive blast")
+	apply_damage(b_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = weapon_message)
+	apply_damage(f_loss * 0.9, BURN, BP, bomb_protection, used_weapon = weapon_message)
 
 	// distribute the remaining 10% on all limbs equally
-	b_loss *= 0.1
-	f_loss *= 0.1
+	b_loss *= 0.5
+	f_loss *= 0.5
 
-	var/weapon_message = "Explosive Blast"
 	take_overall_damage(b_loss, f_loss, used_weapon = weapon_message)
 
 /mob/living/carbon/human/airlock_crush_act()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -263,7 +263,7 @@
 	// focus most of the blast on one organ
 	var/obj/item/organ/external/BP = pick(bodyparts)
 	apply_damage(b_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = "Explosive blast")
-	apply_damage(f_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = "Explosive blast")
+	apply_damage(f_loss * 0.9, BURN, BP, bomb_protection, used_weapon = "Explosive blast")
 
 	// distribute the remaining 10% on all limbs equally
 	b_loss *= 0.1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -226,7 +226,7 @@
 		rig_setup_stat(rig)
 
 /mob/living/carbon/human/ex_act(severity)
-	if(eyecheck() >= FLASHES_FULL_PROTECTION)
+	if(eyecheck() <= FLASHES_FULL_PROTECTION)
 		flash_eyes()
 
 	var/weapon_message = "Explosive Blast"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -226,7 +226,7 @@
 		rig_setup_stat(rig)
 
 /mob/living/carbon/human/ex_act(severity)
-	if(eyecheck() <= FLASHES_FULL_PROTECTION)
+	if(eyecheck() < FLASHES_FULL_PROTECTION)
 		flash_eyes()
 
 	var/weapon_message = "Explosive Blast"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -266,9 +266,9 @@
 	apply_damage(b_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = weapon_message)
 	apply_damage(f_loss * 0.9, BURN, BP, bomb_protection, used_weapon = weapon_message)
 
-	// distribute the remaining 10% on all limbs equally
-	b_loss *= 0.5
-	f_loss *= 0.5
+	// minor "behind the armor" damage from the blast wave across the entire body
+	b_loss *= 0.25
+	f_loss *= 0.25
 
 	take_overall_damage(b_loss, f_loss, used_weapon = weapon_message)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -261,9 +261,10 @@
 			if (prob(50) && !prob(bomb_protection))
 				Paralyse(10)
 
-	for(var/obj/item/organ/external/BP in bodyparts)
-		apply_damage(rand(b_loss * 0.75, b_loss * 0.25), BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
-		apply_damage(rand(f_loss * 0.75, f_loss * 0.25), BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+	// focus most of the blast on one organ
+	var/obj/item/organ/external/BP = pick(bodyparts)
+	apply_damage(b_loss * 0.9, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+	apply_damage(f_loss * 0.9, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
 
 
 	// minor "behind the armor" damage from the blast wave across the entire body

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -226,61 +226,51 @@
 		rig_setup_stat(rig)
 
 /mob/living/carbon/human/ex_act(severity)
-	if(!blinded)
+	if(eyecheck() >= FLASHES_FULL_PROTECTION)
 		flash_eyes()
 
-	var/shielded = 0
-	var/b_loss = null
-	var/f_loss = null
+	var/bomb_protection = getarmor(null, BOMB)
+	var/b_loss = null //brute damage
+	var/f_loss = null //burn (fire) damage
 	switch (severity)
 		if(EXPLODE_DEVASTATE)
 			b_loss += 500
-			if (!prob(getarmor(null, BOMB)))
+			if(!prob(bomb_protection))
 				gib()
 				return
 			else
 				var/atom/target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(target, 200, 4)
-			//return
-//				var/atom/target = get_edge_target_turf(user, get_dir(src, get_step_away(user, src)))
-				//user.throw_at(target, 200, 4)
 
 		if(EXPLODE_HEAVY)
-			if (!shielded)
-				b_loss += 60
-
+			b_loss += 60
 			f_loss += 60
-
-			if (prob(getarmor(null, BOMB)))
-				b_loss = b_loss/1.5
-				f_loss = f_loss/1.5
 
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_damage += 30
 				ear_deaf += 120
-			if (prob(70) && !shielded)
+			if (prob(70) && !prob(bomb_protection))
 				Paralyse(10)
 
 		if(EXPLODE_LIGHT)
 			b_loss += 30
-			if (prob(getarmor(null, BOMB)))
-				b_loss = b_loss/2
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_damage += 15
 				ear_deaf += 60
-			if (prob(50) && !shielded)
+			if (prob(50) && !prob(bomb_protection))
 				Paralyse(10)
 
 	// focus most of the blast on one organ
 	var/obj/item/organ/external/BP = pick(bodyparts)
-	BP.take_damage(b_loss * 0.9, f_loss * 0.9, used_weapon = "Explosive blast")
+	apply_damage(b_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = "Explosive blast")
+	apply_damage(f_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = "Explosive blast")
 
 	// distribute the remaining 10% on all limbs equally
 	b_loss *= 0.1
 	f_loss *= 0.1
 
 	var/weapon_message = "Explosive Blast"
-	take_overall_damage(b_loss * 0.2, f_loss * 0.2, used_weapon = weapon_message)
+	take_overall_damage(b_loss, f_loss, used_weapon = weapon_message)
 
 /mob/living/carbon/human/airlock_crush_act()
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -261,10 +261,10 @@
 			if (prob(50) && !prob(bomb_protection))
 				Paralyse(10)
 
-	// focus most of the blast on one organ
-	var/obj/item/organ/external/BP = pick(bodyparts)
-	apply_damage(b_loss * 0.9, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
-	apply_damage(f_loss * 0.9, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+	for(var/obj/item/organ/external/BP in bodyparts)
+		apply_damage(rand(b_loss * 0.75, b_loss * 0.25), BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+		apply_damage(rand(f_loss * 0.75, f_loss * 0.25), BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+
 
 	// minor "behind the armor" damage from the blast wave across the entire body
 	b_loss *= 0.25

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -258,14 +258,13 @@
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_damage += 15
 				ear_deaf += 60
-			if (prob(50) && !prob(bomb_protection))
+			if(prob(50) && !prob(bomb_protection))
 				Paralyse(10)
 
-	// focus most of the blast on one organ
-	var/obj/item/organ/external/BP = pick(bodyparts)
-	apply_damage(b_loss * 0.9, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
-	apply_damage(f_loss * 0.9, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
-
+	for(var/i in 1 to 3)
+		var/obj/item/organ/external/BP = pick(bodyparts)
+		apply_damage(b_loss * rand(0.25, 1), BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+		apply_damage(f_loss * rand(0.25, 1), BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
 
 	// minor "behind the armor" damage from the blast wave across the entire body
 	b_loss *= 0.25

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -230,7 +230,7 @@
 		flash_eyes()
 
 	var/weapon_message = "Explosive Blast"
-	var/bomb_protection = getarmor(null, BOMB)
+	var/bomb_protection = run_armor_check(null, BOMB)
 	var/b_loss = null //brute damage
 	var/f_loss = null //burn (fire) damage
 	switch (severity)
@@ -263,8 +263,8 @@
 
 	// focus most of the blast on one organ
 	var/obj/item/organ/external/BP = pick(bodyparts)
-	apply_damage(b_loss * 0.9, BRUTE, BP, bomb_protection, used_weapon = weapon_message)
-	apply_damage(f_loss * 0.9, BURN, BP, bomb_protection, used_weapon = weapon_message)
+	apply_damage(b_loss * 0.9, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+	apply_damage(f_loss * 0.9, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
 
 	// minor "behind the armor" damage from the blast wave across the entire body
 	b_loss *= 0.25


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
делает допотопный код екс акта у хумана чуть более логичным и понятным, наверное

убрал там переменную щиелдед которая всегда была = 0

ещё поднял общий урон по всем конечностям от взрыва, до этого урон перемножался на 0.1 и после на 0.2, из-за чего он почти не чувствовался (90 брут демеджа после ТЯЖЕЛОГО взрыва превращались в 2). Вместо этого теперь урон урезается всего в четыре раза

ещё теперь 80% защита от взрыва позволяет поглотить 80% урона от взрыва, 25 процентная защита позволяет поглотить 25% урона от взрыва и тд. до этого была какая-та непонятная хренатень с уменьшением урона

и ещё теперь полная защита от вспышек (шлем от рига или сварочные очки/шлем) позволяют не ослепнуть от взрыва

## Почему и что этот ПР улучшит
код выглядит круче понятнее логичнее
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
🆑 Simbaka
- tweak: Броня защищает от взрывов в соответствии с защитным параметром BOMB.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
