### PR TITLE
При закрытии контейнера предметы "утрамбовываются", и при повторном открытии появляются в рамках "открытой области" контейнера.

### DIFF
--- a/code/__DEFINES/math.dm
+++ b/code/__DEFINES/math.dm
@@ -47,6 +47,8 @@
 
 #define CEIL(x) ceil(x)
 
+#define ROUNDSTRICT(x) abs(fract(x)) <= 0.5 ? floor(x) : ceil(x)
+
 // Similar to clamp but the bottom rolls around to the top and vice versa. min is inclusive, max is exclusive
 #define WRAP(val, min, max) ( min == max ? min : (val) - (round(((val) - (min))/((max) - (min))) * ((max) - (min))) )
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -730,3 +730,47 @@
 		if(stop_type && istype(turf_to_check, stop_type))
 			break
 	return turf_to_check
+
+
+
+/proc/get_box_and_section_intercection_coordinates_list_or_null(s_x1, s_x2, s_y1, s_y2, b_x1, b_x2, b_y1, b_y2)
+	var/list/sides = list(
+		list(b_x1, b_x2, b_y1, b_y1),
+		list(b_x1, b_x2, b_y2, b_y2),
+		list(b_x1, b_x1, b_y1, b_y2),
+		list(b_x2, b_x2, b_y1, b_y2),
+	)
+
+	for(var/side in sides)
+		var/list/coordinates = get_section_and_section_intercection_coordinates_list_or_null(s_x1, s_x2, s_y1, s_y2, side[1], side[2], side[3], side[4])
+		if(isnull(coordinates))
+			continue
+
+		return coordinates
+
+	return null
+
+
+/proc/get_section_and_section_intercection_coordinates_list_or_null(s_x1, s_x2, s_y1, s_y2, b_x1, b_x2, b_y1, b_y2)
+	var/delta_section_x = s_x2 - s_x1
+	var/delta_section_y = s_y2 - s_y1
+
+
+	var/delta_box_x = b_x2 - b_x1
+	var/delta_box_y = b_y2 - b_y1
+
+
+	var/det = delta_section_x * delta_box_y - delta_section_y * delta_box_x
+	if(det != 0)
+		var/acx = b_x1 - s_x1
+		var/acy = b_y1 - s_y1
+
+		var/t = (acx * delta_box_y - acy * delta_box_x) / det
+		var/s = (acx * delta_section_y - acy * delta_section_x) / det
+
+		if((t >= 0) && (t <= 1) && (s >= 0) && (s <= 1))
+			var/ix = s_x1 + t * delta_section_x
+			var/iy = s_y1 + t * delta_section_y
+			return list(ix, iy)
+
+	return null

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -81,7 +81,7 @@
 	for(var/obj/I in src)
 		I.forceMove(src.loc)
 
-/obj/structure/closet/proc/collect_contents()
+/obj/structure/closet/proc/collect_contents(min_x = -5, min_y = -13, max_x = 5, max_y = 7)
 	var/itemcount = 0
 
 	//Cham Projector Exception
@@ -95,6 +95,12 @@
 		if(itemcount >= storage_capacity)
 			break
 		if(!I.anchored && !istype(I, /obj/item/weapon/paper/sticker))
+			if((I.pixel_x > max_x) || (I.pixel_x < min_x) || (I.pixel_y > max_y) || (I.pixel_y < min_y))
+				var/list/new_coords = get_box_and_section_intercection_coordinates_list_or_null(0, I.pixel_x, 0, I.pixel_y, min_x, max_x, min_y, max_y)
+				if(!isnull(new_coords))
+					I.pixel_x = ROUNDSTRICT(new_coords[1])
+					I.pixel_y = ROUNDSTRICT(new_coords[2])
+
 			I.forceMove(src)
 			itemcount++
 

--- a/code/game/objects/structures/crates_lockers/closets/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/crittercrate.dm
@@ -50,6 +50,9 @@
 /obj/structure/closet/critter/spawn_infill_particle(min_x = -10, min_y = -13, max_x = 10, max_y = 0)
 	. = ..()
 
+/obj/structure/closet/critter/collect_contents(min_x = -10, min_y = -13, max_x = 10, max_y = 0)
+	. = ..()
+
 /obj/structure/closet/critter/corgi
 	name = "corgi crate"
 	content_mob = /mob/living/simple_animal/corgi //This statement is (not) false. See above.

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -52,33 +52,8 @@
 		return 0
 
 	playsound(src, 'sound/machines/click.ogg', VOL_EFFECTS_MASTER, 15, FALSE, null, -3)
-	var/itemcount = 0
 
-	for(var/mob/M in src.loc)
-		if(itemcount >= storage_capacity)
-			break
-		if(istype (M, /mob/dead/observer))
-			continue
-		if(M.buckled)
-			continue
-		if(M.w_class > SIZE_SMALL && !(M.lying || M.crawling))
-			continue
-
-		M.forceMove(src)
-		M.instant_vision_update(1,src)
-		itemcount++
-
-	for(var/obj/O in get_turf(src))
-		if(itemcount >= storage_capacity)
-			break
-		if(O.density || O.anchored || istype(O,/obj/structure/closet))
-			continue
-		if(istype(O, /obj/structure/stool/bed)) //This is only necessary because of rollerbeds and swivel chairs.
-			var/obj/structure/stool/bed/B = O
-			if(B.buckled_mob)
-				continue
-		O.forceMove(src)
-		itemcount++
+	collect_contents()
 
 	icon_state = icon_closed
 	src.opened = 0
@@ -500,6 +475,9 @@
 /obj/structure/closet/crate/large/spawn_infill_particle(min_x = -10, min_y = -13, max_x = 10, max_y = -1)
 	. = ..()
 
+/obj/structure/closet/crate/large/collect_contents(min_x = -10, min_y = -13, max_x = 10, max_y = -1)
+	. = ..()
+
 /obj/structure/closet/crate/secure/large
 	name = "large crate"
 	desc = "A hefty metal crate with an electronic locking system."
@@ -529,6 +507,9 @@
 	return
 
 /obj/structure/closet/crate/secure/large/spawn_infill_particle(min_x = -10, min_y = -13, max_x = 10, max_y = -1)
+	. = ..()
+
+/obj/structure/closet/crate/secure/large/collect_contents(min_x = -10, min_y = -13, max_x = 10, max_y = -1)
 	. = ..()
 
 //fluff variant
@@ -635,3 +616,39 @@
 
 /obj/structure/closet/crate/spawn_infill_particle(min_x = -12, min_y = -9, max_x = 12, max_y = 0)
 	. = ..()
+
+/obj/structure/closet/crate/collect_contents(min_x = -12, min_y = -9, max_x = 12, max_y = 0)
+	var/itemcount = 0
+
+	for(var/mob/M in src.loc)
+		if(itemcount >= storage_capacity)
+			break
+		if(istype (M, /mob/dead/observer))
+			continue
+		if(M.buckled)
+			continue
+		if(M.w_class > SIZE_SMALL && !(M.lying || M.crawling))
+			continue
+
+		M.forceMove(src)
+		M.instant_vision_update(1,src)
+		itemcount++
+
+	for(var/obj/O in get_turf(src))
+		if(itemcount >= storage_capacity)
+			break
+		if(O.density || O.anchored || istype(O,/obj/structure/closet))
+			continue
+		if(istype(O, /obj/structure/stool/bed)) //This is only necessary because of rollerbeds and swivel chairs.
+			var/obj/structure/stool/bed/B = O
+			if(B.buckled_mob)
+				continue
+
+		if(isitem(O) && (O.pixel_x > max_x) || (O.pixel_x < min_x) || (O.pixel_y > max_y) || (O.pixel_y < min_y))
+			var/list/new_coords = get_box_and_section_intercection_coordinates_list_or_null(0, O.pixel_x, 0, O.pixel_y, min_x, max_x, min_y, max_y)
+			if(!isnull(new_coords))
+				O.pixel_x = ROUNDSTRICT(new_coords[1])
+				O.pixel_y = ROUNDSTRICT(new_coords[2])
+
+		O.forceMove(src)
+		itemcount++


### PR DESCRIPTION
## Описание изменений
При закрытии контейнера предметы "утрамбовываются", и при повторном открытии появляются в рамках "открытой области" контейнера.
Например, положил итем на крышку ящика. Итем смещен на крышку, при закрытии ящика, ящик найдёт точку пересечения вектора до итема и векторов сторон прямоугольника открытой области контейнера и переместит предмет на эти координаты ближе к центру контейнера.

## Почему и что этот ПР улучшит
Если накидывать тонну предметов на ящик, то при закрытии ящика можно утрамбовывать эти предметы и они больше не будут лежать на крышках и стенках ящика, что позволит удобнее кликать на ящик без пиксельхантинга.

## Авторство
AndreyGysev

## Чеинжлог
:cl: AndreyGysev
 - tweak: При закрытии контейнера предметы "утрамбовываются", и при повторном открытии появляются в рамках "открытой области" контейнера.