### PR TITLE
Блюспейс мешок может собирать мусор переработчиков

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -114,7 +114,7 @@
 	icon_state = "bluetrashbag"
 	item_state_world = "bluetrashbag_world"
 	max_storage_space = 56
-	var/allow_gathering_scrap = 0
+	var/allow_gathering_scrap = FALSE
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_gathering_scrap)
 
 /obj/item/weapon/storage/bag/trash/bluespace/atom_init()
@@ -127,17 +127,16 @@
 
 	allow_gathering_scrap = !allow_gathering_scrap
 	quick_empty()
-	switch (allow_gathering_scrap)
-		if(1)
-			max_w_class = SIZE_NORMAL
-			can_hold = list(/obj/item/weapon/scrap_lump)
-			max_storage_space = 240
-			to_chat(usr, "[src] now picks up only scrap lumps.")
-		if(0)
-			max_w_class = initial(max_w_class)
-			can_hold = list()
-			max_storage_space = initial(max_storage_space)
-			to_chat(usr, "[src] now picks up all items, except scrap lumps.")
+	if (allow_gathering_scrap)
+		max_w_class = SIZE_NORMAL
+		can_hold = list(/obj/item/weapon/scrap_lump)
+		max_storage_space = 240
+		to_chat(usr, "[src] now picks up only scrap lumps.")
+	else
+		max_w_class = initial(max_w_class)
+		can_hold = list()
+		max_storage_space = initial(max_storage_space)
+		to_chat(usr, "[src] now picks up all items, except scrap lumps.")
 
 /datum/action/item_action/hands_free/toggle_gathering_scrap
 	name = "Switch Gathering to Scrap Only"

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -114,7 +114,37 @@
 	icon_state = "bluetrashbag"
 	item_state_world = "bluetrashbag_world"
 	max_storage_space = 56
+	var/allow_gathering_scrap = 0
+	item_action_types = list(/datum/action/item_action/hands_free/toggle_gathering_scrap)
 
+/obj/item/weapon/storage/bag/trash/bluespace/atom_init()
+	. = ..()
+	verbs += /obj/item/weapon/storage/bag/trash/bluespace/proc/switch_gathering_scrap
+
+/obj/item/weapon/storage/bag/trash/bluespace/proc/switch_gathering_scrap()
+	set name = "Switch Gathering to Scrap Only"
+	set category = "Object"
+
+	allow_gathering_scrap = !allow_gathering_scrap
+	quick_empty()
+	switch (allow_gathering_scrap)
+		if(1)
+			max_w_class = SIZE_NORMAL
+			can_hold = list(/obj/item/weapon/scrap_lump)
+			max_storage_space = 240
+			to_chat(usr, "[src] now picks up only scrap lumps.")
+		if(0)
+			max_w_class = initial(max_w_class)
+			can_hold = list()
+			max_storage_space = initial(max_storage_space)
+			to_chat(usr, "[src] now picks up all items, except scrap lumps.")
+
+/datum/action/item_action/hands_free/toggle_gathering_scrap
+	name = "Switch Gathering to Scrap Only"
+
+/datum/action/item_action/hands_free/toggle_gathering_scrap/Activate()
+	var/obj/item/weapon/storage/bag/trash/bluespace/S = target
+	S.switch_gathering_scrap()
 
 // -----------------------------
 //        Plastic Bag


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Блюспейс мешок теперь может собирать мусор, который у переработчиков, до этого он был бесполезен для переработчиков.
Для этого добавлен verb у блюспейс мешка, а так же экшн кнопка на переключения режимов сбора:
1) Старый режим, в мешок влезают SIZE_SMALL предметы, мусор не влезает (у него размер SIZE_NORMAL)
2) Новый режим, как у industrial trash bag, собирает только scrap lump(он же undefined scrap), но емкость в двое больше

## Почему и что этот ПР улучшит
Блюспейс мешок будет полезен для переработчиков.

## Авторство
Моё

## Чеинжлог

:cl:
 - add: Добавлен режим сбора мусора у trash bag of holding
