### PR TITLE
numbers sansara spin

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -269,9 +269,10 @@
 
 		apply_damage(fire_damge * rand(50, 100) * 0.01, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
 		apply_damage(brute_damge * rand(50, 100) * 0.01, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
-		if(!prob(bomb_protection) && (EXPLODE_HEAVY || EXPLODE_DEVASTATE))
+		var/BP_bomb_protection = run_armor_check(BP, BOMB)
+		if(!prob(BP_bomb_protection) && (EXPLODE_HEAVY || EXPLODE_DEVASTATE))
 			if(BP)
-				if(prob(50))
+				if(prob(50) && !BP.is_broken())
 					BP.fracture()
 					BP.sever_artery()
 				else if(prob(50))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -231,11 +231,12 @@
 
 	var/weapon_message = "Explosive Blast"
 	var/bomb_protection = run_armor_check(null, BOMB)
-	var/b_loss = null //brute damage
-	var/f_loss = null //burn (fire) damage
+	var/brute_damge
+	var/fire_damge
 	switch (severity)
 		if(EXPLODE_DEVASTATE)
-			b_loss += 500
+			brute_damge = 150
+			fire_damge = 200
 			if(!prob(bomb_protection))
 				gib()
 				return
@@ -244,8 +245,8 @@
 				throw_at(target, 200, 4)
 
 		if(EXPLODE_HEAVY)
-			b_loss += 60
-			f_loss += 60
+			brute_damge = 15
+			fire_damge = 30
 
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_damage += 30
@@ -254,23 +255,35 @@
 				Paralyse(10)
 
 		if(EXPLODE_LIGHT)
-			b_loss += 30
+			brute_damge = 5
+			fire_damge = 10
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_damage += 15
 				ear_deaf += 60
 			if(prob(50) && !prob(bomb_protection))
 				Paralyse(10)
 
-	for(var/i in 1 to 3)
-		var/obj/item/organ/external/BP = pick(bodyparts)
-		apply_damage(b_loss * rand(25, 100) * 0.01, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
-		apply_damage(f_loss * rand(25, 100) * 0.01, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+	var/list/selecteble_bodyparts = bodyparts.Copy()
+	for(var/i = 0; i < 3; i++)
+		var/obj/item/organ/external/BP = pick(selecteble_bodyparts)
+
+		apply_damage(fire_damge * rand(50, 100) * 0.01, BURN, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+		apply_damage(brute_damge * rand(50, 100) * 0.01, BRUTE, BP, run_armor_check(BP, BOMB), used_weapon = weapon_message)
+		if(!prob(bomb_protection) && (EXPLODE_HEAVY || EXPLODE_DEVASTATE))
+			if(BP)
+				if(prob(50))
+					BP.fracture()
+					BP.sever_artery()
+				else if(prob(50))
+					BP.droplimb()
+
+		selecteble_bodyparts -= BP
 
 	// minor "behind the armor" damage from the blast wave across the entire body
-	b_loss *= 0.25
-	f_loss *= 0.25
+	brute_damge *= 0.25
+	fire_damge *= 0.25
 
-	take_overall_damage(b_loss, f_loss, used_weapon = weapon_message)
+	take_overall_damage(brute_damge, fire_damge, used_weapon = weapon_message)
 
 /mob/living/carbon/human/airlock_crush_act()
 	..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Покрутил цифры перекрученные симбакой в предыдущем пре, закрыл возможность повторения выпадения конечности для нанесения урона, учел порядок нанесения урона, чтобы не ловить рантаймы по рофлу

Уменьшил пороги урона,, было 1/4-1, стало 1/2-1

Теперь эффекты по типу отрыва конечности или перелома+артерии, зависят не от нанесенного урона, а от защиты конечтости параметра BOMB

## Почему и что этот ПР улучшит
код выглядит ещё круче понятнее логичнее
## Авторство

<!-- 
В случае порта с другого билда - укажите источник (репозиторий или номер PR-а). 
Если это оригинальный PR - укажите первоисточник/авторство спрайтов и звуков. 
Укажите лицензию для звуков.
-->

## Чеинжлог
:cl:
- tweak: Тяжесть травмы от взрывов теперь зависит от брони с защитным параметром BOMB
- bugfix: Взрыв больше не может дважды выбрать одну конечность и не вызывает рантаймы из-за раннего отрыва конечности.
<!-- 
В чеинжлог стоит писать изменения, которые будут заметны игрокам. И так, чтобы они были понятны игрокам.
Ключевые слова для чеинжлога: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment

:cl:
 - bugfix: Пофикшен такой-то баг.
 - map: Перемаплен такой-то отсек.
 - image: Обновлен такой-то спрайт.
-->
