### PR TITLE
fix noslip sole

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -62,9 +62,6 @@
 #define SLOT_EARS          22 // Used in obscured checks
 #define SLOT_NECK          23
 
-#define ADD_CLOTHING_TRAIT(mob, trait) ADD_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[REF(src)]")
-#define REMOVE_CLOTHING_TRAIT(mob, trait) REMOVE_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[REF(src)]")
-
 //sprite sheet slot types(as also seen in update_icon.dm)
 #define SPRITE_SHEET_HELD "held"
 #define SPRITE_SHEET_UNIFORM "uniform"

--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -62,6 +62,9 @@
 #define SLOT_EARS          22 // Used in obscured checks
 #define SLOT_NECK          23
 
+#define ADD_CLOTHING_TRAIT(mob, trait) ADD_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[REF(src)]")
+#define REMOVE_CLOTHING_TRAIT(mob, trait) REMOVE_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[REF(src)]")
+
 //sprite sheet slot types(as also seen in update_icon.dm)
 #define SPRITE_SHEET_HELD "held"
 #define SPRITE_SHEET_UNIFORM "uniform"

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -45,8 +45,6 @@ var/global/list/bitflags = list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 
 #define IS_SPINNING            (1<<17)  // Is the thing currently spinning?
 
-#define NOSLIP                 (1<<18)   // Prevents from slipping on wet floors, in space etc.
-
 #define AIR_FLOW_PROTECT       (1<<19)   //  Protects against air flow.
 
 #define NOATTACKANIMATION      (1<<20)   // Removes attack animation

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -280,7 +280,6 @@
 
 // idk why this exists on TG
 #define GENERIC_TRAIT "generic"
-#define CLOTHING_TRAIT "clothing"
 // common trait sources
 #define ROUNDSTART_TRAIT   "roundstart" //cannot be removed without admin intervention
 #define QUALITY_TRAIT      "quality"
@@ -305,6 +304,7 @@
 
 // trait sources
 #define TRAIT_FROM_ELEMENT(source) "element_trait_[source]"
+#define TRAIT_FROM_CLOTHING(source) "clothing_[REF(source)]"
 #define INNATE_TRAIT "innate"
 #define ADMIN_TRAIT "admin"
 #define EYE_DAMAGE_TRAIT "eye_damage"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -172,6 +172,7 @@
 #define TRAIT_AGEUSIA             "ageusia"
 #define TRAIT_DALTONISM           "daltonism"
 #define TRAIT_NO_RUN              "no_run"
+#define TRAIT_NOSLIP              "noslip"
 #define TRAIT_FAST_EQUIP          "fast_equip"
 #define TRAIT_FRIENDLY            "friendly"
 #define TRAIT_VACCINATED          "vaccinated"
@@ -279,6 +280,7 @@
 
 // idk why this exists on TG
 #define GENERIC_TRAIT "generic"
+#define CLOTHING_TRAIT "clothing"
 // common trait sources
 #define ROUNDSTART_TRAIT   "roundstart" //cannot be removed without admin intervention
 #define QUALITY_TRAIT      "quality"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -491,9 +491,7 @@ var/global/list/ghostteleportlocs = list()
 
 	if(ishuman(mob))  // Only humans can wear magboots, so we give them a chance to.
 		var/mob/living/carbon/human/H = mob
-		if((istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.flags & NOSLIP)))
-			return
-		if((istype(H.wear_suit, /obj/item/clothing/suit/space/rig) && (H.wear_suit.flags & NOSLIP))) //Humans in rig with turn on magboots
+		if(H.mob_negates_gravity())
 			return
 
 		if(H.m_intent == "run")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -595,12 +595,7 @@
 			new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 4), 1, FALSE, CALLBACK(C, TYPE_PROC_REF(/mob/living/carbon, spin), 1, 1))
 			C.take_bodypart_damage(2) // Was 5 -- TLE
 		else if(lube & SLIDE_ICE)
-			var/has_NOSLIP = FALSE
-			if(ishuman(C))
-				var/mob/living/carbon/human/H = C
-				if((istype(H.shoes, /obj/item/clothing/shoes) && H.shoes.flags & NOSLIP) || (istype(H.wear_suit, /obj/item/clothing/suit/space/rig) && H.wear_suit.flags & NOSLIP))
-					has_NOSLIP = TRUE
-			if (C.m_intent == MOVE_INTENT_RUN && !has_NOSLIP && prob(30))
+			if (C.m_intent == MOVE_INTENT_RUN && !HAS_TRAIT(C, TRAIT_NOSLIP) && prob(30))
 				if(C.force_moving) //If we're already slipping extend it
 					qdel(C.force_moving)
 				new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 1), 1, FALSE)	//spinning would be bad for ice, fucks up the next dir

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_items.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_items.dm
@@ -35,7 +35,8 @@
 	desc = "Charred-looking feet. They have minature hooks that latch onto flooring."
 	icon_state = "shadowling_shoes"
 	unacidable = 1
-	flags = NOSLIP | ABSTRACT | DROPDEL
+	flags = ABSTRACT | DROPDEL
+	clothing_traits = list(TRAIT_NOSLIP)
 	canremove = 0
 
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -40,12 +40,12 @@
 	if(!is_worn_slot(user, slot))
 		return
 	for(var/trait in clothing_traits)
-		ADD_CLOTHING_TRAIT(user, trait)
+		ADD_TRAIT(user, trait, TRAIT_FROM_CLOTHING(src))
 
 /obj/item/clothing/dropped(mob/user)
 	if(ismob(user))
 		for(var/trait in clothing_traits)
-			REMOVE_CLOTHING_TRAIT(user, trait)
+			REMOVE_TRAIT(user, trait, TRAIT_FROM_CLOTHING(src))
 	return ..()
 
 /obj/item/clothing/proc/is_worn_slot(mob/wearer, slot)
@@ -68,7 +68,7 @@
 	if(!istype(wearer) || !is_worn_slot(wearer, slot_equipped))
 		return
 	for(var/trait in trait_or_traits)
-		ADD_CLOTHING_TRAIT(wearer, trait)
+		ADD_TRAIT(wearer, trait, TRAIT_FROM_CLOTHING(src))
 
 /obj/item/clothing/proc/detach_clothing_traits(trait_or_traits)
 	if(!islist(trait_or_traits))
@@ -79,7 +79,7 @@
 	if(!istype(wearer) || !is_worn_slot(wearer, slot_equipped))
 		return
 	for(var/trait in trait_or_traits)
-		REMOVE_CLOTHING_TRAIT(wearer, trait)
+		REMOVE_TRAIT(wearer, trait, TRAIT_FROM_CLOTHING(src))
 
 //BS12: Species-restricted clothing check.
 /obj/item/clothing/mob_can_equip(M, slot)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -7,6 +7,7 @@
 	var/gang //Is this a gang outfit?
 	var/species_restricted_locked = FALSE
 	var/list/potentially_protected_organs = list() //These organs can be protected by armor if it has high protective properties
+	var/list/clothing_traits
 
 	/*
 		Sprites used when the clothing item is refit. This is done by setting icon_override.
@@ -33,6 +34,52 @@
 	. = ..()
 	if(body_parts_covered & UPPER_TORSO)
 		potentially_protected_organs |= O_HEART
+
+/obj/item/clothing/equipped(mob/user, slot)
+	. = ..()
+	if(!is_worn_slot(user, slot))
+		return
+	for(var/trait in clothing_traits)
+		ADD_CLOTHING_TRAIT(user, trait)
+
+/obj/item/clothing/dropped(mob/user)
+	if(ismob(user))
+		for(var/trait in clothing_traits)
+			REMOVE_CLOTHING_TRAIT(user, trait)
+	return ..()
+
+/obj/item/clothing/proc/is_worn_slot(mob/wearer, slot)
+	if(isIAN(wearer))
+		switch(slot)
+			if(SLOT_BACK, SLOT_IAN_NECK, SLOT_HEAD)
+				return TRUE
+		return FALSE
+	switch(slot)
+		if(SLOT_BACK, SLOT_WEAR_MASK, SLOT_NECK, SLOT_BELT, SLOT_WEAR_ID, SLOT_L_EAR, SLOT_R_EAR, SLOT_GLASSES, SLOT_GLOVES, SLOT_HEAD, SLOT_SHOES, SLOT_WEAR_SUIT, SLOT_W_UNIFORM)
+			return TRUE
+	return FALSE
+
+/obj/item/clothing/proc/attach_clothing_traits(trait_or_traits)
+	if(!islist(trait_or_traits))
+		trait_or_traits = list(trait_or_traits)
+	clothing_traits = LAZYCOPY(clothing_traits)
+	LAZYDISTINCTADD(clothing_traits, trait_or_traits)
+	var/mob/wearer = loc
+	if(!istype(wearer) || !is_worn_slot(wearer, slot_equipped))
+		return
+	for(var/trait in trait_or_traits)
+		ADD_CLOTHING_TRAIT(wearer, trait)
+
+/obj/item/clothing/proc/detach_clothing_traits(trait_or_traits)
+	if(!islist(trait_or_traits))
+		trait_or_traits = list(trait_or_traits)
+	clothing_traits = LAZYCOPY(clothing_traits)
+	LAZYREMOVE(clothing_traits, trait_or_traits)
+	var/mob/wearer = loc
+	if(!istype(wearer) || !is_worn_slot(wearer, slot_equipped))
+		return
+	for(var/trait in trait_or_traits)
+		REMOVE_CLOTHING_TRAIT(wearer, trait)
 
 //BS12: Species-restricted clothing check.
 /obj/item/clothing/mob_can_equip(M, slot)

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -58,7 +58,7 @@
 	name = "galoshes"
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
-	flags = NOSLIP
+	clothing_traits = list(TRAIT_NOSLIP)
 	can_get_wet = FALSE
 	slowdown = SHOES_SLOWDOWN + 0.5
 	species_restricted = null
@@ -73,14 +73,14 @@
 	name = "SWAT shoes"
 	desc = "When you want to turn up the heat."
 	icon_state = "swat"
-	flags = NOSLIP
+	clothing_traits = list(TRAIT_NOSLIP)
 	siemens_coefficient = 0.6
 
 /obj/item/clothing/shoes/boots/combat //Basically SWAT shoes combined with galoshes.
 	name = "combat boots"
 	desc = "When you REALLY want to turn up the heat"
 	icon_state = "swat"
-	flags = NOSLIP
+	clothing_traits = list(TRAIT_NOSLIP)
 	siemens_coefficient = 0.6
 
 	cold_protection = LEGS

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -8,7 +8,6 @@
 	var/magboot_state = "magboots"
 	var/slowdown_off = 2
 	origin_tech = "materials=3;magnets=4;engineering=4"
-//	flags = NOSLIP //disabled by default
 	item_action_types = list(/datum/action/item_action/hands_free/toggle_magboots)
 
 /datum/action/item_action/hands_free/toggle_magboots
@@ -18,7 +17,8 @@
 	if(user.is_busy() || !do_after(user, 0.8 SECONDS, target = src))
 		return
 	if(magpulse)
-		flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
+		detach_clothing_traits(TRAIT_NOSLIP)
+		flags &= ~AIR_FLOW_PROTECT
 		slowdown = SHOES_SLOWDOWN
 		magpulse = 0
 		playsound(src, 'sound/effects/magb4.ogg', VOL_EFFECTS_MASTER, 100)
@@ -27,7 +27,8 @@
 		item_state_inventory = "[magboot_state]0"
 		to_chat(user, "You disable the mag-pulse traction system.")
 	else
-		flags |= NOSLIP | AIR_FLOW_PROTECT
+		attach_clothing_traits(TRAIT_NOSLIP)
+		flags |= AIR_FLOW_PROTECT
 		slowdown = slowdown_off
 		magpulse = 1
 		playsound(src, pick(SOUNDIN_MAGBOOTS_TOGGLE), VOL_EFFECTS_MASTER, 100)
@@ -42,10 +43,8 @@
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	..()
-	var/state = "disabled"
-	if(src.flags & (NOSLIP | AIR_FLOW_PROTECT))
-		state = "enabled"
+	var/state = magpulse ? "enabled" : "disabled"
 	to_chat(user, "Its mag-pulse traction system appears to be [state].")
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
-	return flags & NOSLIP
+	return magpulse

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -4,7 +4,7 @@
 	icon_state = "brown"
 	item_state = "brown"
 	permeability_coefficient = 0.05
-	flags = NOSLIP
+	clothing_traits = list(TRAIT_NOSLIP)
 	origin_tech = "syndicate=3"
 	var/list/clothing_choices = list()
 	siemens_coefficient = 0.8
@@ -18,7 +18,8 @@
 	desc = "A pair of running shoes. Excellent for running and even better for smashing skulls."
 	icon_state = "s-ninja"
 	permeability_coefficient = 0.01
-	flags = NOSLIP | AIR_FLOW_PROTECT
+	flags = AIR_FLOW_PROTECT
+	clothing_traits = list(TRAIT_NOSLIP)
 	siemens_coefficient = 0.2
 
 	cold_protection = LEGS
@@ -168,7 +169,7 @@
 	desc = "Help you swim good."
 	name = "swimming fins"
 	icon_state = "flippers"
-	flags = NOSLIP
+	clothing_traits = list(TRAIT_NOSLIP)
 	slowdown = SHOES_SLOWDOWN+0.5
 
 /obj/item/clothing/shoes/centcom
@@ -218,14 +219,14 @@
 /obj/item/clothing/shoes/boots/nt_pmc_boots
 	name = "NT PMC Boots"
 	desc = "Private security boots. Now with extra grip."
-	flags = NOSLIP
+	clothing_traits = list(TRAIT_NOSLIP)
 	icon_state = "nt_pmc_boots"
 	item_state = "r_feet"
 
 /obj/item/clothing/shoes/boots/lizard_boots
 	name = "Lizard Boots"
 	desc = "Private security boots for Unathi."
-	flags = NOSLIP
+	clothing_traits = list(TRAIT_NOSLIP)
 	icon_state = "Lizard_Boots"
 	item_state = "r_feet"
 	species_restricted = list(UNATHI)

--- a/code/modules/clothing/shoes/noslip_sole.dm
+++ b/code/modules/clothing/shoes/noslip_sole.dm
@@ -10,24 +10,35 @@
 	if(istype(S, /obj/item/clothing/shoes/magboots))
 		to_chat(user, "<span class='warning'>The soles won't fit over the magnetic boots.</span>")
 		return FALSE
+	if(S.flags & NOSLIP)
+		to_chat(user, "<span class='warning'>\The [S] already have good grip.</span>")
+		return FALSE
 	if(locate(/obj/item/noslip_sole) in S)
 		to_chat(user, "<span class='warning'>\The [S] already have soles attached.</span>")
 		return FALSE
 	return TRUE
 
-/obj/item/noslip_sole/afterattack(atom/target, mob/user, proximity, params)
-	. = ..()
-	if(!proximity || !istype(target, /obj/item/clothing/shoes))
-		return
-	var/obj/item/clothing/shoes/S = target
-	if(!can_attach_to(S, user))
-		return
-	S.AddElement(/datum/element/noslip_sole, src)
-	to_chat(user, "<span class='notice'>You fit \the [src] onto \the [S].</span>")
-	playsound(S, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 25)
+/obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
+	if(!istype(I, /obj/item/noslip_sole))
+		return ..()
+	var/obj/item/noslip_sole/sole = I
+	if(!sole.can_attach_to(src, user))
+		return TRUE
+	user.drop_from_inventory(sole, src)
+	AddElement(/datum/element/noslip_sole, sole)
+	to_chat(user, "<span class='notice'>You fit \the [sole] onto \the [src].</span>")
+	playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 25)
+	return TRUE
 
-// The sole obj hides inside the shoe; this element just grants NOSLIP and wires alt-click to pry it
-// back off, so the shoe carries no sole-specific code or state of its own.
+/obj/item/clothing/shoes/AltClick(mob/user)
+	var/obj/item/noslip_sole/sole = locate() in src
+	if(!sole || !Adjacent(user) || user.incapacitated())
+		return ..()
+	RemoveElement(/datum/element/noslip_sole)
+	user.put_in_hands(sole)
+	to_chat(user, "<span class='notice'>You pry \the [sole] off \the [src].</span>")
+	return
+
 /datum/element/noslip_sole
 	element_flags = ELEMENT_DETACH
 
@@ -38,23 +49,7 @@
 	var/obj/item/clothing/shoes/S = target
 	sole.forceMove(S)
 	S.flags |= NOSLIP
-	RegisterSignal(S, COMSIG_ATOM_ALTCLICK, PROC_REF(on_altclick))
 
 /datum/element/noslip_sole/Detach(obj/item/clothing/shoes/S)
 	. = ..()
 	S.flags &= ~NOSLIP
-	UnregisterSignal(S, COMSIG_ATOM_ALTCLICK)
-
-/datum/element/noslip_sole/proc/on_altclick(obj/item/clothing/shoes/S, mob/user)
-	SIGNAL_HANDLER
-	if(!user.Adjacent(S))
-		return
-	if(user.incapacitated())
-		return
-	var/obj/item/noslip_sole/sole = locate() in S
-	if(!sole)
-		return
-	user.put_in_hands(sole)
-	to_chat(user, "<span class='notice'>You pry \the [sole] off \the [S].</span>")
-	S.RemoveElement(/datum/element/noslip_sole)
-	return COMPONENT_CANCEL_ALTCLICK

--- a/code/modules/clothing/shoes/noslip_sole.dm
+++ b/code/modules/clothing/shoes/noslip_sole.dm
@@ -10,7 +10,7 @@
 	if(istype(S, /obj/item/clothing/shoes/magboots))
 		to_chat(user, "<span class='warning'>The soles won't fit over the magnetic boots.</span>")
 		return FALSE
-	if(S.flags & NOSLIP)
+	if(S.clothing_traits && (TRAIT_NOSLIP in S.clothing_traits))
 		to_chat(user, "<span class='warning'>\The [S] already have good grip.</span>")
 		return FALSE
 	if(locate(/obj/item/noslip_sole) in S)
@@ -25,7 +25,7 @@
 	if(!sole.can_attach_to(src, user))
 		return TRUE
 	user.drop_from_inventory(sole, src)
-	AddElement(/datum/element/noslip_sole, sole)
+	attach_clothing_traits(TRAIT_NOSLIP)
 	to_chat(user, "<span class='notice'>You fit \the [sole] onto \the [src].</span>")
 	playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 25)
 	return TRUE
@@ -34,22 +34,13 @@
 	var/obj/item/noslip_sole/sole = locate() in src
 	if(!sole || !Adjacent(user) || user.incapacitated())
 		return ..()
-	RemoveElement(/datum/element/noslip_sole)
+	detach_clothing_traits(TRAIT_NOSLIP)
 	user.put_in_hands(sole)
 	to_chat(user, "<span class='notice'>You pry \the [sole] off \the [src].</span>")
 	return
 
-/datum/element/noslip_sole
-	element_flags = ELEMENT_DETACH
-
-/datum/element/noslip_sole/Attach(datum/target, obj/item/noslip_sole/sole)
-	if(!istype(target, /obj/item/clothing/shoes) || !istype(sole))
-		return ELEMENT_INCOMPATIBLE
-	. = ..()
-	var/obj/item/clothing/shoes/S = target
-	sole.forceMove(S)
-	S.flags |= NOSLIP
-
-/datum/element/noslip_sole/Detach(obj/item/clothing/shoes/S)
-	. = ..()
-	S.flags &= ~NOSLIP
+/obj/item/noslip_sole/Destroy()
+	var/obj/item/clothing/shoes/S = loc
+	if(istype(S))
+		S.detach_clothing_traits(TRAIT_NOSLIP)
+	return ..()

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -415,7 +415,8 @@
 
 /obj/item/clothing/shoes/magboots/vox/attack_self(mob/user)
 	if(src.magpulse)
-		flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
+		detach_clothing_traits(TRAIT_NOSLIP)
+		flags &= ~AIR_FLOW_PROTECT
 		magpulse = 0
 		canremove = 1
 		to_chat(user, "You relax your deathgrip on the flooring.")
@@ -429,7 +430,8 @@
 			return
 
 
-		flags |= NOSLIP | AIR_FLOW_PROTECT
+		attach_clothing_traits(TRAIT_NOSLIP)
+		flags |= AIR_FLOW_PROTECT
 		magpulse = 1
 		canremove = 0	//kinda hard to take off magclaws when you are gripping them tightly.
 		to_chat(user, "You dig your claws deeply into the flooring, bracing yourself.")
@@ -440,7 +442,8 @@
 	..()
 	if(src.magpulse)
 		user.visible_message("The [src] go limp as they are removed from [usr]'s feet.", "The [src] go limp as they are removed from your feet.")
-		flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
+		detach_clothing_traits(TRAIT_NOSLIP)
+		flags &= ~AIR_FLOW_PROTECT
 		magpulse = 0
 		canremove = 1
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -489,21 +489,23 @@
 	H.update_gravity(H.mob_has_gravity())
 
 /obj/item/clothing/suit/space/rig/proc/enable_magpulse(mob/user)
-		flags |= NOSLIP | AIR_FLOW_PROTECT
+		attach_clothing_traits(TRAIT_NOSLIP)
+		flags |= AIR_FLOW_PROTECT
 		slowdown += boots.slowdown_off
 		magpulse = TRUE
 		to_chat(user, "You enable \the [src] the mag-pulse traction system.")
 		playsound(src, pick(SOUNDIN_MAGBOOTS_TOGGLE), VOL_EFFECTS_MASTER, 100)
 
 /obj/item/clothing/suit/space/rig/proc/disable_magpulse(mob/user)
-		flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
+		detach_clothing_traits(TRAIT_NOSLIP)
+		flags &= ~AIR_FLOW_PROTECT
 		slowdown = initial(slowdown)
 		magpulse = FALSE
 		to_chat(user, "You disable \the [src] the mag-pulse traction system.")
 		playsound(src, 'sound/effects/magb4.ogg', VOL_EFFECTS_MASTER, 100)
 
 /obj/item/clothing/suit/space/rig/negates_gravity()
-	return flags & NOSLIP
+	return magpulse
 
 /obj/item/clothing/suit/space/rig/examine(mob/user)
 	..()
@@ -940,7 +942,8 @@
 		update_item_actions()
 
 /obj/item/clothing/suit/space/rig/syndi/disable_magpulse(mob/user)
-	flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
+	detach_clothing_traits(TRAIT_NOSLIP)
+	flags &= ~AIR_FLOW_PROTECT
 	if(combat_mode)
 		slowdown = combat_slowdown
 	else

--- a/code/modules/europa/fluids/fluid_mob.dm
+++ b/code/modules/europa/fluids/fluid_mob.dm
@@ -17,9 +17,7 @@
 		if(C.m_intent == "run" && !C.buckled)
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C
-				if(istype(H.shoes, /obj/item/clothing/shoes) && H.shoes.flags & NOSLIP)
-					return
-				if(istype(H.wear_suit, /obj/item/clothing/suit/space/rig) && H.wear_suit.flags & NOSLIP)
+				if(HAS_TRAIT(H, TRAIT_NOSLIP))
 					return
 				var/list/inv_contents = list()
 				for(var/obj/item/I in H.contents)
@@ -116,11 +114,7 @@
 		var/power_calculated = power
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			if(istype(H.shoes, /obj/item/clothing/shoes) && H.shoes.flags & NOSLIP)
-				power_calculated = 0
-				continue
-
-			if(istype(H.wear_suit, /obj/item/clothing/suit/space/rig) && (H.wear_suit.flags & NOSLIP))
+			if(HAS_TRAIT(H, TRAIT_NOSLIP))
 				power_calculated = 0
 				continue
 

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -596,7 +596,8 @@
 	icon_state = "golem"
 	item_state = null
 	canremove = 0
-	flags = ABSTRACT | DROPDEL | NOSLIP | AIR_FLOW_PROTECT
+	flags = ABSTRACT | DROPDEL | AIR_FLOW_PROTECT
+	clothing_traits = list(TRAIT_NOSLIP)
 	unacidable = 1
 
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -392,7 +392,7 @@
 	if(species.flags[NO_SLIP])
 		return FALSE
 	if(!(lube & GALOSHES_DONT_HELP))
-		if((shoes && (shoes.flags & NOSLIP)) || (wear_suit && (wear_suit.flags & NOSLIP) || (get_species() == SKRELL && !shoes)))
+		if(HAS_TRAIT(src, TRAIT_NOSLIP) || (get_species() == SKRELL && !shoes))
 			return FALSE
 	return ..()
 

--- a/code/unit_tests/clothing_traits_tests.dm
+++ b/code/unit_tests/clothing_traits_tests.dm
@@ -1,0 +1,64 @@
+/datum/unit_test/clothing_traits_noslip_sources
+	name = "CLOTHING TRAITS: noslip sources follow equipped clothing"
+
+/datum/unit_test/clothing_traits_noslip_sources/start_test()
+	var/turf/T = locate(1, 1, 1)
+	var/mob/living/carbon/human/H = new(T)
+	var/obj/item/clothing/shoes/shoes = new(H)
+	H.equip_to_slot_or_del(shoes, SLOT_SHOES)
+	if(HAS_TRAIT(H, TRAIT_NOSLIP))
+		qdel(H)
+		fail("Plain shoes granted noslip before soles were attached")
+		return TRUE
+
+	var/obj/item/noslip_sole/sole = new(H)
+	H.put_in_hands(sole)
+	shoes.attackby(sole, H)
+	if(sole.loc != shoes || !HAS_TRAIT(H, TRAIT_NOSLIP))
+		qdel(H)
+		fail("Attached soles did not grant noslip to the wearer")
+		return TRUE
+
+	var/obj/item/clothing/suit/suit = new(H)
+	suit.attach_clothing_traits(TRAIT_NOSLIP)
+	H.equip_to_slot_or_del(suit, SLOT_WEAR_SUIT)
+	shoes.AltClick(H)
+	if(!HAS_TRAIT(H, TRAIT_NOSLIP))
+		qdel(H)
+		fail("Removing one clothing source removed another source's noslip trait")
+		return TRUE
+
+	H.drop_from_inventory(suit)
+	if(HAS_TRAIT(H, TRAIT_NOSLIP))
+		qdel(H)
+		fail("Noslip remained after all clothing sources were removed")
+		return TRUE
+
+	qdel(H)
+	pass("Noslip follows dynamic clothing sources independently")
+	return TRUE
+
+/datum/unit_test/clothing_traits_ian_slots
+	name = "CLOTHING TRAITS: Ian held items are not worn"
+
+/datum/unit_test/clothing_traits_ian_slots/start_test()
+	var/turf/T = locate(1, 1, 1)
+	var/mob/living/carbon/ian/Ian = new(T)
+	var/obj/item/clothing/shoes/boots/galoshes/shoes = new(T)
+	Ian.put_in_hands(shoes)
+	if(HAS_TRAIT(Ian, TRAIT_NOSLIP))
+		qdel(Ian)
+		fail("Clothing held in Ian's mouth granted its worn trait")
+		return TRUE
+
+	var/obj/item/clothing/head/headwear = new(T)
+	headwear.attach_clothing_traits(TRAIT_NOSLIP)
+	Ian.equip_to_slot_or_del(headwear, SLOT_HEAD)
+	if(!HAS_TRAIT(Ian, TRAIT_NOSLIP))
+		qdel(Ian)
+		fail("Clothing worn by Ian did not grant its trait")
+		return TRUE
+
+	qdel(Ian)
+	pass("Ian clothing traits distinguish held and worn slots")
+	return TRUE

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -2628,6 +2628,7 @@
 #include "code\modules\virus2\items_devices.dm"
 #include "code\modules\zwater\wet_stuff.dm"
 #include "code\unit_tests\chemistry_tests.dm"
+#include "code\unit_tests\clothing_traits_tests.dm"
 #include "code\unit_tests\power_tests.dm"
 #include "code\unit_tests\regex_tests.dm"
 #include "code\unit_tests\revolver_tests.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fix: #14983
аттакбай понадёжнее будет
а ещё убрал возможность лепить нослипы на обувь с флагом ноуслип
## Почему и что этот ПР улучшит
фиксы нерабочих разработок
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
- bugfix: Ноуслипы теперь работают. Снова.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
