### PR TITLE
исправления светящихся сигарет

### DIFF
--- a/code/__DEFINES/_planes_layers.dm
+++ b/code/__DEFINES/_planes_layers.dm
@@ -154,6 +154,9 @@ What is the naming convention for planes or layers?
 #define ENVIRONMENT_LIGHTING_PLANE 105
 #define ENVIRONMENT_LIGHTING_LOCAL_PLANE 106
 
+#define LIGHTING_EMBER_MASK_PLANE 107
+#define LIGHTING_EMBER_PLANE 108
+
 #define LIGHTING_EXPOSURE_PLANE 110 // Light sources "cones"
 #define LIGHTING_LAMPS_SELFGLOW 111 // Light sources glow (lamps, doors overlay, etc.)
 #define LIGHTING_LAMPS_PLANE 112 // Light sources themselves (lamps, screens, etc.)

--- a/code/_onclick/hud/rendering/planes/lighting_planes.dm
+++ b/code/_onclick/hud/rendering/planes/lighting_planes.dm
@@ -127,6 +127,25 @@
 
 #define LIGHTING_LAMPS_RENDER_TARGET PM_RENDER_NAME(/atom/movable/screen/plane_master/lamps)
 
+/atom/movable/screen/plane_master/ember_mask
+	name = "ember mask plane master"
+	plane = LIGHTING_EMBER_MASK_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	render_relay_planes = null
+	color = list(0,0,0,1, 0,0,0,0, 0,0,0,0, 0,0,0,0, 1,1,1,0)
+
+/atom/movable/screen/plane_master/embers
+	name = "embers plane master"
+	plane = LIGHTING_EMBER_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	render_relay_planes = list(LIGHTING_LAMPS_PLANE)
+
+/atom/movable/screen/plane_master/embers/update_effects(client/client)
+	if(!..())
+		return
+	add_filter("ember_colors", 1, layering_filter(render_source = PM_RENDER_NAME(/atom/movable/screen/plane_master/game_world)))
+	add_filter("visible_embers", 2, alpha_mask_filter(render_source = PM_RENDER_NAME(/atom/movable/screen/plane_master/ember_mask)))
+
 /atom/movable/screen/plane_master/lamps_selfglow
 	name = "lamps selfglow plane master"
 	plane = LIGHTING_LAMPS_SELFGLOW

--- a/code/datums/components/ember_blocker.dm
+++ b/code/datums/components/ember_blocker.dm
@@ -1,0 +1,48 @@
+/datum/component/ember_blocker
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	var/atom/movable/ember_blocker/blocker
+	var/assigned_render_target
+	var/added_keep_together = FALSE
+
+/datum/component/ember_blocker/Initialize()
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/ember_blocker/RegisterWithParent()
+	var/atom/movable/owner = parent
+	added_keep_together = !(owner.appearance_flags & KEEP_TOGETHER)
+	owner.appearance_flags |= KEEP_TOGETHER
+	if(!owner.render_target)
+		assigned_render_target = "ember_blocker_[REF(src)]"
+		owner.render_target = assigned_render_target
+	blocker = new
+	blocker.render_source = owner.render_target
+	owner.vis_contents += blocker
+
+/datum/component/ember_blocker/UnregisterFromParent()
+	clear_blocker()
+
+/datum/component/ember_blocker/Destroy()
+	clear_blocker()
+	return ..()
+
+/datum/component/ember_blocker/proc/clear_blocker()
+	if(!blocker)
+		return
+	var/atom/movable/owner = parent
+	owner.vis_contents -= blocker
+	if(added_keep_together)
+		owner.appearance_flags &= ~KEEP_TOGETHER
+	if(assigned_render_target && owner.render_target == assigned_render_target)
+		owner.render_target = null
+	QDEL_NULL(blocker)
+	assigned_render_target = null
+
+/atom/movable/ember_blocker
+	name = "ember blocker"
+	plane = LIGHTING_EMBER_MASK_PLANE
+	layer = FLOAT_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	appearance_flags = KEEP_APART | KEEP_TOGETHER | RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM | PIXEL_SCALE
+	vis_flags = VIS_INHERIT_LAYER | VIS_INHERIT_ID
+	color = COLOR_BLACK

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -167,8 +167,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return null
 
 	var/image/ember = image(_icon, icon_state = ember_state)
-	ember.plane = LIGHTING_LAMPS_PLANE
 	ember.appearance_flags = RESET_COLOR | KEEP_APART
+	var/image/mask = image(_icon, icon_state = ember_state)
+	mask.plane = LIGHTING_EMBER_MASK_PLANE
+	mask.appearance_flags = RESET_COLOR | KEEP_APART
+	var/static/list/mask_color = list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,255, 1,1,1,0)
+	mask.color = mask_color
+	ember.add_overlay(mask)
 	return ember
 
 /obj/item/clothing/mask/cigarette/update_world_icon()
@@ -188,6 +193,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return standing
 	var/image/ember = build_ember_overlay(standing.icon, standing.icon_state)
 	if(ember)
+		// Let the nested ember inherit the mob transform outside its KEEP_TOGETHER group.
+		standing.appearance_flags |= KEEP_APART
 		standing.add_overlay(ember)
 	return standing
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -28,6 +28,7 @@
 
 /obj/structure/closet/atom_init(mapload)
 	. = ..()
+	AddComponent(/datum/component/ember_blocker)
 	closet_list += src
 	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
 		for(var/obj/O in src.loc)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -36,6 +36,7 @@
 
 /obj/structure/table/atom_init()
 	. = ..()
+	AddComponent(/datum/component/ember_blocker)
 	for(var/obj/structure/table/T in loc)
 		if(T != src)
 			warning("Found stacked table at [COORD(src)] while initializing map.")
@@ -797,6 +798,7 @@
 
 /obj/structure/rack/atom_init()
 	. = ..()
+	AddComponent(/datum/component/ember_blocker)
 	AddComponent(/datum/component/clickplace)
 
 /obj/structure/rack/airlock_crush_act()

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -349,6 +349,7 @@
 #include "code\datums\components\cell_selfrecharge.dm"
 #include "code\datums\components\clickplace.dm"
 #include "code\datums\components\connect_range.dm"
+#include "code\datums\components\ember_blocker.dm"
 #include "code\datums\components\epilepsy.dm"
 #include "code\datums\components\examine_research.dm"
 #include "code\datums\components\fishing.dm"


### PR DESCRIPTION
## Описание изменений

исправления свечения сигарет из #14864

огонёк теперь поворачивается вместе с персонажем который лежит 

добавлена маска перекрытия огонька спрайтами столов, стоек, шкафов и ящиков

## Почему и что этот ПР улучшит

огонёк больше не остаётся точкой в воздухе и не просвечивает через столы

## Чеинжлог

:cl:

 - bugfix: огонёк сигареты больше не зависает в воздухе, когда персонаж ложится
 - bugfix: огонёк сигареты больше не просвечивает через столы, стойки, шкафы и ящики