### PR TITLE
fix: логи мехов теперь отображают московское время (MSK)

### DIFF
--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -157,7 +157,7 @@
 /obj/mecha/proc/get_log_html(client/user)
 	var/output = "<html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>[src.name] Log</title>[get_browse_zoom_style(user)]</head><body style='font: 13px 'Courier', monospace;'>"
 	for(var/list/entry in log)
-		output += {"<div style='font-weight: bold;'>[time2text(entry["time"],"DDD MMM DD hh:mm:ss")] [game_year]</div>
+		output += {"<div style='font-weight: bold;'>[time2text(entry["time"] + 3 HOURS,"DDD MMM DD hh:mm:ss")] [game_year]</div>
 						<div style='margin-left:15px; margin-bottom:10px;'>[entry["message"]]</div>
 						"}
 	output += "</body></html>"

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -157,7 +157,7 @@
 /obj/mecha/proc/get_log_html(client/user)
 	var/output = "<html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>[src.name] Log</title>[get_browse_zoom_style(user)]</head><body style='font: 13px 'Courier', monospace;'>"
 	for(var/list/entry in log)
-		output += {"<div style='font-weight: bold;'>[time2text(entry["time"] + 3 HOURS,"DDD MMM DD hh:mm:ss")] [game_year]</div>
+		output += {"<div style='font-weight: bold;'>[worldtime2text(entry["time"])] [game_year]</div>
 						<div style='margin-left:15px; margin-bottom:10px;'>[entry["message"]]</div>
 						"}
 	output += "</body></html>"


### PR DESCRIPTION
## Описание изменений
Исправлено отображение времени в логах мехов — теперь используется worldtime2text() для московского времени.

## Почему и что этот ПР улучшит
Русскоязычные игроки видят логи в московском времени вместо серверного.

## Авторство
Оригинальный PR.

## Чеинжлог
:cl:
- bugfix: Логи мехов теперь показывают московское время (MSK)
- Используется worldtime2text() вместо time2text()
:cl:

Closes #4959