### PR TITLE
Фикс линковки РнД консолей раундстартом

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -89,7 +89,7 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/computer/rdconsole, RDcomputer_list)
 	return return_name
 
 /obj/machinery/computer/rdconsole/proc/SyncRDevices() //Makes sure it is properly sync'ed up with the devices attached to it (if any).
-	for(var/obj/machinery/r_n_d/D in oview(3,src))
+	for(var/obj/machinery/r_n_d/D in orange(3,src))
 		if(D.linked_console != null || D.disabled || D.panel_open)
 			continue
 		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer))

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -34,7 +34,7 @@
 	actions += scan_action
 	actions += hotkey_help
 
-	for(var/obj/machinery/monkey_recycler/recycler in oview(7,src))
+	for(var/obj/machinery/monkey_recycler/recycler in orange(7,src))
 		if(get_area(recycler) == get_area(loc))
 			connected_recycler = recycler
 			connected_recycler.connected_consoles += src


### PR DESCRIPTION
## Описание изменений
Консоли в РнД снова привязаны к машинерии раундстартом, а конкретно консоль РнД, консоль роботеха и консоль ксенобиолога.

## Почему и что этот ПР улучшит
Меньше багов

## Авторство

## Чеинжлог

:cl:
 - bugfix: Фикс линковки РнД консолей к машинерии.
