### PR TITLE
Блюспейс мешок может собирать мусор у переработчиков

### DIFF
--- a/code/modules/scrap/scrap_refine.dm
+++ b/code/modules/scrap/scrap_refine.dm
@@ -31,7 +31,7 @@
 	desc = "This thing is messed up beyond any recognition. Into the grinder it goes!"
 	icon = 'icons/obj/structures/scrap/refine.dmi'
 	icon_state = "unrefined"
-	w_class = SIZE_NORMAL
+	w_class = SIZE_TINY
 
 /obj/item/weapon/scrap_lump/atom_init()
 	. = ..()

--- a/code/modules/scrap/scrap_tools.dm
+++ b/code/modules/scrap/scrap_tools.dm
@@ -6,7 +6,7 @@
 	item_state = "trashbag"
 	color = "red"
 
-	max_storage_space = 120
+	max_storage_space = 30
 	max_w_class = SIZE_NORMAL
 	can_hold = list(/obj/item/weapon/scrap_lump)
 	cant_hold = list()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Блюспейс мешок теперь может собирать мусор, который у переработчиков, до этого он был бесполезен для переработчиков.

## Почему и что этот ПР улучшит
Блюспейс мешок будет полезен для переработчиков.

## Авторство
Моё

## Чеинжлог
:cl:
 - add: Блюспейс мешок может собирать мусор у переработчиков

