### PR TITLE
Добавил параметр silent для триторских стореджей.

### DIFF
--- a/code/game/objects/items/weapons/implants/storage.dm
+++ b/code/game/objects/items/weapons/implants/storage.dm
@@ -4,6 +4,7 @@
 	max_w_class = SIZE_SMALL
 	storage_slots = 2
 	cant_hold = list(/obj/item/weapon/disk/nuclear)
+	silent = TRUE
 
 /obj/item/weapon/implant/storage
 	name = "storage implant"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -28,7 +28,7 @@
 	S.opened = !S.opened
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/I, mob/user, params)
-	if(length(use_sound))
+	if(!silent && length(use_sound))
 		playsound(src, pick(use_sound), VOL_EFFECTS_MASTER, null, FALSE, null, -5)
 	return ..()
 
@@ -328,6 +328,8 @@
 	max_storage_space = DEFAULT_BACKPACK_STORAGE - 10
 	cant_hold = list(/obj/item/weapon/storage/backpack/satchel/flat) //muh recursive backpacks
 
+	silent = TRUE
+
 /obj/item/weapon/storage/backpack/satchel/flat/atom_init()
 	. = ..()
 	new /obj/item/stack/tile/plasteel(src)
@@ -343,6 +345,8 @@
 	item_state = "duffle-syndie"
 	origin_tech = "syndicate=1"
 	max_storage_space = DEFAULT_BACKPACK_STORAGE + 10
+
+	silent = TRUE
 
 /obj/item/weapon/storage/backpack/dufflebag/marinad
 	name = "marine dufflebag"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -751,6 +751,7 @@
 	name = "syndie box"
 	desc = "It's a red box with an 'S' on it. Strange."
 	icon_state = "syndie_box"
+	silent = TRUE
 
 /obj/item/weapon/storage/box/nanotrasenlogo_box
 	name = "NT box"

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -31,6 +31,9 @@
 	//the assoc value can either be the quantity, or a list whose first value is the quantity and the rest are args.
 	var/list/startswith
 
+	//allows for stealth item insertion
+	var/silent = FALSE
+
 /obj/item/weapon/storage/atom_init()
 	. = ..()
 	use_sound = SOUNDIN_RUSTLE
@@ -124,7 +127,7 @@
 		storage_ui.hide_from(user)
 
 /obj/item/weapon/storage/proc/open(mob/user)
-	if (length(use_sound))
+	if(!silent && length(use_sound))
 		playsound(src, pick(use_sound), VOL_EFFECTS_MASTER, null, FALSE, null, -5)
 
 	prepare_ui()
@@ -263,11 +266,14 @@
 
 		if(!(prevent_warning || istype(W, /obj/item/weapon/gun/energy/crossbow)))
 			//If someone is standing close enough or item is larger than TINY, they can tell what it is...
-			usr.visible_message(
-				"<span class='notice'>[usr] puts [W] into [src].</span>",
-				"<span class='notice'>You put \the [W] into [src].</span>",
-				viewing_distance = (W.w_class > SIZE_TINY ? world.view : 1)
-				)
+			if(silent)
+				to_chat(usr, "<span class='notice'>You silently put \the [W] into [src].</span>")
+			else
+				usr.visible_message(
+					"<span class='notice'>[usr] puts [W] into [src].</span>",
+					"<span class='notice'>You put \the [W] into [src].</span>",
+					viewing_distance = (W.w_class > SIZE_TINY ? world.view : 1)
+					)
 		if(crit_fail && prob(25))
 			remove_from_storage(W, get_turf(src))
 		if(!NoUpdate)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -101,6 +101,7 @@
 	item_state = "toolbox_syndi"
 	origin_tech = "combat=1;syndicate=1"
 	force = 7.0
+	silent = TRUE
 
 /obj/item/weapon/storage/toolbox/syndicate/atom_init()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/storage/box/syndicate
 	icon_state = "doom_box"
+	silent = TRUE
 
 /obj/item/weapon/storage/box/syndicate/atom_init()
 	. = ..()
@@ -105,6 +106,7 @@
 	name = "box"
 	desc = "A sleek, sturdy box."
 	icon_state = "doom_box"
+	silent = TRUE
 
 /obj/item/weapon/storage/box/syndie_kit/bonepen
 	name = "Prototype Bone Repair Kit"


### PR DESCRIPTION
## Описание изменений
Триторские контейнеры при открытии не издают звука и позволяют класть в них предметы без лога для окружающих.

## Почему и что этот ПР улучшит
Скрытное ношение и использование триторских контейнеров, например, имплантов стореджа.

## Авторство
AndreyGysev

## Чеинжлог
:cl: AndreyGysev
 - tweak: Триторские контейнеры при открытии не издают звука и позволяют класть в них предметы без лога для окружающих.