### PR TITLE
Добавлена поддержка стеков basetype для турфов

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -437,9 +437,10 @@
 	return FALSE
 
 /turf/simulated/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	if(basetype)
-		underlay_appearance.icon = initial(basetype.icon)
-		underlay_appearance.icon_state = initial(basetype.icon_state)
+	var/base_turf = get_base_turf_type()
+	if(base_turf)
+		underlay_appearance.icon = initial(base_turf.icon)
+		underlay_appearance.icon_state = initial(base_turf.icon_state)
 		return TRUE
 	return ..()
 

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -437,7 +437,7 @@
 	return FALSE
 
 /turf/simulated/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	var/base_turf = get_base_turf_type()
+	var/turf/base_turf = get_base_turf_type()
 	if(base_turf)
 		underlay_appearance.icon = initial(base_turf.icon)
 		underlay_appearance.icon_state = initial(base_turf.icon_state)

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -437,10 +437,10 @@
 	return FALSE
 
 /turf/simulated/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	var/turf/base_turf = get_base_turf_type()
-	if(base_turf)
-		underlay_appearance.icon = initial(base_turf.icon)
-		underlay_appearance.icon_state = initial(base_turf.icon_state)
+	var/turf/base_turf_type = get_base_turf_type()
+	if(base_turf_type)
+		underlay_appearance.icon = initial(base_turf_type.icon)
+		underlay_appearance.icon_state = initial(base_turf_type.icon_state)
 		return TRUE
 	return ..()
 

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -210,7 +210,6 @@
 /turf/simulated/shuttle
 	name = "shuttle"
 	icon = 'icons/turf/shuttle.dmi'
-	basetype = list(/turf/environment/space, /turf/simulated/shuttle/plating/airless)
 	thermal_conductivity = 0.05
 	layer = 2
 

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -210,6 +210,7 @@
 /turf/simulated/shuttle
 	name = "shuttle"
 	icon = 'icons/turf/shuttle.dmi'
+	basetype = list(/turf/environment/space, /turf/simulated/floor/plating)
 	thermal_conductivity = 0.05
 	layer = 2
 

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -210,7 +210,7 @@
 /turf/simulated/shuttle
 	name = "shuttle"
 	icon = 'icons/turf/shuttle.dmi'
-	basetype = list(/turf/environment/space, /turf/simulated/floor/plating/airless)
+	basetype = list(/turf/environment/space, /turf/simulated/shuttle/plating/airless)
 	thermal_conductivity = 0.05
 	layer = 2
 

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -210,7 +210,7 @@
 /turf/simulated/shuttle
 	name = "shuttle"
 	icon = 'icons/turf/shuttle.dmi'
-	basetype = list(/turf/environment/space, /turf/simulated/floor/plating)
+	basetype = list(/turf/environment/space, /turf/simulated/floor/plating/airless)
 	thermal_conductivity = 0.05
 	layer = 2
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -7,7 +7,8 @@
 	// dynamic lighting subsystem uses lighting_object's for luminosity
 	luminosity = 0
 
-	var/basetype = /turf/environment/space
+	// Either a turf type or a list of turf types, sorted bottom layer to top.
+	var/list/basetype = /turf/environment/space
 	var/can_deconstruct = FALSE
 
 	var/underfloor_accessibility = UNDERFLOOR_HIDDEN
@@ -339,25 +340,34 @@
 	if(turf_type)
 		ChangeTurf(turf_type)
 
+/turf/proc/normalize_base_turf_stack(list/base_turfs)
+	var/list/normalized_turfs = list()
+	for(var/base_turf in base_turfs)
+		if(!base_turf || normalized_turfs.Find(base_turf))
+			continue
+		normalized_turfs += base_turf
+
+	if(!normalized_turfs.len)
+		normalized_turfs += /turf/environment/space
+
+	return normalized_turfs
+
 /turf/proc/get_base_turf_type()
 	if(islist(basetype))
-		var/list/base_turfs = basetype
-		if(!base_turfs.len)
-			return /turf/environment/space
+		var/list/base_turfs = normalize_base_turf_stack(basetype)
 		return base_turfs[base_turfs.len]
 	return basetype
 
 /turf/proc/get_base_turf_stack(include_self = FALSE)
 	var/list/base_turfs
 	if(islist(basetype))
-		var/list/base_stack = basetype
-		base_turfs = base_stack.Copy()
+		base_turfs = normalize_base_turf_stack(basetype)
 	else if(basetype)
 		base_turfs = list(basetype)
 	else
 		base_turfs = list(/turf/environment/space)
 
-	if(include_self && base_turfs[base_turfs.len] != type)
+	if(include_self && !base_turfs.Find(type))
 		base_turfs += type
 
 	if(base_turfs.len == 1)
@@ -371,9 +381,7 @@
 
 	var/new_basetype
 	if(islist(path))
-		var/list/base_turfs = path
-		if(!base_turfs.len)
-			return
+		var/list/base_turfs = normalize_base_turf_stack(path)
 		path = base_turfs[base_turfs.len]
 		if(base_turfs.len > 1)
 			new_basetype = base_turfs.Copy(1, base_turfs.len)
@@ -510,7 +518,7 @@
 
 /turf/proc/MoveTurf(turf/target, move_unmovable = 0)
 	if(type != get_base_turf_type() || move_unmovable)
-		var/target_basetype = target.get_base_turf_stack(TRUE)
+		var/target_basetype = target.get_base_turf_stack(target.type != type)
 		. = target.ChangeTurf(src.type)
 		var/turf/moved_turf = .
 		if(moved_turf)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -7,7 +7,7 @@
 	// dynamic lighting subsystem uses lighting_object's for luminosity
 	luminosity = 0
 
-	var/turf/basetype = /turf/environment/space
+	var/basetype = /turf/environment/space
 	var/can_deconstruct = FALSE
 
 	var/underfloor_accessibility = UNDERFLOOR_HIDDEN
@@ -339,10 +339,29 @@
 	if(turf_type)
 		ChangeTurf(turf_type)
 
+/turf/proc/get_base_turf_type()
+	if(islist(basetype))
+		var/list/base_turfs = basetype
+		if(base_turfs.len)
+			return base_turfs[base_turfs.len]
+		return /turf/environment/space
+	return basetype
+
 //Creates a new turf
 /turf/proc/ChangeTurf(path, list/arguments = list())
 	if (!path)
 		return
+
+	var/new_basetype
+	if(islist(path))
+		var/list/base_turfs = path
+		if(!base_turfs.len)
+			return
+		path = base_turfs[base_turfs.len]
+		if(base_turfs.len > 1)
+			new_basetype = base_turfs.Copy(1, base_turfs.len)
+		else
+			new_basetype = path
 
 	clean_turf_decals()
 
@@ -356,6 +375,8 @@
 			path = env_turf_type
 
 	if (path == type)
+		if(new_basetype)
+			basetype = new_basetype
 		return src
 
 	// Back all this data up, so we can set it after the turf replace.
@@ -440,7 +461,7 @@
 
 	W.levelupdate()
 
-	basetype = old_basetype
+	basetype = new_basetype || old_basetype
 
 	queue_smooth_neighbors(W)
 
@@ -471,7 +492,7 @@
 	return W
 
 /turf/proc/MoveTurf(turf/target, move_unmovable = 0)
-	if(type != basetype || move_unmovable)
+	if(type != get_base_turf_type() || move_unmovable)
 		. = target.ChangeTurf(src.type)
 		ChangeTurf(basetype)
 	else

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -340,12 +340,26 @@
 		ChangeTurf(turf_type)
 
 /turf/proc/get_base_turf_type()
+	var/base_turfs = get_base_turf_stack()
+	if(islist(base_turfs))
+		return base_turfs[base_turfs.len]
+	return base_turfs
+
+/turf/proc/get_base_turf_stack(include_self = FALSE)
+	var/list/base_turfs
 	if(islist(basetype))
-		var/list/base_turfs = basetype
-		if(base_turfs.len)
-			return base_turfs[base_turfs.len]
-		return /turf/environment/space
-	return basetype
+		base_turfs = basetype.Copy()
+	else if(basetype)
+		base_turfs = list(basetype)
+	else
+		base_turfs = list(/turf/environment/space)
+
+	if(include_self && base_turfs[base_turfs.len] != type)
+		base_turfs += type
+
+	if(base_turfs.len == 1)
+		return base_turfs[1]
+	return base_turfs
 
 //Creates a new turf
 /turf/proc/ChangeTurf(path, list/arguments = list())
@@ -493,7 +507,11 @@
 
 /turf/proc/MoveTurf(turf/target, move_unmovable = 0)
 	if(type != get_base_turf_type() || move_unmovable)
+		var/target_basetype = target.get_base_turf_stack(TRUE)
 		. = target.ChangeTurf(src.type)
+		var/turf/moved_turf = .
+		if(moved_turf)
+			moved_turf.basetype = target_basetype
 		ChangeTurf(basetype)
 	else
 		return target

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -340,15 +340,18 @@
 		ChangeTurf(turf_type)
 
 /turf/proc/get_base_turf_type()
-	var/base_turfs = get_base_turf_stack()
-	if(islist(base_turfs))
+	if(islist(basetype))
+		var/list/base_turfs = basetype
+		if(!base_turfs.len)
+			return /turf/environment/space
 		return base_turfs[base_turfs.len]
-	return base_turfs
+	return basetype
 
 /turf/proc/get_base_turf_stack(include_self = FALSE)
 	var/list/base_turfs
 	if(islist(basetype))
-		base_turfs = basetype.Copy()
+		var/list/base_stack = basetype
+		base_turfs = base_stack.Copy()
 	else if(basetype)
 		base_turfs = list(basetype)
 	else

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -340,6 +340,11 @@
 	if(turf_type)
 		ChangeTurf(turf_type)
 
+/turf/proc/get_environment_turf_type()
+	if(SSenvironment && SSenvironment.turf_type && z && SSenvironment.turf_type.len >= z && SSenvironment.turf_type[z])
+		return SSenvironment.turf_type[z]
+	return /turf/environment/space
+
 /turf/proc/normalize_base_turf_stack(list/base_turfs)
 	var/list/normalized_turfs = list()
 	for(var/base_turf in base_turfs)
@@ -348,7 +353,7 @@
 		normalized_turfs += base_turf
 
 	if(!normalized_turfs.len)
-		normalized_turfs += /turf/environment/space
+		normalized_turfs += get_environment_turf_type()
 
 	return normalized_turfs
 
@@ -356,7 +361,9 @@
 	if(islist(basetype))
 		var/list/base_turfs = normalize_base_turf_stack(basetype)
 		return base_turfs[base_turfs.len]
-	return basetype
+	if(basetype)
+		return basetype
+	return get_environment_turf_type()
 
 /turf/proc/get_base_turf_stack(include_self = FALSE)
 	var/list/base_turfs
@@ -365,7 +372,7 @@
 	else if(basetype)
 		base_turfs = list(basetype)
 	else
-		base_turfs = list(/turf/environment/space)
+		base_turfs = list(get_environment_turf_type())
 
 	if(include_self && !base_turfs.Find(type))
 		base_turfs += type
@@ -395,7 +402,7 @@
 		return*/
 
 	if(ispath(path, /turf/environment))
-		var/env_turf_type = SSenvironment.turf_type[z]
+		var/env_turf_type = get_environment_turf_type()
 		if(!ispath(path, env_turf_type))
 			path = env_turf_type
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -605,7 +605,8 @@
 
 	var/turf/t
 	if(SSticker.current_state > GAME_STATE_SETTING_UP)
-		t = new basetype(T)
+		var/base_turf = get_base_turf_type()
+		t = new base_turf(T)
 	else
 		t = T.ChangeTurf(basetype)
 	spawn(2)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -605,7 +605,7 @@
 
 	var/turf/t
 	if(SSticker.current_state > GAME_STATE_SETTING_UP)
-		var/base_turf = get_base_turf_type()
+		var/turf/base_turf = get_base_turf_type()
 		t = new base_turf(T)
 	else
 		t = T.ChangeTurf(basetype)

--- a/code/modules/replicators/replicator_reactions.dm
+++ b/code/modules/replicators/replicator_reactions.dm
@@ -25,7 +25,7 @@
 
 /* TURFS */
 /turf/simulated/floor/get_replicator_material_amount()
-	if(type == basetype)
+	if(type == get_base_turf_type())
 		return -1
 
 	return 1


### PR DESCRIPTION
## Описание

Resolve #14916

Добавлена поддержка стеков `basetype` для турфов и применена к shuttle turfs. Теперь `basetype` может быть как одиночным turf path, так и списком, где верхний элемент используется как следующий базовый турф, а оставшаяся цепочка сохраняется для последующих разрушений/замен.

Базовые `/turf/simulated/shuttle` теперь стартуют со стеком `space -> floor/plating`, поэтому первый отлёт шаттла оставляет plating вместо вакуума. При дальнейших перемещениях `MoveTurf()` запоминает фактический турф, который шаттл накрыл на цели, вместе с его base-chain: например, если шаттл прилетел на plating с `basetype = space`, следующий отлёт снова восстановит plating, а сам plating сможет откатиться к space.

## Детали

- `ChangeTurf()` понимает список `basetype` и снимает верхний слой.
- `MoveTurf()` сравнивает текущий тип с фактическим верхним base turf, а не с raw `basetype`.
- `MoveTurf()` сохраняет covered turf stack цели перед заменой цели на shuttle turf.
- Прямые места, где нужен concrete turf path (`initial(base.icon)`, `new base(T)`, сравнение типа), переведены на `get_base_turf_type()`.
- Существующие одиночные `basetype` продолжают работать как раньше.

## Проверки

- `git diff --check`
- Поиск старых прямых форм: `rg -n "var/turf/basetype|initial\\(basetype\\.|new basetype\\(|type == basetype" code --glob '*.dm' || true`
- GitHub CI: DreamChecker, OpenDream, Code/Map linting, Compile Everything, unit test matrix

Локально DreamChecker не запускался: официальный `suite-1.11` бинарник скачивается как Linux x86_64 ELF, а текущая среда — Darwin arm64. Проверку компиляции выполняет CI.

:cl:
 - bugfix: Шаттлы при перемещении оставляют настроенное базовое покрытие вместо вакуума и сохраняют цепочку basetype для последующих замен.