### PR TITLE
Сильные удары током заставляют людей случайно выкрикивать ключевые воспоминания.

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -280,3 +280,15 @@
 	blacklisted_species_traits = list(
 		TRAIT_NO_BLOOD,
 	)
+
+/datum/quirk/low_pain_threshold
+	name = QUIRK_LOW_PAIN_THRESHOLD
+	desc = "Ваш болевой порог понижен."
+	value = -1
+	mob_trait = TRAIT_LOW_PAIN_THRESHOLD
+	gain_text = "<span class='danger'>Вам страшно от одной лишь мысли о боли.</span>"
+	lose_text = "<span class='notice'>Вы больше не хотите выглядеть слабаком. Теперь вы пытаетесь терпеть боль.</span>"
+
+	blacklisted_species_traits = list(
+		TRAIT_NO_PAIN,
+	)

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -1,31 +1,3 @@
-/datum/quirk/high_pain_threshold
-	name = QUIRK_HIGH_PAIN_THRESHOLD
-	desc = "Ваш болевой порог повышен. Влияет только на издаваемые вами звуки."
-	value = 0
-	mob_trait = TRAIT_HIGH_PAIN_THRESHOLD
-	gain_text = "<span class='danger'>Вы хотите показать свою силу. Вы попытаетесь игнорировать любую боль.</span>"
-	lose_text = "<span class='notice'>Вы устали превозмогать боль.</span>"
-
-	blacklisted_species_traits = list(
-		TRAIT_NO_PAIN,
-	)
-
-
-
-/datum/quirk/low_pain_threshold
-	name = QUIRK_LOW_PAIN_THRESHOLD
-	desc = "Ваш болевой порог понижен. Влияет только на издаваемые вами звуки. "
-	value = 0
-	mob_trait = TRAIT_LOW_PAIN_THRESHOLD
-	gain_text = "<span class='danger'>Вам страшно от одной лишь мысли о боли.</span>"
-	lose_text = "<span class='notice'>Вы больше не хотите выглядеть слабаком. Теперь вы пытаетесь терпеть боль.</span>"
-
-	blacklisted_species_traits = list(
-		TRAIT_NO_PAIN,
-	)
-
-
-
 /datum/quirk/no_taste
 	name = QUIRK_AGEUSIA
 	desc = "Всё для вас одинаково пресно на вкус! Токсичная еда остаётся ядовитой для вас."

--- a/code/datums/quirks/positive.dm
+++ b/code/datums/quirks/positive.dm
@@ -135,3 +135,15 @@
 	mob_trait = TRAIT_FRIENDLY
 	gain_text = "<span class='notice'>Вы хотите кого-нибудь обнять.</span>"
 	lose_text = "<span class='danger'>Ваши объятия теперь мало радуют.</span>"
+
+/datum/quirk/high_pain_threshold
+	name = QUIRK_HIGH_PAIN_THRESHOLD
+	desc = "Ваш болевой порог повышен."
+	value = 1
+	mob_trait = TRAIT_HIGH_PAIN_THRESHOLD
+	gain_text = "<span class='danger'>Вы хотите показать свою силу. Вы попытаетесь игнорировать любую боль.</span>"
+	lose_text = "<span class='notice'>Вы устали превозмогать боль.</span>"
+
+	blacklisted_species_traits = list(
+		TRAIT_NO_PAIN,
+	)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -675,7 +675,7 @@
 		return
 	if(!can_remember())
 		return
-	if(reagents.has_reagent("endorphin"))
+	if(get_painkiller_effect() <= PAINKILLERS_EFFECT_MEDIUM)
 		return
 
 	var/probability = .

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -671,6 +671,18 @@
 			. = 0
 		electrocution_animation(4 SECONDS)
 
+	if(.)
+		if(!(can_remember() && prob(50))) //electrocuting people makes them randomly tell things they know
+			return
+
+		var/memory_key = pick(mind.key_memories)
+		var/memory = mind.get_key_memory(memory_key)
+
+		say("[memory]!")
+
+		if(prob(25))
+			mind.clear_key_memory(memory_key)
+
 /mob/living/carbon/human/Topic(href, href_list)
 	if(href_list["skill"])
 		update_skills(href_list)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -672,7 +672,7 @@
 		electrocution_animation(4 SECONDS)
 
 	if(.)
-		if(!(can_remember() && prob(50))) //electrocuting people makes them randomly tell things they know
+		if(!(can_remember() && prob(25))) //electrocuting people makes them randomly tell things they know
 			return
 
 		var/memory_key = pick(mind.key_memories)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -672,7 +672,7 @@
 		electrocution_animation(4 SECONDS)
 
 	if(.)
-		if(!(can_remember() && prob(25))) //electrocuting people makes them randomly tell things they know
+		if(!(can_remember() && prob(.))) //electrocuting people makes them randomly tell things they know
 			return
 
 		var/memory_key = pick(mind.key_memories)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -671,17 +671,20 @@
 			. = 0
 		electrocution_animation(4 SECONDS)
 
-	if(.)
-		if(!(can_remember() && prob(.))) //electrocuting people makes them randomly tell things they know
-			return
+	if(!.) //electrocuting people makes them randomly tell things they know
+		return
+	if(!can_remember())
+		return
+	if(!prob(.))
+		return
 
-		var/memory_key = pick(mind.key_memories)
-		var/memory = mind.get_key_memory(memory_key)
+	var/memory_key = pick(mind.key_memories)
+	var/memory = mind.get_key_memory(memory_key)
 
-		say("[memory]!")
+	say(stutter("[memory]!"))
 
-		if(prob(25))
-			mind.clear_key_memory(memory_key)
+	if(prob(25)) //sometimes they forget these things
+		mind.clear_key_memory(memory_key)
 
 /mob/living/carbon/human/Topic(href, href_list)
 	if(href_list["skill"])

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -675,7 +675,17 @@
 		return
 	if(!can_remember())
 		return
-	if(!prob(.))
+	if(reagents.has_reagent("endorphin"))
+		return
+
+	var/probability = .
+	if(HAS_TRAIT(src, TRAIT_LOW_PAIN_THRESHOLD))
+		probability += 25
+	if(HAS_TRAIT(src, TRAIT_HIGH_PAIN_THRESHOLD))
+		probability -= 25
+	probability = clamp(probability, 0, 100)
+
+	if(!prob(probability))
 		return
 
 	var/memory_key = pick(mind.key_memories)


### PR DESCRIPTION
## Описание изменений
Сильные удары током заставляют людей случайно выкрикивать ключевые воспоминания.

## Почему и что этот ПР улучшит
Пытки током на стуле психолога.

## Авторство
AndreyGysev

## Чеинжлог
:cl: AndreyGysev
 - rscadd: Сильные удары током заставляют людей случайно выкрикивать ключевые воспоминания.