### PR TITLE
ядерное уничтожение застрявших тултипов

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -58,6 +58,8 @@
 	client.images = null //remove the images such as AIs being unable to see runes
 	client.screen = list() //remove hud items just in case
 
+	closeToolTip(src) //dismiss any stuck tooltip on mob transition
+
 	create_mob_hud()
 
 	client.set_main_screen_plane_masters()

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -38,6 +38,7 @@ Notes:
 	var/showing = 0
 	var/queueHide = 0
 	var/init = 0
+	var/atom/last_target
 
 /datum/tooltip/New(client/C)
 	if (C)
@@ -50,6 +51,13 @@ Notes:
 /datum/tooltip/proc/show(atom/movable/thing, params = null, title = null, content = null, theme = "default", special = "none")
 	if (!thing || !params || (!title && !content) || !owner || !isnum(world.icon_size))
 		return 0
+
+	// BYOND drops MouseExited when the hovered object is deleted (radial slices, action buttons),
+	// leaving the tooltip stuck. Hide it ourselves when its source goes away.
+	if (last_target)
+		UnregisterSignal(last_target, COMSIG_PARENT_QDELETING)
+	RegisterSignal(thing, COMSIG_PARENT_QDELETING, PROC_REF(on_target_qdel))
+	last_target = thing
 
 	if (!init)
 		//Initialize some vars
@@ -89,6 +97,15 @@ Notes:
 	queueHide = showing ? 1 : 0
 
 	return 1
+
+/datum/tooltip/proc/on_target_qdel()
+	SIGNAL_HANDLER
+	last_target = null
+	hide()
+
+/datum/tooltip/Destroy(force)
+	last_target = null
+	return ..()
 
 
 /* TG SPECIFIC CODE */

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -88,6 +88,8 @@ Notes:
 	return 1
 
 /datum/tooltip/proc/hide()
+	if (owner)
+		owner << output(null, "[control]:tooltip.hide") //cancels a pending async show that would otherwise re-show us
 	if (queueHide)
 		spawn(1)
 			winshow(owner, control, 0)

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -84,15 +84,18 @@
 			'text': '',
 			'theme': '',
 			'padding': 2,
+			'closed': false,
 			init: function(tileSize, control) {
 				tooltip.tileSize = parseInt(tileSize);
 				tooltip.control = control;
 			},
 			hide: function() {
+				tooltip.closed = true;
 				window.location = 'byond://winset?id='+tooltip.control+';is-visible=false';
 			},
 			updateCallback: function(map) {
 				if (typeof map === 'undefined' || !map) {return false;}
+				if (tooltip.closed) {return false;} //hidden after this update was requested, don't re-show
 
 				//alert(tooltip.params+' | '+tooltip.clientView+' | '+tooltip.text+' | '+tooltip.theme); //DEBUG
 
@@ -212,6 +215,7 @@
 				});
 			},
 			update: function(params, clientView, text, theme, special, pixelRatio) {
+				tooltip.closed = false;
 				//Assign our global object
 				tooltip.params = $.parseJSON(params);
 				tooltip.clientView = parseInt(clientView);


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тултипы залипали из трёх причин, пофиксил каждую, разбил по коммитам:
     
  - быстрый проход курсора по кнопке - js-колбэк опаздывал и переоткрывал уже закрытый тултип,
  добавил флаг чтобы не воскрешал
  - объект под курсором удалился - byond не шлёт MouseExited, прячу по сигналу qdel
  - тултип переживал рестарт/смену моба - сбрасываю в LateLogin
## Почему и что этот ПР улучшит
надоели застревающие тултипы
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
- tweak: Тултипы не застревают больше.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
