### PR TITLE
Снижена цена оружия в карго при аспекте на перевооружение

### DIFF
--- a/code/datums/round_aspects/round_aspects.dm
+++ b/code/datums/round_aspects/round_aspects.dm
@@ -56,7 +56,7 @@
 			smg.materials[M] *= 5
 
 	for(var/datum/supply_pack/ballistic/b in global.all_supply_pack)
-		b.cost *= 50
+		b.cost *= 5
 
 	new /datum/event/feature/area/replace/station_rearmament_energy
 
@@ -85,7 +85,7 @@
 			plsmsh.materials[M] *= 5
 
 	for(var/datum/supply_pack/energy/e in global.all_supply_pack)
-		e.cost *= 50
+		e.cost *= 5
 
 	new /datum/event/feature/area/replace/station_rearmament_bullets
 
@@ -134,10 +134,10 @@
 			plsmsh.materials[M] *= 5
 
 	for(var/datum/supply_pack/energy/e in global.all_supply_pack)
-		e.cost *= 50
+		e.cost *= 5
 
 	for(var/datum/supply_pack/ballistic/b in global.all_supply_pack)
-		b.cost *= 50
+		b.cost *= 5
 
 	new /datum/event/feature/area/replace/sec_rearmament_elite
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Сейчас с аспектами на перевооружение цены на оружие в карго ставятся x50, при этом стоимость в ресурсах на производство в РнД всего x5. В итоге карго не может купить ни одного ящика оружия из-за абсурдных цен от 60000 до 100000 за ящик, в то время как РнД может продолжать клепать оружие, поэтому множитель цен снижен.

## Почему и что этот ПР улучшит
Баланс, при аспекте на перевооружение можно будет заказать оружие, пусть и в меньших объемах, как и задумано аспектом.

## Авторство
Моё

## Чеинжлог
:cl:
 - balance: Снижена цена оружия в карго при аспекте на перевооружение