### PR TITLE
фикс нанесения урона от взрывов

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -263,8 +263,8 @@
 
 	for(var/i in 1 to 3)
 		var/obj/item/organ/external/BP = pick(bodyparts)
-		apply_damage(b_loss * rand(0.25, 1), BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
-		apply_damage(f_loss * rand(0.25, 1), BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+		apply_damage(b_loss * rand(25, 100) * 0.01, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+		apply_damage(f_loss * rand(25, 100) * 0.01, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
 
 	// minor "behind the armor" damage from the blast wave across the entire body
 	b_loss *= 0.25


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
я забыл что rand не очень хорошо работает с дробями
теперь урон от взрыва должен корректно рандомиться
## Почему и что этот ПР улучшит
фикс
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
я думаю никто не заметит изменений...
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
