### PR TITLE
Шлемы ригов снова плавятся

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -15,7 +15,7 @@
 	var/obj/item/clothing/suit/space/rig/rig_connect
 	can_be_modded = TRUE
 
-	unacidable = TRUE //all helmets on rigs can be acidable
+	unacidable = FALSE //all helmets on rigs can be acidable
 
 	//Species-specific stuff.
 	species_restricted = list("exclude", UNATHI, TAJARAN, SKRELL, DIONA, VOX)
@@ -50,6 +50,11 @@
 
 	if(on)	set_light(brightness_on)
 	else	set_light(0)
+
+/obj/item/clothing/head/helmet/space/rig/Destroy()
+	if(rig_connect)
+		rig_connect.helmet = null
+	. = ..()
 
 /obj/item/clothing/suit/space/rig
 	name = "hardsuit"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
По какой-то причине с приходом новых шкафов для ригов шлемы перестали плавится кислотой. Теперь шлемы ригов снова плавятся.
## Почему и что этот ПР улучшит
Make Polytrinic great again
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог

:cl:
 - balance: Шлемы ригов снова плавятся кислотой.

